### PR TITLE
[API] Avoid ambiguous updateWith method overloading

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/Stateful.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/Stateful.scala
@@ -31,7 +31,7 @@ object Stateful {
      *
      * @param f the update function to be applied for each point in the distributed state.
      */
-    @deprecated("Use updateWith instead.", "28.04.2015")
+    @deprecated("Use updateWithZero instead.", "28.04.2015")
     def update(f: A => Option[A]): DataBag[A] = DataBag(for (
       s <- state.values.toList;
       d <- f(s)) yield {
@@ -44,7 +44,7 @@ object Stateful {
      * @param f the update function to be applied for each point with matching update in the distributed state.
      * @tparam B A set of update messages to be passed as first extra agument to the update function.
      */
-    @deprecated("Use updateWith instead.", "28.04.2015")
+    @deprecated("Use updateWithOne instead.", "28.04.2015")
     def update[B <: Identity[K]](updates: DataBag[B])(f: (A, B) => Option[A]): DataBag[A] = DataBag(for (
       u <- updates.impl;
       s <- state.get(u.identity);
@@ -57,14 +57,14 @@ object Stateful {
      * however with the restriction that the modification should not affect it's identity.
      *
      * @param f the update function to be applied for each point in the distributed state.
-     * @tparam B The type of the output elements.
+     * @tparam C The type of the output elements.
      * @return The flattened result of all update invocations.
      */
-    def updateWith[B](f: A => DataBag[B]): DataBag[B] =
+    def updateWithZero[C](f: A => DataBag[C]): DataBag[C] =
       for {
-        s <- bag()
-        d <- f(s)
-      } yield d
+        state  <- bag()
+        result <- f(state)
+      } yield result
 
     /**
      * Computes and flattens the `leftJoin` with `updates` which passes for each update element `u` it's
@@ -72,17 +72,18 @@ object Stateful {
      * state element `s`, however with the restriction that the modification should not affect it's identity.
      *
      * @param updates A collection of inputs to be joined with.
+     * @param k A key extractor function for matching `k(u) == s.identity`.
      * @param f A UDF to be applied per pair `f(s, u)` as described above.
      * @tparam B The type of the `updates` elements.
      * @tparam C The type of the output elements.
      * @return The flattened result of all update invocations.
      */
-    def updateWith[B <: Identity[K], C](updates: DataBag[B])(f: (A, B) => DataBag[C]): DataBag[C] =
+    def updateWithOne[B, C](updates: DataBag[B])(k: B => K, f: (A, B) => DataBag[C]): DataBag[C] =
       for {
-        u <- updates
-        s <- DataBag(state.get(u.identity).toSeq)
-        d <- f(s, u)
-      } yield d
+        update <- updates
+        state  <- DataBag(state.get(k(update)).toSeq)
+        result <- f(state, update)
+      } yield result
 
     /**
      * Computes and flattens the `nestJoin(p, f)` which nests the current state elements `s` against their
@@ -110,11 +111,11 @@ object Stateful {
      * @tparam C The type of the output elements.
      * @return The flattened collection
      */
-    def updateWith[B, C](updates: DataBag[B])(k: B => K, f: (A, DataBag[B]) => DataBag[C]): DataBag[C] =
+    def updateWithMany[B, C](updates: DataBag[B])(k: B => K, f: (A, DataBag[B]) => DataBag[C]): DataBag[C] =
       for {
-        s <- bag()
-        d <- f(s, for (u <- updates; if k(u) == s.identity) yield u)
-      } yield d
+        state  <- bag()
+        result <- f(state, updates withFilter { k(_) == state.identity })
+      } yield result
 
     /**
      * Converts the stateful bag into an immutable Bag.

--- a/emma-sketchbook/src/main/scala/eu/stratosphere/emma/examples/graphs/GraphColoring.scala
+++ b/emma-sketchbook/src/main/scala/eu/stratosphere/emma/examples/graphs/GraphColoring.scala
@@ -40,8 +40,8 @@ class GraphColoring(input: String, output: String, rt: Engine)
 
       // resolve conflicting colors until convergence
       while (!messages.empty()) {
-        messages = vertices.updateWith(messages)(_.dst,
-          (v, ms) => { // if the color is taken choose a new one
+        messages = vertices.updateWithMany(messages)(
+          _.dst, (v, ms) => { // if the color is taken choose a new one
             if (ms exists { _.col == v.col }) {
               val colors = for {
                 e <- directed
@@ -68,7 +68,7 @@ class GraphColoring(input: String, output: String, rt: Engine)
       write(output, new CSVOutputFormat[ColoredVertex]) { colored }
     }
 
-    //algorithm.run(rt)
+    //algorithm run rt
   }
 }
 

--- a/emma-sketchbook/src/main/scala/eu/stratosphere/emma/examples/graphs/MinimumSpanningForest.scala
+++ b/emma-sketchbook/src/main/scala/eu/stratosphere/emma/examples/graphs/MinimumSpanningForest.scala
@@ -105,7 +105,7 @@ class MinimumSpanningForest(inputUrl: String, outputUrl: String, rt: Engine) ext
         // create initial questions
         var questions = for (d <- supervertices.bag()) yield QuestionMsg(d.label.pointer, d.id)
         // initial answer phase: send messages to pointers
-        val answers = (supervertices updateWith questions)(q => q.receiver, (s, questions) => {
+        val answers = (supervertices updateWithMany questions)(q => q.receiver, (s, questions) => {
           if (questions.map(_.sender).exists(_ == s.label.pointer)) {
             // an incoming question message was sent by by the current supervertex pointer (conjoined-tree root case)
             s.label.pointer = s.id
@@ -117,7 +117,7 @@ class MinimumSpanningForest(inputUrl: String, outputUrl: String, rt: Engine) ext
 
         while (supervertices.bag().exists(_.label.tpe == Unknown)) {
           // question phase: merge answers and generate next questions
-          questions = (supervertices updateWith answers)(a => a.receiver, (s, answers) => {
+          questions = (supervertices updateWithMany answers)(a => a.receiver, (s, answers) => {
             val supervertex = answers.fetch().collectFirst({
               case x if x.pointerIsSupervertex => x
             })


### PR DESCRIPTION
However, examples using `updateWith` still don't compile, although with different errors.
