### PR TITLE
[TESTS] Change TypeTag to ClassTag in SemanticChecksTest.failWith.

### DIFF
--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/TicTacToeTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/TicTacToeTest.scala
@@ -1,11 +1,13 @@
 package eu.stratosphere.emma.examples.graphs
 
-import eu.stratosphere.emma.testutil.withRuntime
+import eu.stratosphere.emma.testutil.{ExampleTest, withRuntime}
+import org.junit.experimental.categories.Category
 
 import org.junit.runner.RunWith
 import org.scalatest._
 import org.scalatest.junit.JUnitRunner
 
+@Category(Array(classOf[ExampleTest]))
 @RunWith(classOf[JUnitRunner])
 class TicTacToeTest extends FlatSpec with Matchers {
   import TicTacToe._

--- a/emma-language/src/test/scala/eu/stratosphere/emma/macros/SemanticChecksTest.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/macros/SemanticChecksTest.scala
@@ -7,6 +7,7 @@ import org.junit.runner.RunWith
 import org.scalatest._
 import org.scalatest.junit.JUnitRunner
 
+import scala.reflect.ClassTag
 import scala.tools.reflect.ToolBoxError
 
 @RunWith(classOf[JUnitRunner])
@@ -92,8 +93,8 @@ class SemanticChecksTest extends FlatSpec with Matchers with RuntimeUtil {
     }
   }
 
-  def failWith[E <: Throwable : TypeTag] =
-    include (typeOf[E].typeSymbol.name.toString) compose { (tree: Tree) =>
+  def failWith[E <: Throwable : ClassTag] =
+    include (implicitly[ClassTag[E]].runtimeClass.getSimpleName) compose { (tree: Tree) =>
       intercept[ToolBoxError] { tb.typecheck(q"{ ..$imports; $tree }") }.getMessage
     }
 }


### PR DESCRIPTION
This fixes an error that only arises for certain people, and only when the test is run from Maven. For details, see the Slack discussion on Nov. 26. started by @bderak.

(An other thing is that I realized that `@Category(Array(classOf[ExampleTest]))` was missing from TicTacToeTest. I have added this now.)
