### PR TITLE
[TEST] Refactored `TicTacToe` test

### DIFF
--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/TicTacToeTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/TicTacToeTest.scala
@@ -1,41 +1,29 @@
 package eu.stratosphere.emma.examples.graphs
 
-import eu.stratosphere.emma.runtime.{Native, Flink}
+import eu.stratosphere.emma.testutil.withRuntime
+
 import org.junit.runner.RunWith
 import org.scalatest._
 import org.scalatest.junit.JUnitRunner
-import eu.stratosphere.emma.runtime
 
 @RunWith(classOf[JUnitRunner])
 class TicTacToeTest extends FlatSpec with Matchers {
+  import TicTacToe._
 
-  "TicTacToe" should "compute the game-theoretical values" in {
-    val rt = runtime.default()
-
-    val rtName = System.getProperty("emma.execution.backend", "")
+  "TicTacToe" should "compute the game-theoretical values" in withRuntime() { rt =>
+    val rtName = sys.props.getOrElse("emma.execution.backend", "").toLowerCase
     if (rtName == "flink" || rtName == "native") {
-      val result = new TicTacToe().algorithm.run(rt).fetch()
-
-      // Could be compared to the native rt, but it is too slow, so I calculate a "checksum" instead.
-
-      result.exists(v => v.vc.isInstanceOf[TicTacToe.Undefined]) should equal(false)
-
-      result.flatMap(v => v.vc match {
-        case v: TicTacToe.Win => Seq(v.depth);
-        case _ => Seq()
-      }).sum should equal(8697)
-
-      result.flatMap(v => v.vc match {
-        case v: TicTacToe.Loss => Seq(v.depth);
-        case _ => Seq()
-      }).sum should equal(4688)
-
-      result.flatMap(v => v.vc match {
-        case v: TicTacToe.Count => Seq(v.count);
-        case _ => Seq()
-      }).sum should equal(3495)
+      val result = new TicTacToe().algorithm.run(rt).fetch().map { _.vc }
+      // Could be compared to the native rt, but it is too slow, so we use a "checksum" instead
+      result.collect { case u: Undefined => u } should be ('empty)
+      result.collect { case Win(depth) => depth }.sum should equal (8697)
+      result.collect { case Loss(depth) => depth }.sum should equal (4688)
+      result.collect { case Count(cnt) => cnt }.sum should equal (3495)
     } else {
-      println("Skipping TicTacToe test, because it only works with Flink and Native. (because of the stateful)")
+      println("""
+        |Skipping TicTacToe test, because it only works with Flink and Native.
+        |(due to stateful API support)
+        |""".stripMargin)
     }
   }
 }


### PR DESCRIPTION
- Remove unused imports (caused test to fail before)
- Use `withRuntime` to initialize the backend
- Use `collect` and pattern matching instead of `flatMap`

This fixes #94 
