### PR TITLE
[RUNTIME] Delayed `ToolBox` initialization

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/ir/package.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/ir/package.scala
@@ -1,7 +1,5 @@
 package eu.stratosphere.emma
 
-import java.util.UUID
-
 import eu.stratosphere.emma.api.{DataBag, InputFormat, OutputFormat}
 
 import scala.collection.mutable
@@ -174,18 +172,9 @@ package object ir {
 
   object UDF {
 
-    val fnSymbols = Set[Symbol](
-      runtime.mirror.staticClass("scala.Function0"),
-      runtime.mirror.staticClass("scala.Function1"),
-      runtime.mirror.staticClass("scala.Function2"),
-      runtime.mirror.staticClass("scala.Function3"),
-      runtime.mirror.staticClass("scala.Function4"),
-      runtime.mirror.staticClass("scala.Function5"),
-      runtime.mirror.staticClass("scala.Function6"),
-      runtime.mirror.staticClass("scala.Function7"),
-      runtime.mirror.staticClass("scala.Function8"),
-      runtime.mirror.staticClass("scala.Function9"),
-      runtime.mirror.staticClass("scala.Function10"))
+    val fnSymbols: Set[Symbol] = {
+      for (n <- 0 to 22) yield rootMirror.staticClass(s"scala.Function$n")
+    }.toSet
 
     def apply(fn: Tree, tpe: Type, tb: ToolBox[ru.type]) = new UDF(fn.asInstanceOf[Function], tpe, tb)
 

--- a/emma-common/src/main/scala/eu/stratosphere/emma/runtime/package.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/runtime/package.scala
@@ -24,8 +24,6 @@ package object runtime {
 
   private[emma] val logger = Logger(LoggerFactory.getLogger(classOf[Engine]))
 
-  val mirror = runtimeMirror(getClass.getClassLoader)
-
   abstract class Engine {
 
     val envSessionID = UUID.randomUUID()
@@ -105,8 +103,8 @@ package object runtime {
 
   def factory(name: String, host: String, port: Int) = {
     // reflect engine
-    val engineClazz = mirror.staticClass(s"${getClass.getPackage.getName}.${toCamelCase(name)}")
-    val engineClazzMirror = mirror.reflectClass(engineClazz)
+    val engineClazz = rootMirror.staticClass(s"${getClass.getPackage.getName}.${toCamelCase(name)}")
+    val engineClazzMirror = rootMirror.reflectClass(engineClazz)
     val engineClassType = appliedType(engineClazz)
 
     if (!(engineClassType <:< typeOf[Engine]))

--- a/emma-flink/src/main/scala/eu/stratosphere/emma/runtime/Flink.scala
+++ b/emma-flink/src/main/scala/eu/stratosphere/emma/runtime/Flink.scala
@@ -28,7 +28,7 @@ abstract class Flink(val host: String, val port: Int) extends Engine {
 
   val env: ExecutionEnvironment
 
-  val dataflowCompiler = new DataflowCompiler(mirror)
+  val dataflowCompiler = new DataflowCompiler(runtimeMirror(getClass.getClassLoader))
 
   val dataflowGenerator = new DataflowGenerator(dataflowCompiler, envSessionID)
 

--- a/emma-spark/src/main/scala/eu/stratosphere/emma/runtime/Spark.scala
+++ b/emma-spark/src/main/scala/eu/stratosphere/emma/runtime/Spark.scala
@@ -25,7 +25,7 @@ abstract class Spark(val host: String, val port: Int) extends Engine {
 
   val sc: SparkContext
 
-  val dataflowCompiler = new DataflowCompiler(mirror)
+  val dataflowCompiler = new DataflowCompiler(runtimeMirror(getClass.getClassLoader))
 
   val dataflowGenerator = new DataflowGenerator(dataflowCompiler, envSessionID)
 


### PR DESCRIPTION
Initialize the `ToolBox` as late as possible to pick up intermediate classpath additions. This is beneficial when running in the REPL.
