### PR TITLE
Fix a bug related to closures in ComprehensionCompiler

### DIFF
--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionCompiler.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionCompiler.scala
@@ -199,8 +199,13 @@ private[emma] trait ComprehensionCompiler[C <: blackbox.Context]
         case vd@ValDef(_, _, _, _) => vd.symbol.asTerm
       }).toSet
 
+      // find all term symbols bound within the term
+      val bound = t.collect({
+        case bind@Bind(_, _) => bind.symbol.asTerm
+      }).toSet
+
       // the closure is the difference between the referenced and the defined symbols
-      referenced diff defined
+      referenced diff defined diff bound
     }
   }
 


### PR DESCRIPTION
This fixes #17

As a consequence, it will enable the following syntax sugar:
- Partial functions:
  
  `DataBag(Seq(1, 2, 3)).map { case x => x + 1 }`
- Pattern matching on `DataBag` elements:
  
  `for ((x, y) <- DataBag(Seq(1 -> 2, 2 -> 3, 3 -> 4))) yield x + y`
  Note: this will add an extra `withFilter` comprehension.
- `val` definitions within `for` comprehensions:
  
  `for (x <- DataBag(Seq(1, 2, 3)); x2 = x * x) yield x2`
