### PR TITLE
[MACROS] Give meaningful prefixes to some freshNames.

### DIFF
--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionModel.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionModel.scala
@@ -837,8 +837,8 @@ private[emma] trait ComprehensionModel extends BlackBoxUtil {
 
     // xs join ys where kx equalTo ky
     case combinator.EquiJoin(kx, ky, xs, ys) =>
-      val x = freshName("x")
-      val y = freshName("y")
+      val x = freshName("unComp$x")
+      val y = freshName("unComp$y")
       q"""for {
         $x <- ${unComprehend(xs)}
         $y <- ${unComprehend(ys)}
@@ -847,8 +847,8 @@ private[emma] trait ComprehensionModel extends BlackBoxUtil {
 
     // xs cross ys
     case combinator.Cross(xs, ys) =>
-      val x = freshName("x")
-      val y = freshName("y")
+      val x = freshName("unComp$x")
+      val y = freshName("unComp$y")
       q"""for {
         $x <- ${unComprehend(xs)}
         $y <- ${unComprehend(ys)}
@@ -884,7 +884,7 @@ private[emma] trait ComprehensionModel extends BlackBoxUtil {
 
     // xs groupBy key map { g => Group(g.key, g.values.fold(empty)(sng, union)) }
     case combinator.FoldGroup(key, empty, sng, union, xs) =>
-      val g = freshName("g")
+      val g = freshName("unComp$g")
       q"""${unComprehend(xs)}.groupBy($key).map({ case $g =>
         _root_.eu.stratosphere.emma.api.Group($g.key, $g.values.fold($empty)($sng, $union))
       })"""

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/rewrite/ComprehensionCombination.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/rewrite/ComprehensionCombination.scala
@@ -212,7 +212,7 @@ trait ComprehensionCombination extends ComprehensionRewriteEngine {
 
       // bind join result to a fresh variable
       val tpt = tq"(${kx.vparams.head.tpt}, ${ky.vparams.head.tpt})"
-      val vd  = mk.valDef(freshName("x"), tpt)
+      val vd  = mk.valDef(freshName("join"), tpt)
       val sym = mk.freeTerm(vd.name.toString, vd.trueType)
       val qs  = suffix drop 2 filter { _ != filter }
 
@@ -310,8 +310,8 @@ trait ComprehensionCombination extends ComprehensionRewriteEngine {
       // construct combinator node with input and predicate sides aligned
       val cross = combinator.Cross(xs.rhs, ys.rhs)
 
-      // bind join result to a fresh variable
-      val vd  = mk.valDef(freshName("x"), tq"(${rm.xs.tpe}, ${rm.ys.tpe})")
+      // bind cross result to a fresh variable
+      val vd  = mk.valDef(freshName("cross"), tq"(${rm.xs.tpe}, ${rm.ys.tpe})")
       val sym = mk.freeTerm(vd.name.toString, vd.trueType)
 
       // substitute [v._1/x] in affected expressions

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/rewrite/ComprehensionNormalization.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/rewrite/ComprehensionNormalization.scala
@@ -83,7 +83,7 @@ trait ComprehensionNormalization extends ComprehensionRewriteEngine {
         parent.hd = child.hd
         parent // return new root
       case RuleMatch(parent, child: Expression) =>
-        val vd  = mk.valDef(freshName("x"), child.tpe)
+        val vd  = mk.valDef(freshName("head"), child.tpe)
         val sym = mk.freeTerm(vd.name.toString, vd.elementType)
         parent.qualifiers ++= List(Generator(sym, child))
         parent.hd = ScalaExpr(mk ref sym)
@@ -145,7 +145,7 @@ trait ComprehensionNormalization extends ComprehensionRewriteEngine {
 
     def fire(rm: RuleMatch) = {
       val RuleMatch(fold, map, child) = rm
-      val x    = freshName("x")
+      val x    = freshName("agg")
       val head = map.hd.as[ScalaExpr].tree.rename(child.lhs.name, x)
       val sng  = fold.sng.as[Function]
       val body = sng.body.substitute(sng.vparams.head.name, head)


### PR DESCRIPTION
When debugging code generation, it is often hard to figure out from where is a particular piece of code coming from. Giving meaningful prefixes to freshNames helps with this.
