### PR TITLE
[RUNTIME] Migrate to Flink's Scala API

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/ir/package.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/ir/package.scala
@@ -183,6 +183,8 @@ package object ir {
     }
 
     def body = tree.body.asInstanceOf[Function].body
+
+    def func = q"(..$params) => $body"
   }
 
   object UDF {


### PR DESCRIPTION
This alleviates the need for creating a lot of classes/objects and reduces the code base, since we can use function literals directly.
