### PR TITLE
[MACROS] Reenabled predicate normalization in CNF

### DIFF
--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/WorkflowMacros.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/WorkflowMacros.scala
@@ -8,7 +8,9 @@ import scala.language.existentials
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
-class WorkflowMacros(val c: blackbox.Context) extends ControlFlow with Comprehension with SemanticChecks {
+class WorkflowMacros(val c: blackbox.Context)
+    extends ControlFlow with Comprehension with SemanticChecks {
+
   import universe._
   import syntax._
 
@@ -44,7 +46,7 @@ class WorkflowMacros(val c: blackbox.Context) extends ControlFlow with Comprehen
     compView      = createComprehensionView(cfGraph)
 
     // 2. Normalize filter predicates to CNF
-    // normalizePredicates(optimized)
+//    normalizePredicates(optimized)
 
     // 3. Apply Fold-Group-Fusion where possible
     foldGroupFusion(optimized)

--- a/emma-language/src/test/scala/eu/stratosphere/emma/macros/PredicateNormalizationTest.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/macros/PredicateNormalizationTest.scala
@@ -1,126 +1,87 @@
 package eu.stratosphere.emma.macros
 
-import eu.stratosphere.emma.ir.Filter
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
 
-import tools.reflect.ToolBox
-import org.junit.Ignore
-import org.junit.Test
+@RunWith(classOf[JUnitRunner])
+class PredicateNormalizationTest extends FlatSpec with Matchers {
 
-class PredicateNormalizationTest {
+  val tb = mkToolbox(s"-cp $toolboxClasspath")
+  import tb.u._
 
-  @Ignore
-  @Test
-  def `Normalize Predicates into CNF`() {
-    val cm = reflect.runtime.currentMirror
-    val tb = mkToolbox(s"-cp ${toolboxClasspath}")
-    val tree = tb.parse(
-      """
-        |import eu.stratosphere.emma.api._
-        |import eu.stratosphere.emma.ir._
-        |
-        |
-        |eu.stratosphere.emma.macros.testmacros.parallelize {
-        | val alg = for (x <- DataBag(1 to 10)
-        |                if !(x > 5 || (x < 2 && x == 0)) || (x > 5 || !(x < 2)))
-        |              yield x} """.stripMargin)
+  val imports = """
+    |import eu.stratosphere.emma.api._
+    |import eu.stratosphere.emma.ir._
+    |""".stripMargin
 
-    val tree1 = tb.typecheck(tree)
-    import tb.u._
+  "Predicate normalization" should "normalize predicates into CNF" in {
+    val algorithm = """
+      |eu.stratosphere.emma.macros.testmacros.parallelize {
+      |  val alg = for {
+      |    x <- DataBag(1 to 10)
+      |    if !(x > 5 || (x < 2 && x == 0)) || (x > 5 || !(x < 2))
+      |  } yield x
+      |} """.stripMargin
 
-    val filters = tree1 collect {case f@Apply(TypeApply(Select(Select(q, TermName("Filter")), _), as), args)=> f}
-    filters.size mustBe 1
-
-    val ft = filters.flatMap(x => x collect {case Literal(t) => t})
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.<(2).`unary_!`.||(x.==(0).`unary_!`).||(x.>(5))))")) mustBe true
+    filtersIn (algorithm) should contain theSameElementsAs
+      "(() => ((x: Int) => x.<(2).`unary_!`.||(x.==(0).`unary_!`).||(x.>(5))))" :: Nil
   }
 
-  @Ignore
-  @Test
-  def `seperate filter conjunction into seperate filters`() {
-    val cm = reflect.runtime.currentMirror
-    val tb = mkToolbox(s"-cp ${toolboxClasspath}")
-    val tree = tb.parse(
-      """
-        |import eu.stratosphere.emma.api._
-        |import eu.stratosphere.emma.ir._
-        |
-        |
-        |eu.stratosphere.emma.macros.testmacros.parallelize {
-        | val alg = for (x <- DataBag(1 to 10)
-        |                if x > 5 && x > 0 && x != 4)
-        |              yield x} """.stripMargin)
+  it should "separate filter conjunction into seperate filters" in {
+    val algorithm = """
+      |eu.stratosphere.emma.macros.testmacros.parallelize {
+      |  val alg = for {
+      |    x <- DataBag(1 to 10)
+      |    if x > 5 && x > 0 && x != 4
+      |  } yield x
+      |} """.stripMargin
 
-    val tree1 = tb.typecheck(tree)
-    import tb.u._
-
-    val filters = tree1 collect {case f@Apply(TypeApply(Select(Select(q, TermName("Filter")), _), as), args)=> f}
-    filters.size mustBe 3
-
-    val ft = filters.flatMap(x => x collect {case Literal(t) => t})
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.!=(4)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.>(5)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.>(0)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.>(5).&&(x.>(0)).&&(x.!=(4))))")) mustBe false
+    filtersIn (algorithm) should contain theSameElementsAs
+      "(() => ((x: Int) => x.!=(4)))" ::
+      "(() => ((x: Int) => x.>(5)))" ::
+      "(() => ((x: Int) => x.>(0)))" :: Nil
   }
 
-  @Ignore
-  @Test
-  def `seperate filter conjunction and single predicate into seperate filters`() {
-    val cm = reflect.runtime.currentMirror
-    val tb = mkToolbox(s"-cp ${toolboxClasspath}")
-    val tree = tb.parse(
-      """
-        |import eu.stratosphere.emma.api._
-        |import eu.stratosphere.emma.ir._
-        |
-        |
-        |eu.stratosphere.emma.macros.testmacros.parallelize {
-        | val alg = for (x <- DataBag(1 to 10)
-        |                if x > 5 && x > 0 && x != 4 if x <= 2)
-        |              yield x} """.stripMargin)
+  it should "separate filter conjunction and single predicate into separate filters" in {
+    val algorithm = """
+      |eu.stratosphere.emma.macros.testmacros.parallelize {
+      |  val alg = for {
+      |    x <- DataBag(1 to 10)
+      |    if x > 5 && x > 0 && x != 4
+      |    if x <= 2
+      |  } yield x
+      |}""".stripMargin
 
-    val tree1 = tb.typecheck(tree)
-    import tb.u._
-
-    val filters = tree1 collect {case f@Apply(TypeApply(Select(Select(q, TermName("Filter")), _), as), args)=> f}
-    filters.size mustBe 4
-
-    val ft = filters.flatMap(x => x collect {case Literal(t) => t})
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.!=(4)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.>(5)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.>(0)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.<=(2)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.>(5).&&(x.>(0)).&&(x.!=(4))))")) mustBe false
+    filtersIn (algorithm) should contain theSameElementsAs
+      "(() => ((x: Int) => x.!=(4)))" ::
+      "(() => ((x: Int) => x.>(5)))" ::
+      "(() => ((x: Int) => x.>(0)))" ::
+      "(() => ((x: Int) => x.<=(2)))" :: Nil
   }
 
-  @Ignore
-  @Test
-  def `seperate filter conjunction with udf predicate into seperate filters`() {
-    val cm = reflect.runtime.currentMirror
-    val tb = mkToolbox(s"-cp ${toolboxClasspath}")
-    val tree = tb.parse(
-      """
-        |import eu.stratosphere.emma.api._
-        |import eu.stratosphere.emma.ir._
-        |
-        |def predicate1(x: Int) = x <= 2
-        |def predicate2(x: Int) = x > 5
-        |
-        |eu.stratosphere.emma.macros.testmacros.parallelize {
-        | val alg = for (x <- DataBag(1 to 10)
-        |                if predicate1(x) && x > 0 && x != 4 if predicate2(x))
-        |              yield x} """.stripMargin)
+  it should "seperate filter conjunction with UDF predicate into seperate filters" in {
+    val algorithm = """
+      |eu.stratosphere.emma.macros.testmacros.parallelize {
+      |  def predicate1(x: Int) = x <= 2
+      |  def predicate2(x: Int) = x > 5
+      |
+      |  val alg = for {
+      |    x <- DataBag(1 to 10)
+      |    if predicate1(x) && x > 0 && x != 4
+      |    if predicate2(x)
+      |  } yield x
+      |} """.stripMargin
 
-    val tree1 = tb.typecheck(tree)
-    import tb.u._
-
-    val filters = tree1 collect {case f@Apply(TypeApply(Select(Select(q, TermName("Filter")), _), as), args)=> f}
-    filters.size mustBe 4
-
-    val ft = filters.flatMap(x => x collect {case Literal(t) => t})
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.!=(4)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => predicate2(x)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => x.>(0)))")) mustBe true
-    ft.contains(Constant("(() => ((x: _root_.scala.Int) => predicate1(x)))")) mustBe true
+    filtersIn (algorithm) should contain theSameElementsAs
+      "(() => ((x: Int) => x.!=(4)))" ::
+      "((predicate2: Int => Boolean) => ((x: Int) => predicate2(x)))" ::
+      "(() => ((x: Int) => x.>(0)))" ::
+      "((predicate1: Int => Boolean) => ((x: Int) => predicate1(x)))" :: Nil
   }
+
+  def filtersIn(algorithm: String): List[String] =
+    tb.typecheck(tb.parse(imports + algorithm)) collect {
+      case q"$_.Filter.apply[$_](${Literal(Constant(f: String))}, ..$_)" => f
+    }
 }


### PR DESCRIPTION
- Reworked the implementation to use `traverse` from `ReflectUtil` instead of `Traverser`.
- Factored out code duplication in the test suite.
