### PR TITLE
[IR] Bypass mock comprehensions `anf` transform

### DIFF
--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/ir/CommonIR.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/ir/CommonIR.scala
@@ -54,6 +54,18 @@ trait CommonIR extends ReflectUtil {
     val GROUP /*           */ = typeOf[eu.stratosphere.emma.api.Group[Nothing, Nothing]].typeConstructor
   }
 
+  protected object IR {
+    val moduleSymbol /*    */ = rootMirror.staticModule("eu.stratosphere.emma.compiler.ir.package")
+
+    val flatten /*         */ = moduleSymbol.info.decl(TermName("flatten"))
+    val generator /*       */ = moduleSymbol.info.decl(TermName("generator"))
+    val comprehension /*   */ = moduleSymbol.info.decl(TermName("comprehension"))
+    val guard /*           */ = moduleSymbol.info.decl(TermName("guard"))
+    val head /*            */ = moduleSymbol.info.decl(TermName("head"))
+
+    val comprehensionOps /**/ = Set(flatten, generator, comprehension, guard, head)
+  }
+
   // ---------------------------------------------------------------------------
   // Helper Patterns
   // ---------------------------------------------------------------------------

--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/ir/lnf/Language.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/ir/lnf/Language.scala
@@ -256,9 +256,9 @@ trait Language extends CommonIR {
           val term = Term.of(sel)
           val tpe = Type.of(sel)
           val expr = Term.sel(target, term, tpe)
-          if (term.isPackage || {
-            term.isMethod && !term.isAccessor
-          }) {
+          if (IR.comprehensionOps contains term) {
+            expr
+          } else if (term.isPackage || (term.isMethod && !term.isAccessor)) {
             block(stats, expr)
           } else {
             val name = Term.fresh(member).toString
@@ -271,6 +271,9 @@ trait Language extends CommonIR {
         case TypeApply(Block(stats, target), types) =>
           block(stats,
             typeApp(target, types.map(Type.of): _*))
+
+        case app@Apply(Block(stats, target), args) if IR.comprehensionOps contains Term.of(target) =>
+          app
 
         case app@Apply(Block(stats, target), args) =>
           val name = Term.fresh(nameOf(target))

--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/ir/package.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/ir/package.scala
@@ -13,4 +13,6 @@ package object ir {
   def comprehension[A](block: A) = ???
 
   def guard(expr: Boolean) = ???
+
+  def head[A](expr: A): A = ???
 }


### PR DESCRIPTION
Sugared comprehensions are modeled in the Scala AST-based IR thorugh
a set of mock methods defined in `eu.stratosphere.emma.compiler.ir`.

The `anf` transformation should preserve this syntax.

@joroKr21 can you please review and merge this?
