### PR TITLE
[MACROS] Fix the collecting of the used variables in parseJoinPredicate.

### DIFF
--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/rewrite/ComprehensionCombination.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/rewrite/ComprehensionCombination.scala
@@ -242,15 +242,8 @@ trait ComprehensionCombination extends ComprehensionRewriteEngine {
         case q"${lhs: Tree} == ${rhs: Tree}" =>
           val defVars = p.definedVars(root)
 
-          val lhsVars = { // Find expr.vars used in the `lhs`
-            val useVars = lhs.collect { case id @ Ident(n: TermName) => id.term }.toSet
-            defVars intersect useVars
-          }
-
-          val rhsVars = { // Find expr.vars used in the `rhs`
-            val useVars = rhs.collect { case id @ Ident(n: TermName) => id.term }.toSet
-            defVars intersect useVars
-          }
+          val lhsVars = defVars intersect lhs.freeTerms
+          val rhsVars = defVars intersect rhs.freeTerms
 
           if (lhsVars.size != 1 || rhsVars.size != 1) {
             None // Both `lhs` and `rhs` must refer to exactly one variable


### PR DESCRIPTION
I'm trying to get `BeliefPropagation` working with `parallelize`, and I've run into a bug in `parseJoinPredicate`. The collecting of `useVars` in parseJoinPredicate doesn't have the check `if id.hasTerm`. I have changed this to use `TreeOps.references` from `ReflectUtil`, which has the missing  check.
