### PR TITLE
[API] Fix stateful native, to do deep copies. (introduced Kryo for this)

### DIFF
--- a/emma-common/pom.xml
+++ b/emma-common/pom.xml
@@ -76,6 +76,18 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.tools.version}</artifactId>
         </dependency>
+
+        <!-- Serialization -->
+        <dependency>
+            <groupId>com.esotericsoftware</groupId>
+            <artifactId>kryo</artifactId>
+            <version>3.0.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.twitter</groupId>
+            <artifactId>chill_${scala.tools.version}</artifactId>
+            <version>0.5.2</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/Stateful.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/Stateful.scala
@@ -1,12 +1,15 @@
 package eu.stratosphere.emma.api
 
+import com.esotericsoftware.kryo.KryoException
+import com.twitter.chill.ScalaKryoInstantiator
 import eu.stratosphere.emma.api.model._
-import scala.collection.mutable
 
 /**
  * Abstractions for stateful collections.
  */
 object Stateful {
+
+  val kryo = (new ScalaKryoInstantiator).newKryo()
 
   /**
    * An abstraction for stateful collections.
@@ -17,15 +20,24 @@ object Stateful {
    * @tparam S The element of the stored state.
    * @tparam K The key type.
    */
-  sealed class Bag[S <: Identity[K], K] private(val state: mutable.Map[K, S]) {
+  sealed class Bag[S <: Identity[K], K] private(val state: Map[K, S]) {
 
     /**
      * Private constructor that transforms a DataBag into a stateful Bag.
      *
      * @param bag A DataBag containing elements with identity to be indexed and managed by this stateful Bag.
      */
-    private[api] def this(bag: DataBag[S]) =
-      this(bag.fold(mutable.Map.empty[K, S])(s => mutable.Map(s.identity -> s), _ ++ _))
+    private[api] def this(bag: DataBag[S]) = {
+      this ({
+        try bag.vals.map(s => {
+          s.identity -> kryo.copy(s)
+        }).toMap catch {
+          case e: KryoException =>
+            throw new Exception("""Kryo serializer could not copy state object. A likely cause is that the class of the
+                                |state object is an inner class. Try moving it to a companion object.
+                              """.stripMargin, e)
+        }})
+    }
 
     /**
      * Computes and flattens a delta without additional inputs. The UDF `f` is allowed to modify the state element `s`,
@@ -36,9 +48,10 @@ object Stateful {
      * @return The flattened result of all update invocations.
      */
     def updateWithZero[B](f: S => DataBag[B]): DataBag[B] = for {
-      state  <- bag()
-      result <- f(state)
-    } yield result
+      s <- DataBag(state.values.toList)
+      b <- f(s)
+    } yield b
+
 
     /**
      * Computes and flattens the `leftJoin` with `updates` which passes for each update element `u` it's
@@ -55,9 +68,9 @@ object Stateful {
     def updateWithOne[A, B](updates: DataBag[A])
       (k: A => K, f: (S, A) => DataBag[B]): DataBag[B] = for {
         update <- updates
-        state  <- DataBag(state.get(k(update)).toSeq)
-        result <- f(state, update)
-      } yield result
+        s <- DataBag(state.get(k(update)).toList)
+        b <- f(s, update)
+      } yield b
 
     /**
      * Computes and flattens the `nestJoin(p, f)` which nests the current state elements `s` against their
@@ -87,15 +100,16 @@ object Stateful {
      */
     def updateWithMany[A, B](updates: DataBag[A])
       (k: A => K, f: (S, DataBag[A]) => DataBag[B]): DataBag[B] = for {
-        state  <- bag()
-        result <- f(state, updates withFilter { k(_) == state.identity })
-      } yield result
+        s <- DataBag(state.values.toList)
+        b <- f(s, updates withFilter { k(_) == s.identity })
+      } yield b
+
 
     /**
      * Converts the stateful bag into an immutable Bag.
      *
      * @return A Databag containing the set of elements contained in this stateful Bag.
      */
-    def bag(): DataBag[S] = DataBag((for (x <- state) yield x._2).toSeq)
+    def bag(): DataBag[S] = DataBag((for (x <- state) yield kryo.copy(x._2)).toSeq)
   }
 }

--- a/emma-common/src/test/scala/eu/stratosphere/emma/api/StatefulNativeTest.scala
+++ b/emma-common/src/test/scala/eu/stratosphere/emma/api/StatefulNativeTest.scala
@@ -1,0 +1,34 @@
+package eu.stratosphere.emma.api
+
+import eu.stratosphere.emma.api.model.{Identity, id}
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class StatefulNativeTest extends FlatSpec with Matchers with BeforeAndAfter {
+
+  "Stateful native" should "do deep copies" in  {
+
+    val b1 = DataBag(Seq(Foo(1, 1)))
+
+    val s1 = stateful[Foo, Int](b1)
+    s1.updateWithZero(x => {
+      x.n = x.n + 1
+      DataBag()
+    })
+    b1.fetch().head should equal (Foo(1, 1)) // ctor did deep copy, original should not change
+    val b2 = s1.bag()
+    b2.fetch().head should equal (Foo(1, 2)) // we see the change in the stateful
+    s1.updateWithZero(x => {
+      x.n = x.n + 1
+      DataBag()
+    })
+    b2.fetch().head should equal (Foo(1, 2)) // .bag() did deep copy, the resulting DataBag is independent of the stateful
+  }
+}
+
+
+case class Foo(@id s: Int, var n: Int) extends Identity[Int] {
+  override def identity = n
+}

--- a/emma-examples/src/main/scala/eu/stratosphere/emma/examples/graphs/BeliefPropagation.scala
+++ b/emma-examples/src/main/scala/eu/stratosphere/emma/examples/graphs/BeliefPropagation.scala
@@ -131,6 +131,7 @@ class BeliefPropagation(
           Belief(v, s, prob)
         }
 
+        val messagesPrev = messages.bag()
         messages.updateWithMany(edges)(
           e => (e.var1, e.var2, e.state2), (m, es) => {
             m.prob = (for {
@@ -139,7 +140,7 @@ class BeliefPropagation(
               if v.identity == (e.var1, e.state1)
               p <- products
               if p.identity == (e.var1, e.state1)
-              m <- messages.bag()
+              m <- messagesPrev
               if m.identity == (e.var2, e.var1, e.state1)
             } yield {
               v.prior * e.prob * p.marginal / m.prob


### PR DESCRIPTION
It turned out that Chill can't handle inner classes (*), but I think we can live with this limitation for now. The stateful ctor will give a (hopefully) helpful error msg, when a user accidentally tries to use an inner class.

Btw, I didn't use 6dc076b9eebbb81a3fff360557625e3abe67d6d8, because `GraphColoringTest` fails with that (see https://github.com/stratosphere/emma/pull/70#issuecomment-148927971). I have instead wrote

``` scala
s <- DataBag((for (x <- state) yield x._2).toSeq)
```

at both places.

(*) This is because inner classes have a synthesized field called `$outer`, and Chill tries to serialize this, which usually leads to disaster. (I tried to hack Chill to make it call `.setIgnoreSyntheticFields(false)` on the underlying Kryo serializer, but that didn't work well, because then the generated equality for case classes was not working when comparing a copied instance to an original.)
