### PR TITLE
Added semantic check for calls to s.bag() from a UDF of s.updateWith*

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/package.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/package.scala
@@ -154,4 +154,18 @@ package object api {
 
   implicit def materializeCSVConverters[T]: CSVConverters[T] =
     macro ConvertersMacros.materializeCSVConverters[T]
+
+  // -----------------------------------------------------
+  // exceptions
+  // -----------------------------------------------------
+
+  class InvalidProgramException(message: String = null, cause: Throwable = null) extends Exception(message, cause) {}
+
+  class StatefulAccessedFromUdfException()
+    extends InvalidProgramException("""
+      | Called .bag() from the UDF of an updateWith* on the same stateful that is
+      | "being updated. A possible fix is to save the result of the .bag() call to a DataBag before the
+      | "updateWith* call, and use that one in place of this .bag() call.""".stripMargin)
+  // Note: Don't catch this!
+  // This should terminate the program, because the stateful will be in an invalid state after throwing this.
 }

--- a/emma-common/src/test/scala/eu/stratosphere/emma/api/StatefulNativeTest.scala
+++ b/emma-common/src/test/scala/eu/stratosphere/emma/api/StatefulNativeTest.scala
@@ -9,6 +9,7 @@ import org.scalatest.junit.JUnitRunner
 class StatefulNativeTest extends FlatSpec with Matchers with BeforeAndAfter {
 
   "Stateful native" should "do deep copies" in  {
+    import eu.stratosphere.emma.api.StatefulNativeTest.Foo
 
     val b1 = DataBag(Seq(Foo(1, 1)))
 
@@ -28,7 +29,10 @@ class StatefulNativeTest extends FlatSpec with Matchers with BeforeAndAfter {
   }
 }
 
+object StatefulNativeTest {
 
-case class Foo(@id s: Int, var n: Int) extends Identity[Int] {
-  override def identity = n
+  case class Foo(@id s: Int, var n: Int) extends Identity[Int] {
+    override def identity = n
+  }
+
 }

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/SemanticChecks.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/SemanticChecks.scala
@@ -1,0 +1,22 @@
+package eu.stratosphere.emma.macros.program
+
+import eu.stratosphere.emma.api.StatefulAccessedFromUdfException
+import eu.stratosphere.emma.macros.program.comprehension.ComprehensionAnalysis
+
+private[emma] trait SemanticChecks extends ComprehensionAnalysis {
+  import universe._
+
+  def doSemanticChecks(t: Tree): Unit =
+    checkForStatefulAccessedFromUdf(t)
+
+  /**
+   * Checks that .bag() is not called from the UDF of an updateWith* on the same stateful that is being updated.
+   */
+  def checkForStatefulAccessedFromUdf(t: Tree): Unit =
+    t.traverse {
+      case q"${updateWith @ Select(ident @ Ident(_), _)}[$_]($udf)"
+        if api.updateWith contains updateWith.symbol =>
+        if ((udf: Tree).freeTerms.map(x => x.asInstanceOf[Symbol]) contains ident.symbol)
+          throw new StatefulAccessedFromUdfException()
+    }
+}

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/WorkflowMacros.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/WorkflowMacros.scala
@@ -8,7 +8,7 @@ import scala.language.existentials
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
-class WorkflowMacros(val c: blackbox.Context) extends ControlFlow with Comprehension {
+class WorkflowMacros(val c: blackbox.Context) extends ControlFlow with Comprehension with SemanticChecks {
   import universe._
 
   val ENGINE = typeOf[Engine]
@@ -17,6 +17,8 @@ class WorkflowMacros(val c: blackbox.Context) extends ControlFlow with Comprehen
   /** Translate an Emma expression to an [[Algorithm]]. */
   // TODO: Add more comprehensive ScalaDoc
   def parallelize[T: c.WeakTypeTag](e: Expr[T]) = {
+
+    doSemanticChecks(e.tree)
 
     // Create a normalized version of the original tree
     val normalized = normalize(e.tree)
@@ -72,6 +74,8 @@ class WorkflowMacros(val c: blackbox.Context) extends ControlFlow with Comprehen
   /** Translate an Emma expression to an [[Algorithm]]. */
   // TODO: Add more comprehensive ScalaDoc
   def comprehend[T: c.WeakTypeTag](e: Expr[T]) = {
+
+    doSemanticChecks(e.tree)
 
     // Create a normalized version of the original tree
     val normalized = normalize(e.tree)

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionModel.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionModel.scala
@@ -45,6 +45,8 @@ private[emma] trait ComprehensionModel extends BlackBoxUtil {
     ) ++ apply.alternatives
 
     val monadic = Set(map, flatMap, withFilter)
+
+    val updateWith = Set(updateWithZero, updateWithOne, updateWithMany)
   }
 
   // Type constructors

--- a/emma-language/src/test/scala/eu/stratosphere/emma/macros/SemanticChecksTest.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/macros/SemanticChecksTest.scala
@@ -1,0 +1,75 @@
+package eu.stratosphere.emma.macros
+
+import eu.stratosphere.emma.api._
+import eu.stratosphere.emma.api.model._
+import org.junit.runner.RunWith
+import org.scalatest.{Matchers, FlatSpec}
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.prop.PropertyChecks
+
+@RunWith(classOf[JUnitRunner])
+class SemanticChecksTest extends FlatSpec with PropertyChecks with Matchers {
+  import CheckForStatefulAccessedFromUdfTest.Foo
+
+  "The updateWith* functions" should "throw an exception when the stateful is accessed from the updateWith* UDF" in {
+    val b = DataBag(Seq(Foo(1, 1)))
+
+    // These should throw exceptions:
+
+    intercept[StatefulAccessedFromUdfException] {
+      val s = stateful[Foo, Int](b)
+      s.updateWithZero(x => s.bag())
+    }
+
+    val us = DataBag(Seq(Foo(1, 2)))
+
+    intercept[StatefulAccessedFromUdfException] {
+      val s = stateful[Foo, Int](b)
+      s.updateWithOne(us)(_.s, (x,y) => s.bag())
+    }
+    intercept[StatefulAccessedFromUdfException] {
+      val s = stateful[Foo, Int](b)
+      s.updateWithMany(us)(_.s, (x,y) => s.bag())
+    }
+
+    // And these should not throw exceptions:
+    val s = stateful[Foo, Int](b)
+    s.updateWithZero(x => DataBag())
+    s.updateWithOne(us)(_.s, (x, y) => DataBag())
+    s.updateWithMany(us)(_.s, (x, y) => DataBag())
+  }
+
+  "parallelize" should "check for the stateful being accessed from the updateWith* UDF" in {
+    val b = DataBag(Seq(Foo(1, 1)))
+
+    """emma.parallelize {
+      val s = stateful[Foo, Int](b)
+      s.updateWithZero(x => s.bag())
+    }""" shouldNot compile
+
+    """emma.parallelize {
+      val s = stateful[Foo, Int](b)
+      s.updateWithOne(us)(_.s, (x,y) => s.bag())
+    }""" shouldNot compile
+
+    """emma.parallelize {
+      val s = stateful[Foo, Int](b)
+      s.updateWithMany(us)(_.s, (x,y) => s.bag())
+    }""" shouldNot compile
+
+    // This should compile
+    val dummy = emma.parallelize {
+      val s = stateful[Foo, Int](b)
+      val us = DataBag(Seq(Foo(1, 2)))
+      s.updateWithZero(x => DataBag())
+      s.updateWithOne(us)(_.s, (x, y) => DataBag())
+      s.updateWithMany(us)(_.s, (x, y) => DataBag())
+    }
+  }
+}
+
+object CheckForStatefulAccessedFromUdfTest {
+  case class Foo(@id s: Int, var n: Int) extends Identity[Int] {
+    override def identity = n
+  }
+}


### PR DESCRIPTION
This is solving the first issue in https://github.com/stratosphere/emma/issues/84. I implemented what I wrote in the comment there.

(This PR is on top of the commit of https://github.com/stratosphere/emma/pull/83. I will rebase this, after that is merged.)
