### PR TITLE
[POM] Switched to vanilla Flink 0.10.0.

### DIFF
--- a/emma-examples/pom.xml
+++ b/emma-examples/pom.xml
@@ -141,16 +141,16 @@
             <dependencies>
                 <!-- Flink -->
                 <dependency>
-                    <groupId>eu.stratosphere</groupId>
-                    <artifactId>flink-scala</artifactId>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-scala_${scala.tools.version}</artifactId>
                 </dependency>
                 <dependency>
-                    <groupId>eu.stratosphere</groupId>
-                    <artifactId>flink-java</artifactId>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-java_${scala.tools.version}</artifactId>
                 </dependency>
                 <dependency>
-                    <groupId>eu.stratosphere</groupId>
-                    <artifactId>flink-clients</artifactId>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-clients_${scala.tools.version}</artifactId>
                 </dependency>
             </dependencies>
         </profile>
@@ -239,9 +239,7 @@
                                 <excludes>
                                     <exclude>org.apache.hadoop:*</exclude>
                                     <exclude>org.apache.spark:*</exclude>
-                                    <exclude>eu.stratosphere:flink-scala</exclude>
-                                    <exclude>eu.stratosphere:flink-java</exclude>
-                                    <exclude>eu.stratosphere:flink-clients</exclude>
+                                    <exclude>org.apache.flink:*</exclude>
                                     <exclude>org.scala-lang:*</exclude>
                                     <exclude>com.google.guava:*</exclude>
                                     <exclude>org.slf4j:slf4j-log4j12</exclude>

--- a/emma-flink/pom.xml
+++ b/emma-flink/pom.xml
@@ -65,16 +65,16 @@
 
         <!-- Flink -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
-            <artifactId>flink-scala</artifactId>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-scala_${scala.tools.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>eu.stratosphere</groupId>
-            <artifactId>flink-java</artifactId>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-java_${scala.tools.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>eu.stratosphere</groupId>
-            <artifactId>flink-clients</artifactId>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_${scala.tools.version}</artifactId>
         </dependency>
 
         <!-- Test -->

--- a/emma-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/emma-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -184,20 +184,20 @@
                 </dependency>
                 <!-- Flink -->
                 <dependency>
-                    <groupId>eu.stratosphere</groupId>
-                    <artifactId>flink-scala</artifactId>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-scala_${scala.tools.version}</artifactId>
                     <version>${flink.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>eu.stratosphere</groupId>
-                    <artifactId>flink-java</artifactId>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-java_${scala.tools.version}</artifactId>
                     <version>${flink.version}</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
-                    <groupId>eu.stratosphere</groupId>
-                    <artifactId>flink-clients</artifactId>
+                    <groupId>org.apache.flink</groupId>
+                    <artifactId>flink-clients_${scala.tools.version}</artifactId>
                     <version>${flink.version}</version>
                     <scope>provided</scope>
                 </dependency>
@@ -257,9 +257,7 @@
                                 <excludes>
                                     <exclude>org.apache.hadoop:*</exclude>
                                     <exclude>org.apache.spark:*</exclude>
-                                    <exclude>eu.stratosphere:flink-scala</exclude>
-                                    <exclude>eu.stratosphere:flink-java</exclude>
-                                    <exclude>eu.stratosphere:flink-clients</exclude>
+                                    <exclude>org.apache.flink:*</exclude>
                                     <exclude>org.scala-lang:*</exclude>
                                     <exclude>com.google.guava:*</exclude>
                                     <exclude>org.slf4j:slf4j-log4j12</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <!-- Hadoop -->
         <hadoop.version>2.2.0</hadoop.version>
         <!-- Flink -->
-        <flink.version>0.9-SNAPSHOT</flink.version>
+        <flink.version>0.10.0</flink.version>
         <!-- Spark -->
         <spark.version>1.5.1</spark.version>
 
@@ -168,20 +168,20 @@
 
             <!-- Flink -->
             <dependency>
-                <groupId>eu.stratosphere</groupId>
-                <artifactId>flink-scala</artifactId>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-scala_${scala.tools.version}</artifactId>
                 <version>${flink.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>eu.stratosphere</groupId>
-                <artifactId>flink-java</artifactId>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-java_${scala.tools.version}</artifactId>
                 <version>${flink.version}</version>
                 <scope>provided</scope>
             </dependency>
             <dependency>
-                <groupId>eu.stratosphere</groupId>
-                <artifactId>flink-clients</artifactId>
+                <groupId>org.apache.flink</groupId>
+                <artifactId>flink-clients_${scala.tools.version}</artifactId>
                 <version>${flink.version}</version>
                 <scope>provided</scope>
             </dependency>


### PR DESCRIPTION
I'm opening the PR already as the feature is ready. All tests are passing and I also managed to run some experiments against standalone vanilla Flink 0.10.0-rc6 last night).

However, I suggest to wait until the Flink folks manage to push a release out in order to spare other devs the need to build and deploy Flink 0.10 from source.
