### PR TITLE
Wordcount example, a TextInputFormat and compiler fixes for Flink and Spark.

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/InputFormat.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/InputFormat.scala
@@ -4,6 +4,8 @@ import java.io.{InputStream, InputStreamReader}
 
 import au.com.bytecode.opencsv.CSVReader
 
+import scala.io.Source
+
 abstract class InputFormat[T] {
   def read(is: InputStream): Seq[T]
 }
@@ -22,6 +24,21 @@ class CSVInputFormat[T: CSVConvertors](val separator: Char) extends InputFormat[
     while (obj != null) {
       sb += convert.fromCSV(obj)
       obj = reader.readNext()
+    }
+
+    reader.close()
+    sb.result()
+  }
+}
+
+class TextInputFormat[T <: String](val separator: Char) extends InputFormat[T] {
+
+  override def read(is: InputStream): Seq[T] = {
+    val reader = Source.fromInputStream(is)
+
+    val sb = Seq.newBuilder[T]
+    for(line <-  reader.getLines()){
+      sb += line.asInstanceOf[T]
     }
 
     reader.close()

--- a/emma-common/src/test/scala/eu/stratosphere/emma/testutil/package.scala
+++ b/emma-common/src/test/scala/eu/stratosphere/emma/testutil/package.scala
@@ -60,4 +60,13 @@ package object testutil {
     assert((exp diff act) == Seq.empty[String], s"Unexpected elements in result: $exp")
     assert((act diff exp) == Seq.empty[String], s"Unseen elements in result: $act")
   }
+
+  def deleteRecursive(path: java.io.File): Boolean = {
+    val ret = if (path.isDirectory) {
+      path.listFiles().toSeq.foldLeft(true)((r, f) => deleteRecursive(f))
+    } else { /* regular file */
+      true
+    }
+    ret && path.delete()
+  }
 }

--- a/emma-flink/src/main/scala/eu/stratosphere/emma/codegen/flink/DataflowGenerator.scala
+++ b/emma-flink/src/main/scala/eu/stratosphere/emma/codegen/flink/DataflowGenerator.scala
@@ -3,7 +3,7 @@ package eu.stratosphere.emma.codegen.flink
 import java.net.URI
 import java.util.UUID
 
-import eu.stratosphere.emma.api.{CSVInputFormat, CSVOutputFormat}
+import eu.stratosphere.emma.api.{TextInputFormat, CSVInputFormat, CSVOutputFormat}
 import eu.stratosphere.emma.codegen.utils.DataflowCompiler
 import eu.stratosphere.emma.ir
 import eu.stratosphere.emma.macros.ReflectUtil._
@@ -168,6 +168,19 @@ class DataflowGenerator(
     val tpe = typeOf(op.tag).dealias
 
     val inFormatTree = op.format match {
+      case fmt: TextInputFormat[_] =>
+
+        val inf = freshName("inFormat$flink$")
+
+        q"""{
+          val $inf =
+            new _root_.org.apache.flink.api.java.io.TextInputFormat(
+              new _root_.org.apache.flink.core.fs.Path(${op.location}))
+
+          $inf.setDelimiter(${fmt.separator})
+          $inf
+        }"""
+
       case fmt: CSVInputFormat[_] =>
         if (!(tpe <:< weakTypeOf[Product]))
           throw new RuntimeException(

--- a/emma-sketchbook/pom.xml
+++ b/emma-sketchbook/pom.xml
@@ -178,7 +178,6 @@
                     <groupId>eu.stratosphere</groupId>
                     <artifactId>emma-spark</artifactId>
                 </dependency>
-                <!-- Spark -->
                 <dependency>
                     <groupId>org.apache.spark</groupId>
                     <artifactId>spark-core_${scala.tools.version}</artifactId>

--- a/emma-sketchbook/src/main/scala/eu/stratosphere/emma/examples/text/WordCount.scala
+++ b/emma-sketchbook/src/main/scala/eu/stratosphere/emma/examples/text/WordCount.scala
@@ -1,0 +1,92 @@
+package eu.stratosphere.emma.examples.text
+
+import eu.stratosphere.emma.api._
+import eu.stratosphere.emma.examples.Algorithm
+import eu.stratosphere.emma.runtime.Engine
+import net.sourceforge.argparse4j.inf.{Namespace, Subparser}
+
+
+/**
+ *
+ * Implements the "WordCount" program that computes a simple word occurrence histogram
+ * over text files.
+ *
+ * The input is a plain text file with lines separated by newline characters and the
+ * output is a file containing words and the number of times that they occure in the
+ * input text file.
+ *
+ * Usage:
+ * {{{
+ *   WordCount <text path> <result path>>
+ * }}}
+ *
+ * This example shows how to:
+ *
+ *   - write a very simple Emma program.
+ *
+ * @param inPath Base input path
+ * @param outPath Output path
+ */
+class WordCount(inPath: String, outPath: String, rt: Engine) extends Algorithm(rt) {
+
+  def this(ns: Namespace, rt: Engine) = this(
+    ns.get[String](WordCount.Command.KEY_INPUT),
+    ns.get[String](WordCount.Command.KEY_OUTPUT),
+    rt)
+
+  def run() = {
+
+    val alg =  emma.parallelize {
+
+      //read the text file, producing a databag
+      val text = read(inPath, new TextInputFormat[String]('\n'))
+
+      //split the text into lowercased words and group them
+      val wordGroups = text.flatMap(s => DataBag[String](s.toLowerCase.split("\\W+")))
+        .groupBy(x => x)
+
+      //iterate over all groups and output a {key,count} pair for each of them
+      val wc = for(grp <- wordGroups) yield (grp.key, grp.values.count())
+
+      //write the results into a CSV file
+      write(outPath,new CSVOutputFormat[(String, Long)])(wc)
+    }
+
+    alg.run(rt)
+  }
+}
+
+
+object WordCount {
+
+  class Command extends Algorithm.Command[WordCount] {
+
+    // algorithm names
+    override def name = "wordcount"
+
+    override def description = "Word Count Example"
+
+    override def setup(parser: Subparser) = {
+      // basic setup
+      super.setup(parser)
+
+      // add arguments
+      parser.addArgument(Command.KEY_INPUT)
+        .`type`[String](classOf[String])
+        .dest(Command.KEY_INPUT)
+        .metavar("INPATH")
+        .help("base input file")
+      parser.addArgument(Command.KEY_OUTPUT)
+        .`type`[String](classOf[String])
+        .dest(Command.KEY_OUTPUT)
+        .metavar("OUTPUT")
+        .help("output file")
+    }
+  }
+
+  object Command {
+    // argument names
+    val KEY_INPUT = "input"
+    val KEY_OUTPUT = "output"
+  }
+}

--- a/emma-sketchbook/src/test/scala/eu/stratosphere/emma/examples/text/WordCountTest.scala
+++ b/emma-sketchbook/src/test/scala/eu/stratosphere/emma/examples/text/WordCountTest.scala
@@ -1,0 +1,40 @@
+package eu.stratosphere.emma.examples.text
+
+import eu.stratosphere.emma.api.DataBag
+import eu.stratosphere.emma.runtime
+import eu.stratosphere.emma.testutil._
+
+import java.nio.file.{Paths, Files}
+import java.nio.charset.StandardCharsets
+
+import java.io.File
+
+import org.junit.runner.RunWith
+
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class WordCountTest extends FunSuite with Matchers {
+  // default parameters
+  val dir        = "/text/"
+  val path       = tempPath(dir)
+  val rt         = runtime.default()
+  val text       = "To be or not to Be"
+
+  deleteRecursive(Paths.get(path).toFile)
+
+  // initialize resources
+  new File(path).mkdirs()
+  Files.write(Paths.get(s"$path/hamlet.txt"), text.getBytes(StandardCharsets.UTF_8))
+
+  test("Counts Words") {
+    new WordCount(s"$path/hamlet.txt", s"$path/output.txt", rt).run()
+
+    val actual = DataBag(fromPath(s"$path/output.txt"))
+    val expected   = DataBag(text.toLowerCase.split("\\W+").groupBy(x => x).toSeq.map(x => s"${x._1}\t${x._2.size}"))
+
+    compareBags(actual.fetch(), expected.fetch())
+  }
+}

--- a/emma-spark/src/main/scala/eu/stratosphere/emma/codegen/spark/DataflowGenerator.scala
+++ b/emma-spark/src/main/scala/eu/stratosphere/emma/codegen/spark/DataflowGenerator.scala
@@ -2,7 +2,7 @@ package eu.stratosphere.emma.codegen.spark
 
 import java.util.UUID
 
-import eu.stratosphere.emma.api.{CSVOutputFormat, CSVInputFormat}
+import eu.stratosphere.emma.api.{CSVOutputFormat, CSVInputFormat, TextInputFormat}
 import eu.stratosphere.emma.codegen.utils.DataflowCompiler
 import eu.stratosphere.emma.ir
 import eu.stratosphere.emma.macros.ReflectUtil._
@@ -113,7 +113,7 @@ class DataflowGenerator(
       case fmt: CSVInputFormat[tp] =>
         if (!(tpe <:< weakTypeOf[Product]))
           throw new RuntimeException(
-            s"Cannot create Flink CsvInputFormat for non-product type ${typeOf(op.tag)}")
+            s"Cannot create Spark CsvInputFormat for non-product type ${typeOf(op.tag)}")
 
         val line = freshName("line$spark$")
         val name = closure nextTermName "converter"
@@ -123,6 +123,9 @@ class DataflowGenerator(
         q"""$sc.textFile($path).map({ ($line: ${typeOf[String]}) =>
           $name.fromCSV($line.split(${fmt.separator}))
         })"""
+
+      case fmt: TextInputFormat[tp] =>
+        q"""$sc.textFile($path)"""
 
       case _ => throw new RuntimeException(
         s"Unsupported InputFormat of type '${op.format.getClass}'")

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <!-- Flink -->
         <flink.version>0.9-SNAPSHOT</flink.version>
         <!-- Spark -->
-        <spark.version>1.2.1</spark.version>
+        <spark.version>1.3.1</spark.version>
 
         <!-- Logging -->
         <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
Bumped Spark to 1.3.1 in order to fix Guava dependency hell.
