### PR TITLE
[MACROS] Proper symbol substitution in fold-group fusion.

### DIFF
--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionAnalysis.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionAnalysis.scala
@@ -357,6 +357,8 @@ private[emma] trait ComprehensionAnalysis
             }
             com.comprehension.substitute(foldTree, replTree)
           }
+
+          com.comprehension.substitute(gSym, gen.lhs)
         }
 
       // Ignore other expression types

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionModel.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionModel.scala
@@ -69,6 +69,15 @@ private[emma] trait ComprehensionModel extends BlackBoxUtil {
       expr = transformer.transform(expr)
     }
 
+    def substitute(find: TermSymbol, repl: TermSymbol): Unit = {
+      val transformer = new ExpressionTransformer {
+        override def xform(tree: Tree) = tree transform {
+          case ident @ Ident(name: TermName) if ident.symbol == find => mk ref repl
+        }
+      }
+      expr = transformer.transform(expr)
+    }
+
     override def toString =
       prettyPrint(expr)
   }


### PR DESCRIPTION
This adds substitution also for those occurrences of `g`, where it is used not as `g.values.somefold` but as eg. `g.key`.
