### PR TITLE
[MACROS] [RUNTIME] Clean up unused executeUpdateWith* methods from Runtime.

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/runtime/package.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/runtime/package.scala
@@ -51,15 +51,6 @@ package object runtime {
     def executeStatefulCreate[A <: Identity[K]: TypeTag, K: TypeTag]
       (root: StatefulCreate[A, K], name: String, closure: Any*): AbstractStatefulBackend[A, K]
 
-    def executeUpdateWithZero[S: TypeTag, K: TypeTag, B: TypeTag]
-      (root: UpdateWithZero[S, K, B], name: String, closure: Any*): DataBag[B]
-
-    def executeUpdateWithOne[S <: Identity[K]: TypeTag, K: TypeTag, A: TypeTag, B: TypeTag]
-      (root: UpdateWithOne[S, K, A, B], name: String, closure: Any*): DataBag[B]
-
-    def executeUpdateWithMany[S <: Identity[K]: TypeTag, K: TypeTag, A: TypeTag, B: TypeTag]
-      (root: UpdateWithMany[S, K, A, B], name: String, closure: Any*): DataBag[B]
-
     final def closeSession() = if (!closed) {
       doCloseSession()
       closed = true
@@ -86,15 +77,6 @@ package object runtime {
 
     override def executeStatefulCreate[A <: Identity[K]: TypeTag, K: TypeTag]
       (root: StatefulCreate[A, K], name: String, closure: Any*): AbstractStatefulBackend[A, K] = ???
-
-    override def executeUpdateWithZero[S: TypeTag, K: TypeTag, B: TypeTag]
-      (root: UpdateWithZero[S, K, B], name: String, closure: Any*): DataBag[B] = ???
-
-    override def executeUpdateWithOne[S <: Identity[K]: TypeTag, K: TypeTag, A: TypeTag, B: TypeTag]
-      (root: UpdateWithOne[S, K, A, B], name: String, closure: Any*): DataBag[B] = ???
-
-    override def executeUpdateWithMany[S <: Identity[K]: TypeTag, K: TypeTag, A: TypeTag, B: TypeTag]
-      (root: UpdateWithMany[S, K, A, B], name: String, closure: Any*): DataBag[B] = ???
   }
 
   def default(): Engine = {

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/BeliefPropagationTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/BeliefPropagationTest.scala
@@ -32,7 +32,6 @@ class BeliefPropagationTest extends FlatSpec with Matchers with BeforeAndAfter {
   }
 
   "Belief Propagation" should "calculate unknown marginal probabilities" in withRuntime() { rt =>
-    val rtName = sys.props.getOrElse("emma.execution.backend", "").toLowerCase
     new BeliefPropagation(
       path, s"$path/marginals", epsilon, iterations, rt).run()
 

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/ConnectedComponentsTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/ConnectedComponentsTest.scala
@@ -13,7 +13,6 @@ class ConnectedComponentsTest extends FlatSpec with Matchers {
   import ConnectedComponents.Schema._
 
   "Connected components" should "find all connected sub-graphs" in withRuntime() { rt =>
-    val rtName = sys.props.getOrElse("emma.execution.backend", "").toLowerCase
     val actual = new ConnectedComponents("", "", rt).algorithm.run(rt)
     val expected =
       Component(1, 7) ::

--- a/emma-flink/src/main/scala/eu/stratosphere/emma/runtime/Flink.scala
+++ b/emma-flink/src/main/scala/eu/stratosphere/emma/runtime/Flink.scala
@@ -56,28 +56,4 @@ class Flink(val env: ExecutionEnvironment) extends Engine {
     resMgr.gc()
     res
   }
-
-  override def executeUpdateWithZero[S: TypeTag, K: TypeTag, B: TypeTag]
-      (root: UpdateWithZero[S, K, B], name: String, closure: Any*): DataBag[B] = {
-    val dataflowSymbol = dataflowGenerator.generateDataflowDef(root, name)
-    val expr = dataflowCompiler.execute[DataSet[B]](dataflowSymbol, Array[Any](env, resMgr) ++ closure ++ localInputs(root))
-    resMgr.gc()
-    DataBag(root.name, expr, expr.collect())
-  }
-
-  override def executeUpdateWithOne[S <: Identity[K]: TypeTag, K: TypeTag, A: TypeTag, B: TypeTag]
-      (root: UpdateWithOne[S, K, A, B], name: String, closure: Any*): DataBag[B] = {
-    val dataflowSymbol = dataflowGenerator.generateDataflowDef(root, name)
-    val expr = dataflowCompiler.execute[DataSet[B]](dataflowSymbol, Array[Any](env, resMgr) ++ closure ++ localInputs(root))
-    resMgr.gc()
-    DataBag(root.name, expr, expr.collect())
-  }
-
-  override def executeUpdateWithMany[S <: Identity[K]: TypeTag, K: TypeTag, A: TypeTag, B: TypeTag]
-      (root: UpdateWithMany[S, K, A, B], name: String, closure: Any*): DataBag[B] = {
-    val dataflowSymbol = dataflowGenerator.generateDataflowDef(root, name)
-    val expr = dataflowCompiler.execute[DataSet[B]](dataflowSymbol, Array[Any](env, resMgr) ++ closure ++ localInputs(root))
-    resMgr.gc()
-    DataBag(root.name, expr, expr.collect())
-  }
 }

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionCompiler.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/program/comprehension/ComprehensionCompiler.scala
@@ -54,9 +54,6 @@ private[emma] trait ComprehensionCompiler
         case _: combinator.Write          => TermName("executeWrite")
         case _: combinator.Fold           => TermName("executeFold")
         case _: combinator.StatefulCreate => TermName("executeStatefulCreate")
-        case _: combinator.UpdateWithZero => TermName("updateWithZero")
-        case _: combinator.UpdateWithOne  => TermName("updateWithOne")
-        case _: combinator.UpdateWithMany => TermName("updateWithMany")
         case _                            => TermName("executeTempSink")
       }
 

--- a/emma-spark/src/main/scala/eu/stratosphere/emma/runtime/Spark.scala
+++ b/emma-spark/src/main/scala/eu/stratosphere/emma/runtime/Spark.scala
@@ -55,21 +55,6 @@ class Spark(val sc: SparkContext) extends Engine {
     dataflowCompiler.execute[AbstractStatefulBackend[A, K]](dataflowSymbol, Array[Any](sc) ++ closure ++ localInputs(root))
   }
 
-  override def executeUpdateWithZero[S: TypeTag, K: TypeTag, B: TypeTag]
-    (root: UpdateWithZero[S, K, B], name: String, closure: Any*): DataBag[B] = {
-    ??? // Not supported yet
-  }
-
-  override def executeUpdateWithOne[S <: Identity[K]: TypeTag, K: TypeTag, A: TypeTag, B: TypeTag]
-    (root: UpdateWithOne[S, K, A, B], name: String, closure: Any*): DataBag[B] = {
-    ??? // Not supported yet
-  }
-
-  override def executeUpdateWithMany[S <: Identity[K]: TypeTag, K: TypeTag, A: TypeTag, B: TypeTag]
-    (root: UpdateWithMany[S, K, A, B], name: String, closure: Any*): DataBag[B] = {
-    ??? // Not supported yet
-  }
-
   override protected def doCloseSession() = {
     super.doCloseSession()
     sc.stop()


### PR DESCRIPTION
These were never get called because ComprehensionAnalysis.createComprehensionView
adds a TempSink to the root, when it sees updateWith*.

See: https://github.com/stratosphere/emma/issues/112#issuecomment-155414985
