### PR TITLE
[API] Deprecate empty in favor of isEmpty

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/DataBag.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/DataBag.scala
@@ -146,7 +146,10 @@ sealed class DataBag[+A] private(private[api] val impl: Seq[A]) extends Collecti
 
   def forall(f: A => Boolean): Boolean = fold[Boolean](true, x => f(x), (x, y) => x && y)
 
+  @deprecated("Use isEmpty instead", "08.06.2015")
   def empty(): Boolean = impl.isEmpty
+
+  def isEmpty: Boolean = impl.isEmpty
 
   // -----------------------------------------------------
   // Conversion Methods

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionAnalysis.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionAnalysis.scala
@@ -48,6 +48,7 @@ private[emma] trait ComprehensionAnalysis[C <: blackbox.Context]
     val exists = bagSymbol.info.decl(TermName("exists"))
     val forall = bagSymbol.info.decl(TermName("forall"))
     val empty = bagSymbol.info.decl(TermName("empty"))
+    val isEmpty = bagSymbol.info.decl(TermName("isEmpty"))
 
     val methods = Set(
       read, write,
@@ -56,7 +57,7 @@ private[emma] trait ComprehensionAnalysis[C <: blackbox.Context]
       map, flatMap, withFilter,
       groupBy,
       minus, plus, distinct,
-      minBy, maxBy, min, max, sum, product, count, exists, forall, empty
+      minBy, maxBy, min, max, sum, product, count, exists, forall, empty, isEmpty
     ) ++ apply.alternatives
 
     val monadic = Set(map, flatMap, withFilter)
@@ -323,6 +324,11 @@ private[emma] trait ComprehensionAnalysis[C <: blackbox.Context]
       case Apply(select@Select(in, _), Nil) if select.symbol == api.empty =>
         val comprehendedIn = comprehend(Nil)(in)
         combinator.Fold(c.typecheck(q"false"), c.typecheck(q"(x: ${comprehendedIn.tpe.typeArgs.head}) => true"), c.typecheck(q"(x: Boolean, y: Boolean) => x || y"), comprehendedIn, t)
+
+      // in.isEmpty
+      case Apply(select@Select(in, _), Nil) if select.symbol == api.isEmpty =>
+        val comprehendedIn = comprehend(Nil)(in)
+        combinator.Fold(c.typecheck(q"true"), c.typecheck(q"(x: ${comprehendedIn.tpe.typeArgs.head}) => false"), c.typecheck(q"(x: Boolean, y: Boolean) => x && y"), comprehendedIn, t)
 
       // ----------------------------------------------------------------------
       // Environment & Host Language Connectors

--- a/emma-language/src/test/scala/eu/stratosphere/emma/codegen/BaseCodegenTest.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/codegen/BaseCodegenTest.scala
@@ -702,4 +702,13 @@ abstract class BaseCodegenTest(rtName: String) {
     // assert that the result contains the expected values
     assert(exp == act, s"Unexpected result:  $act != $exp")
   }
+
+  @Test def testEmpty() = {
+    val alg = emma.parallelize { DataBag(Seq.empty[Int]).isEmpty }
+    // compute the algorithm using the original code and the runtime under test
+    val act = alg.run(rt)
+    val exp = alg.run(native)
+    // assert that the result contains the expected values
+    assert(exp == act, s"Unexpected result:  $act != $exp")
+  }
 }


### PR DESCRIPTION
- isEmpty is semantically consistent across backends

This should fix #37, but I still think it's better to separate aggregate functions into higher level macros.
