### PR TITLE
Normalize filter predicates

### DIFF
--- a/emma-sketchbook/src/test/scala/eu/stratosphere/emma/examples/prototype/TranslationPrototype.scala
+++ b/emma-sketchbook/src/test/scala/eu/stratosphere/emma/examples/prototype/TranslationPrototype.scala
@@ -26,13 +26,15 @@ class TranslationPrototype(rt: Engine) extends Algorithm(rt) {
         x <- DataBag(1 to 10);
         y <- DataBag(11 to 20);
         z <- DataBag(Seq(1, 2, 3));
-        if x < 5 && y > 15 && z == 2; if z > 2 && y == 20) yield (x, y, z)
+        if x < 5 && y > 15 && z == 2 && z > 2 && y == 20) yield (x, y, z)
 
       val b = for (
         x <- DataBag(1 to 10);
         y <- DataBag(11 to 20);
         z <- DataBag(Seq(1, 2, 3));
-        if x < 5; if y > 15; if z == 2) yield (x, y, z)
+        if x < 5; if y > 15; if z == 2; if z > 2; if y == 20) yield (x, y, z)
+
+      //val b = DataBag(Seq(1, 2, 3)).map(x => x).withFilter(x => x < 5).map(y => y)
     }
   }
 


### PR DESCRIPTION
This code collects all predicates - conjuncts or not - from withFilter() expressions and returns the "trunk" (e.g. the databag withFilter() was called on) and a disjunction of the predicates. 

example:

This code

``` scala
val a = for (
        x <- DataBag(1 to 10);
        y <- DataBag(11 to 20);
        z <- DataBag(Seq(1, 2, 3));
        if x < 5 && y > 15 && z == 2; if z > 2 && y == 20) yield (x, y, z)
```

would return 

`eu.stratosphere.emma.api.DataBag.apply[Int](collection.this.Seq.apply[Int](1, 2, 3))` 
and 
`List(x.<(5), y.>(15), z.==(2), z.>(2), y.==(20))` which then can be turned into the equivalent representation

``` scala
val b = for (
        x <- DataBag(1 to 10);
        y <- DataBag(11 to 20);
        z <- DataBag(Seq(1, 2, 3));
        if x < 5; if y > 15; if z == 2; if z > 2; if y == 20) yield (x, y, z)
```

It should be carefully tested to not break anything else. Further optimizations of predicates/set theory as De Morgan's laws etc. are not implemented yet.
