### PR TITLE
[INFRA] Fixed a bug in the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,7 @@ cache:
     $HOME/.m2
 
 script:
+  # Enable exit code propagation through pipes
+  - set -o pipefail
   # Use pipe view (`pv`) to work around command line output timeout
   - mvn test ${TEST_ARGS[@]} | pv -t -b -l -i 10


### PR DESCRIPTION
Enabled failure propagation through pipes when running tests. Without this the build would always succeed even if the `mvn` command failed die to pipe viewer swallowing the exit code.
