### PR TITLE
[MACROS] Fixed fold-group fusion of Folds

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/package.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/package.scala
@@ -150,9 +150,7 @@ package object api {
    * @param self the actual [[DataBag]] instance
    * @tparam E the type of elements to fold over
    */
-  implicit class DataBagWithFolds[+E](val self: DataBag[E]) extends AnyVal with Folds[E] {
-    def fold[R](z: R, s: E => R, p: (R, R) => R) = self.fold[R](z, s, p)
-  }
+  implicit class DataBagWithFolds[+E](val self: DataBag[E]) extends AnyVal with Folds[E]
 
   implicit def materializeCSVConvertors[T]: CSVConvertors[T] = macro ConvertorsMacros.materializeCSVConvertorsImpl[T]
 }

--- a/emma-common/src/main/scala/eu/stratosphere/emma/macros/FoldMacros.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/macros/FoldMacros.scala
@@ -15,9 +15,16 @@ import scala.reflect.macros.blackbox
 class FoldMacros(val c: blackbox.Context) {
   import c.universe._
 
-  private lazy val self = c.prefix
+  private lazy val self = unbox(c.prefix.tree)
 
-  def freshName(prefix: String): TermName =
+  // unbox implicit type conversions
+  private def unbox(tree: Tree) = tree match {
+    case       Apply(_: TypeApply, arg :: Nil)     => arg
+    case Typed(Apply(_: TypeApply, arg :: Nil), _) => arg
+    case _ => tree
+  }
+
+  private def freshName(prefix: String): TermName =
     TermName(c freshName prefix)
 
   def isEmpty = q"!$self.nonEmpty"

--- a/emma-common/src/main/scala/eu/stratosphere/emma/macros/Folds.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/macros/Folds.scala
@@ -9,8 +9,6 @@ import scala.language.experimental.macros
  */
 trait Folds[+E] extends Any {
 
-  def fold[R](z: R, s: E => R, p: (R, R) => R): R
-
   /**
    * Test the collection for emptiness.
    * @return `true` if the collection contains no elements at all

--- a/emma-language/src/test/scala/eu/stratosphere/emma/macros/FoldSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/macros/FoldSpec.scala
@@ -1,5 +1,7 @@
 package eu.stratosphere.emma.macros
 
+import java.io.ByteArrayOutputStream
+
 import eu.stratosphere.emma.api._
 import eu.stratosphere.emma.runtime.Native
 import org.junit.runner.RunWith
@@ -216,6 +218,20 @@ class FoldSpec extends FunSuite with Matchers with PropertyChecks {
         case Some(_) => negative.get should be < 0
         case None    => negative should be ('empty)
       }
+    }
+  }
+
+  test("fold group fusion (char count)") {
+    forAll { str: String =>
+      val buffer = new ByteArrayOutputStream()
+      Console.withOut(buffer) {
+        emma.comprehend {
+          for (g <- DataBag(str) groupBy identity)
+            yield g.key -> g.values.count()
+        }
+      }
+
+      buffer.toString.toLowerCase should include ("foldgroup")
     }
   }
 }


### PR DESCRIPTION
The implicit type conversion (aka "pimp my library") used with the `Folds` trait caused a regression of fold-group fusion transformations.
- Solved the problem by unboxing the target in `FoldMacros`
- The `fold` method in `Folds` is no longer necessary
- Added a regression test for fold-group fusion
