### PR TITLE
[MACROS] Introduce `unComprehend` method

### DIFF
--- a/emma-language/src/test/scala/eu/stratosphere/emma/macros/UnComprehensionTest.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/macros/UnComprehensionTest.scala
@@ -1,0 +1,83 @@
+package eu.stratosphere.emma.macros
+
+import eu.stratosphere.emma.api.DataBag
+import org.junit.runner.RunWith
+import org.scalatest.{Matchers, FunSuite}
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class UnComprehensionTest extends FunSuite with Matchers {
+
+  lazy val cm = reflect.runtime.currentMirror
+  lazy val tb = mkToolbox(s"-cp $toolboxClasspath")
+
+  val imports = """
+    |import eu.stratosphere.emma.api._
+    |import eu.stratosphere.emma.ir._
+    |import eu.stratosphere.emma.runtime.Native
+    |""".stripMargin
+
+  test("fold-group fusion") {
+    val tree = tb parse imports + """
+      |eu.stratosphere.emma.macros.testmacros.reComprehend {
+      |  DataBag(1 to 100).groupBy { _ % 7 }.map { _.values.sum() }.product()
+      |}.run(Native())
+      |""".stripMargin
+
+    val expected = DataBag(1 to 100).groupBy { _ % 7 }.map { _.values.sum() }.product()
+    tb eval tree should be (expected)
+  }
+
+  test("filter only") {
+    val tree = tb parse imports + """
+      |eu.stratosphere.emma.macros.testmacros.reComprehend {
+      |  (for (x <- DataBag(1 to 100) if x % 2 == 0) yield x).sum()
+      |}.run(Native())
+      |""".stripMargin
+
+    val expected = (for (x <- DataBag(1 to 100) if x % 2 == 0) yield x).sum()
+    tb eval tree should be (expected)
+  }
+
+  test("simple flatMap") {
+    val tree = tb parse imports + """
+      |eu.stratosphere.emma.macros.testmacros.reComprehend {
+      |  (for {
+      |    x <- DataBag(1 to 100)
+      |    y <- DataBag(1 to 100)
+      |    z = x + y
+      |    if z % 2 == 0
+      |  } yield z).sum()
+      |}.run(Native())
+      |""".stripMargin
+
+    val expected = (for {
+      x <- DataBag(1 to 100)
+      y <- DataBag(1 to 100)
+      z = x + y
+      if z % 2 == 0
+    } yield z).sum()
+
+    tb eval tree should be (expected)
+  }
+
+  test("join") {
+    val tree = tb parse imports + """
+      |eu.stratosphere.emma.macros.testmacros.reComprehend {
+      |  (for {
+      |    x <- DataBag(1 to 100)
+      |    y <- DataBag(1 to 100)
+      |    if x == y
+      |  } yield x * y).sum()
+      |}.run(Native())
+      |""".stripMargin
+
+    val expected = (for {
+      x <- DataBag(1 to 100)
+      y <- DataBag(1 to 100)
+      if x == y
+    } yield x * y).sum()
+
+    tb eval tree should be (expected)
+  }
+}

--- a/emma-language/src/test/scala/eu/stratosphere/emma/macros/testmacros.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/macros/testmacros.scala
@@ -3,7 +3,6 @@ package eu.stratosphere.emma.macros
 import eu.stratosphere.emma.api.Algorithm
 import eu.stratosphere.emma.macros.program.comprehension.TestMacros
 
-
 object testmacros {
 
   import scala.language.experimental.macros
@@ -12,6 +11,6 @@ object testmacros {
   // test macros
   // -----------------------------------------------------
 
-  final def parallelize[T](e: T): Algorithm[T] = macro TestMacros.parallelize[T]
-
+  def parallelize[T](e: T): Algorithm[T] = macro TestMacros.parallelize[T]
+  def reComprehend[T](e: T): Algorithm[T] = macro TestMacros.reComprehend[T]
 }


### PR DESCRIPTION
`unComprehend` serializes expressions back to executable Scala code.
