### PR TITLE
[MACROS] Migrate to symbol-based substitution

### DIFF
--- a/emma-backend/src/main/scala/eu/stratosphere/emma/codegen/utils/DataflowCompiler.scala
+++ b/emma-backend/src/main/scala/eu/stratosphere/emma/codegen/utils/DataflowCompiler.scala
@@ -82,18 +82,7 @@ class DataflowCompiler(val mirror: Mirror) {
 }
 
 object DataflowCompiler {
-
-  val CODEGEN_DIR_DEFAULT = Paths.get(System.getProperty("java.io.tmpdir"), "emma", "codegen").toAbsolutePath.toString
-  val CONSTRUCTOR = termNames.CONSTRUCTOR
   val RUN_METHOD = TermName("run")
-
-  object replaceIdents extends Transformer with (Tree => Tree) {
-    override def transform(tree: Tree): Tree = tree match {
-      case ident@Ident(TermName(x)) => Ident(TermName(x))
-      case x => super.transform(x)
-    }
-
-    override def apply(tree: Tree) = transform(tree)
-  }
-
+  val CODEGEN_DIR_DEFAULT =
+    Paths.get(System.getProperty("java.io.tmpdir"), "emma", "codegen").toAbsolutePath.toString
 }

--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/BlackBoxUtil.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/BlackBoxUtil.scala
@@ -8,72 +8,27 @@ package eu.stratosphere.emma.macros
 trait BlackBoxUtil extends BlackBox with ReflectUtil {
   import universe._
   import c.internal._
+  import syntax._
 
-  def parse(str: String) =
-    c parse str
+  def parse(string: String) =
+    c.parse(string)
 
   def typeCheck(tree: Tree) =
     if (tree.isType) c.typecheck(tree, c.TYPEmode)
-    else c typecheck tree
+    else c.typecheck(tree)
 
   def termSym(owner: Symbol, name: TermName, tpe: Type, flags: FlagSet, pos: Position) =
-    newTermSymbol(owner, name, pos, flags).withInfo(tpe).asTerm
+    newTermSymbol(owner, name, pos, flags).withType(tpe).asTerm
 
   def typeSym(owner: Symbol, name: TypeName, flags: FlagSet, pos: Position) =
     newTypeSymbol(owner, name, pos, flags)
 
-  /** Syntactic sugar for [[Tree]]s. */
-  implicit class BlackBoxTreeOps(self: Tree) extends TreeOps(self) {
-
-    /**
-     * Replace the owner of all [[Symbol]]s in this [[Tree]].
-     *
-     * NOTE: The [[Tree]] will be implicitly type-checked if it doesn't have a [[Type]].
-     *
-     * @param prev The owner [[Symbol]] to replace
-     * @param next The new owner [[Symbol]] to use
-     * @return This [[Tree]] with all [[Symbol]] owner changed from `prev` to `next`
-     */
-    def withOwner(prev: Symbol, next: Symbol): Tree =
-      changeOwner(self, prev, next)
-
-    /**
-     * Transform this [[Tree]] while repairing the [[Symbol]] owner chain. After this there should
-     * be no need to type-check or re-type-check the [[Tree]].
-     *
-     * NOTE: The [[Tree]] will be implicitly type-checked if it doesn't have a [[Type]].
-     *
-     * @param pf A transforming [[PartialFunction]]
-     * @return A tranformed copy of this [[Tree]]
-     */
-    def typingTransform(pf: (Tree, TypingTransformApi) ~> Tree): Tree =
-      c.internal.typingTransform(typeChecked) {
-        case x if pf isDefinedAt x => pf(x)
-        case (tree, xform) => xform default tree
-      }
-
-    /**
-     * Transform this [[Tree]] while repairing the [[Symbol]] owner chain. After this there should
-     * be no need to type-check or re-type-check the [[Tree]].
-     *
-     * NOTE: The [[Tree]] will be implicitly type-checked if it doesn't have a [[Type]].
-     *
-     * @param owner The owner [[Symbol]] tu use when type-checking
-     * @param pf A transforming [[PartialFunction]]
-     * @return A tranformed copy of this [[Tree]]
-     */
-    def typingTransform(owner: Symbol)(pf: (Tree, TypingTransformApi) ~> Tree): Tree =
-      c.internal.typingTransform(typeChecked, owner) {
-        case x if pf isDefinedAt x => pf(x)
-        case (tree, xform) => xform default tree
-      }
-
-    override def transform(pf: Tree ~> Tree) = super.transform(pf orElse {
+  override def transform(tree: Tree)(pf: Tree ~> Tree) =
+    super.transform(tree)(pf orElse {
       // NOTE:
       // - `TypeTree.original` is not transformed by default
       // - `setOriginal` is only available at compile-time
       case tt: TypeTree if tt.original != null =>
-        setOriginal(tt, tt.original transform pf)
+        setOriginal(tt, transform(tt.original)(pf))
     })
-  }
 }

--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/ConvertersMacros.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/ConvertersMacros.scala
@@ -4,26 +4,25 @@ import scala.reflect.macros.blackbox
 
 // TODO: add DateTime support
 class ConvertersMacros(val c: blackbox.Context) extends BlackBoxUtil {
-  import c.universe._
+  import universe._
+  import syntax._
 
-  val nextIndex = freshName("nextIndex")
-  val builder   = freshName("builder")
+  val nextIndex = $"nextIndex"
+  val builder = $"builder"
 
   /** Entry macro for emma algorithms. */
   def materializeCSVConverters[T: c.WeakTypeTag] = {
     val tpe = weakTypeOf[T]
-    val v   = freshName("value")
-    val i   = freshName("i")
-    val sep = freshName("separator")
+    val $(v, i, sep) = $("value", "i", "separator")
 
-    val fromStringFn = q"""
+    val fromStringFun = q"""
       def fromCSV($v: ${ARRAY(STRING)}): $tpe = {
-        var $i = -1;
+        var $i = -1
         def $nextIndex = { $i += 1; $i }
         ${fromString[T](tpe, q"$v")}
       }"""
 
-    val toStringFn = q"""
+    val toStringFun = q"""
       def toCSV($v: $tpe, $sep: $CHAR): ${ARRAY(STRING)} = {
         $builder.clear()
         ${toString[T](tpe, q"$v")}
@@ -32,8 +31,8 @@ class ConvertersMacros(val c: blackbox.Context) extends BlackBoxUtil {
 
     q"""new _root_.eu.stratosphere.emma.api.CSVConverters[$tpe] {
       val $builder = _root_.scala.collection.mutable.ArrayBuilder.make[$STRING]
-      $fromStringFn
-      $toStringFn
+      $fromStringFun
+      $toStringFun
     }"""
   }
 

--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/RuntimeUtil.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/RuntimeUtil.scala
@@ -15,21 +15,18 @@ trait RuntimeUtil extends ReflectUtil {
   
   import universe._
   import internal._
+  import syntax._
 
-  def parse(str: String) =
-    tb parse str
+  def parse(string: String) =
+    tb.parse(string)
 
   def typeCheck(tree: Tree) =
     if (tree.isType) tb.typecheck(tree, tb.TYPEmode)
-    else tb typecheck tree
+    else tb.typecheck(tree)
 
   def termSym(owner: Symbol, name: TermName, tpe: Type, flags: FlagSet, pos: Position) =
-    newTermSymbol(owner, name, pos, flags).withInfo(tpe).asTerm
+    newTermSymbol(owner, name, pos, flags).withType(tpe).asTerm
 
   def typeSym(owner: Symbol, name: TypeName, flags: FlagSet, pos: Position) =
     newTypeSymbol(owner, name, pos, flags)
-
-  /** Syntax sugar for [[Tree]]s. */
-  implicit def fromTree(self: Tree): TreeOps =
-    new TreeOps(self)
 }

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/prototype/TranslationPrototype.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/prototype/TranslationPrototype.scala
@@ -1,5 +1,6 @@
 package eu.stratosphere.emma.examples.prototype
 
+import eu.stratosphere.emma.api.{DataBag, emma}
 import eu.stratosphere.emma.examples.Algorithm
 import eu.stratosphere.emma.runtime
 

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/WorkflowMacros.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/WorkflowMacros.scala
@@ -10,6 +10,7 @@ import scala.reflect.macros.blackbox
 
 class WorkflowMacros(val c: blackbox.Context) extends ControlFlow with Comprehension with SemanticChecks {
   import universe._
+  import syntax._
 
   val ENGINE = typeOf[Engine]
   val NATIVE = typeOf[Native]

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/controlflow/ControlFlowCompiler.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/controlflow/ControlFlowCompiler.scala
@@ -6,6 +6,7 @@ import scala.collection.mutable.ListBuffer
 
 private[emma] trait ControlFlowCompiler extends ControlFlowModel with BlackBoxUtil {
   import universe._
+  import syntax._
 
   def compileDriver[T: c.WeakTypeTag](cfGraph: CFGraph): ListBuffer[Tree] = {
     // Build driver tree starting from the (per construction unique) head block

--- a/emma-language/src/test/scala/eu/stratosphere/emma/macros/program/comprehension/TestMacros.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/macros/program/comprehension/TestMacros.scala
@@ -7,7 +7,8 @@ import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
 class TestMacros(val c: blackbox.Context) extends ControlFlow with Comprehension {
-  import c.universe._
+  import universe._
+  import syntax._
 
   /**
    * Translates an Emma expression to an Algorithm.


### PR DESCRIPTION
First, I apologize for the huge PR. Unfortunately changes in the `ReflectUtil` trait API are pervasive. Here is the changelog:
- Migrated to symbol-based substitution:
  - Affects `substitute`, `rename`, `refresh` and `Tree` constructors in `mk`.
  - Operations on `Name`s are to be avoided from now on.
- Redesigned the API of `ReflectUtil`:
  - Recursive methods are not decorators any more (substantially reduces garbage objects).
  - All decorators moved to `syntax`, their use is optional.
  - Introduced fresh name string interpolator (`$"prefix"`).
  - Introduced more fluent API for `Tree`s construction:
    - `let (x -> t1, y -> t2) in tree = substitute(tree) { Map(x -> t1, y -> t2) }`
    - `val_(name, tpe) := rhs = mk.valDef(name, tpe, rhs)`
    - `λ(args: _*) { body } = mk.anonFun(args.toList, body)`
    - `term @@ pattern = mk.bind(term, pattern)`
    - `tree :: tpe = tree.withType(tpe)`
    - `&(term) = mk.ref(term)`
