### PR TITLE
[MACROS] Replace substitution with symbol binding

### DIFF
--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/BlackBoxUtil.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/BlackBoxUtil.scala
@@ -9,15 +9,15 @@ trait BlackBoxUtil extends BlackBox with ReflectUtil {
   import universe._
   import c.internal._
 
-  def parse(str: String) =
-    c parse str
+  def parse(string: String) =
+    c.parse(string)
 
   def typeCheck(tree: Tree) =
     if (tree.isType) c.typecheck(tree, c.TYPEmode)
-    else c typecheck tree
+    else c.typecheck(tree)
 
   def termSym(owner: Symbol, name: TermName, tpe: Type, flags: FlagSet, pos: Position) =
-    newTermSymbol(owner, name, pos, flags).withInfo(tpe).asTerm
+    newTermSymbol(owner, name, pos, flags).withType(tpe.precise).asTerm
 
   def typeSym(owner: Symbol, name: TypeName, flags: FlagSet, pos: Position) =
     newTypeSymbol(owner, name, pos, flags)
@@ -48,7 +48,7 @@ trait BlackBoxUtil extends BlackBox with ReflectUtil {
      */
     def typingTransform(pf: (Tree, TypingTransformApi) ~> Tree): Tree =
       c.internal.typingTransform(typeChecked) {
-        case x if pf isDefinedAt x => pf(x)
+        case x if pf.isDefinedAt(x) => pf(x)
         case (tree, xform) => xform default tree
       }
 
@@ -64,7 +64,7 @@ trait BlackBoxUtil extends BlackBox with ReflectUtil {
      */
     def typingTransform(owner: Symbol)(pf: (Tree, TypingTransformApi) ~> Tree): Tree =
       c.internal.typingTransform(typeChecked, owner) {
-        case x if pf isDefinedAt x => pf(x)
+        case x if pf.isDefinedAt(x) => pf(x)
         case (tree, xform) => xform default tree
       }
 

--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/RuntimeUtil.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/RuntimeUtil.scala
@@ -16,15 +16,15 @@ trait RuntimeUtil extends ReflectUtil {
   import universe._
   import internal._
 
-  def parse(str: String) =
-    tb parse str
+  def parse(string: String) =
+    tb.parse(string)
 
   def typeCheck(tree: Tree) =
     if (tree.isType) tb.typecheck(tree, tb.TYPEmode)
-    else tb typecheck tree
+    else tb.typecheck(tree)
 
   def termSym(owner: Symbol, name: TermName, tpe: Type, flags: FlagSet, pos: Position) =
-    newTermSymbol(owner, name, pos, flags).withInfo(tpe).asTerm
+    newTermSymbol(owner, name, pos, flags).withType(tpe.precise).asTerm
 
   def typeSym(owner: Symbol, name: TypeName, flags: FlagSet, pos: Position) =
     newTypeSymbol(owner, name, pos, flags)

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/controlflow/ControlFlowNormalization.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/controlflow/ControlFlowNormalization.scala
@@ -85,7 +85,7 @@ private[emma] trait ControlFlowNormalization extends BlackBoxUtil {
     override def transform(tree: Tree) = tree match {
       case sel @ Select(enclosing: This, name) if needsSubstitution(enclosing, sel) =>
         val alias = aliases.getOrElseUpdate(sel.symbol,
-          mk.valDef(TermName(s"__this$$$name"), sel.trueType, rhs = sel))
+          mk.valDef(TermName(s"__this$$$name"), sel.preciseType, rhs = sel))
 
         Ident(alias.name)
 


### PR DESCRIPTION
We step on the equivalence of the following two constructs (shown in untyped lambda calculus for simplicity):

```
expr[t\x] =β (λx. expr) t
```

I.e. substitution and binding followed by subsequent application are beta-equivalent. Instead of beta-reduction, we can use abstraction, which is cleaner to program in macros.

In Scala the right-hand side can be simplified to a local variable definition inside a block instead of an anonymous function (with careful renaming in case `x` is free in `t`:

```
{ val fresh = t; expr[fresh\x] }
```

The advantage is that renaming can safely be performed on symbols. Furthermore, the program execution is potentially more efficient and follows closely the original (`t` is executed only once).

This fixes #69.
Open issue (#90): handle `substitute(find: Tree, repl: Tree)`
