### PR TITLE
[UTIL] Library-Inline-Snapshot

### DIFF
--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/compiler/Symbols.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/compiler/Symbols.scala
@@ -44,6 +44,10 @@ trait Symbols extends Util { this: Trees with Terms with Types =>
     /** Returns the modifiers associated with `sym`. */
     def mods(sym: Symbol): Modifiers =
       mods(flags(sym))
+
+    /** Returns a [[Symbol]]s annotation of type A, if any */
+    def annotation[A: TypeTag](sym: Symbol): Option[Annotation] =
+      sym.annotations.find { _.tree.tpe == universe.typeOf[A] }
   }
 
   /** Utility for symbol owners. */

--- a/emma-language/src/main/java/eu/stratosphere/emma/api/Inlined.java
+++ b/emma-language/src/main/java/eu/stratosphere/emma/api/Inlined.java
@@ -1,0 +1,19 @@
+package eu.stratosphere.emma.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Runtime annotation indicating that the annotated method
+ * has been prepared for inlining.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Inlined {
+    /**
+     * @return the name of the inlineable variant (in the same scope)
+     */
+    String forwardTo();
+}

--- a/emma-language/src/main/scala/eu/stratosphere/emma/api/emma.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/api/emma.scala
@@ -2,7 +2,8 @@ package eu.stratosphere.emma.api
 
 import eu.stratosphere.emma.macros.program.WorkflowMacros
 import eu.stratosphere.emma.macros.utility.UtilMacros
-
+import eu.stratosphere.emma.macros.utility.InlineMacros
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
 
 // TODO: Add more detailed documentation with examples.
@@ -26,4 +27,9 @@ object emma {
 
   final def visualize[T](e: T): T =
     macro UtilMacros.visualize[T]
+
+  @compileTimeOnly("enable macro paradise to expand macro annotations")
+  class inline extends StaticAnnotation {
+    def macroTransform(annottees: Any*): Any = macro InlineMacros.inlineImpl
+  }
 }

--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/RuntimeCompiler.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/RuntimeCompiler.scala
@@ -3,11 +3,11 @@ package compiler
 
 import java.net.URLClassLoader
 import java.nio.file.{Files, Paths}
-
+import eu.stratosphere.emma.compiler.ir.library.Inline
 import scala.tools.reflect.ToolBoxFactory
 
 /** A reflection-based [[eu.stratosphere.emma.compiler.Compiler]]. */
-class RuntimeCompiler extends Compiler with RuntimeUtil {
+class RuntimeCompiler extends Compiler with Inline with RuntimeUtil {
 
   import RuntimeCompiler._
   import universe._

--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/ir/library/Inline.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/ir/library/Inline.scala
@@ -1,0 +1,161 @@
+package eu.stratosphere.emma.compiler.ir.library
+
+import eu.stratosphere.emma.api.Inlined
+import eu.stratosphere.emma.compiler.RuntimeCompiler
+import scala.annotation.tailrec
+
+/** Library behavior for the [[RuntimeCompiler]] */
+trait Inline { this: RuntimeCompiler =>
+  import universe._
+  lazy val mirror: universe.Mirror = tb.mirror
+
+  private[emma] val INLINE_FIXED_POINT_LIMIT = 100
+
+  /** Very simple memoization for [[Function1]] i.e. [[(A => R]] functions.
+    *
+    * TODO brain: Currently implemented using [[collection.mutable.WeakHashMap]],
+    * which may not be ideal.
+    *
+    * @param f the function to be memoized
+    * @tparam A argument type (contravariant)
+    * @tparam R result type (covariant)
+    */
+  class Memo[-A, +R](f: A => R) extends (A => R) {
+    private[this] val memo = collection.mutable.WeakHashMap.empty[A, R]
+    def apply(a: A): R = memo.getOrElseUpdate(a, f(a))
+  }
+
+  /** Memo for [[mirror.reflectModule]] */
+  private val reflectModule = new Memo[ModuleSymbol, ModuleMirror](mirror.reflectModule)
+
+  /** Memo for [[mirror.reflect]] */
+  private val reflect = new Memo[Any, InstanceMirror](mirror.reflect)
+
+  /** Performs beta-reduction on a tree
+    *
+    * Example:
+    *
+    * {{{
+    *   val lo = 23
+    *   val hi = 66
+    *   val between = ((lo: Int, hi: Int) => (x: Int) => lo <= x && x < hi)(lo, hi)(42)
+    * }}}
+    *
+    * becomes
+    *
+    * {{{
+    *   val lo = 23
+    *   val hi = 66
+    *   val between = lo <= 42 && 42 < hi
+    * }}}
+    *
+    * @param t the tree
+    * @return the beta-reduced tree
+    */
+  def betaReduce(t: Tree): Tree = {
+    def bRed(body:Tree, params: List[ValDef], args: List[Tree]) = {
+      assert(params.size == args.size)
+      Tree.subst(body, (params.map(_.symbol) zip args).toMap)
+    }
+    postWalk(t) {
+      case Apply(Function(params, body), args) =>
+        bRed(body, params, args)
+      case Apply(Select(Function(params, body), TermName("apply")), args) =>
+        bRed(body, params, args)
+    }
+  }
+
+  /** Inlines all applications to methods tagged with the [[Inlined]] runtime annotation.
+    *
+    * Example:
+    *
+    * Assuming there is a inlined method
+    *
+    * {{{
+    *   @emma.inline object MyLibrary {
+    *     def geq(lower: Double)(x: Double) = lower <= x
+    *   }
+    * }}}
+    *
+    * then an inlined application
+    *
+    * {{{
+    *   val isGeq = MyLibrary.geq(23.0)(42.0)
+    * }}}
+    *
+    * will result in:
+    *
+    * {{{
+    *   val isGeq: Boolean = ((lower: Double) => ((x: Double) => lower.<=(x)))(23.0)(42.0);
+    * }}}
+    *
+    * @param t the original tree
+    * @return the resulting tree with one iteration of inlined methods.
+    */
+  private[emma] def transformApplications(t: Tree): Tree = postWalk(t) {
+    case functionSelection @ Select(moduleSelection @ Select(qualifier, name), func)
+      if qualifier.symbol.isModule && !qualifier.symbol.hasPackageFlag =>
+      val qualifierMirror = reflectModule(qualifier.symbol.asModule)
+      val modSymbol = qualifierMirror.symbol.info.member(name).asModule
+      val modMirror = reflectModule(modSymbol)
+      val modInstanceMirror = reflect(modMirror.instance)
+      val modFunc = functionSelection.symbol.asMethod
+      val maybeReplacement = for {
+        ann <- Symbol.annotation[Inlined](modFunc)
+        Literal(Constant(target)) <- findArg(ann, TermName("forwardTo"))
+      } yield {
+        val targetTermName = TermName(target.asInstanceOf[String])
+        val targetMethodSymbol = modSymbol.info.decl(targetTermName).asMethod
+        val targetMethodMirror = modInstanceMirror.reflectMethod(targetMethodSymbol)
+        targetMethodMirror(universe) match {
+          case e: Expr[_] => preWalk(Type.check(e.tree)) {
+            case a@Apply(sel@Select(This(qualifierThis), funName), args) =>
+              transformApplications(Method.call(functionSelection.qualifier, sel.symbol.asMethod)(List(args: _*)))
+          }
+          case x =>
+            abort(functionSelection.pos, s"Unable to inline $functionSelection")
+            functionSelection
+        }
+      }
+      maybeReplacement.getOrElse(functionSelection)
+  }
+
+  /** Inlines all applications to methods tagged with the [[Inlined]] runtime annotation
+    * until a fixed point is reached.
+    *
+    * @param tree
+    * @return
+    */
+  def transformInline(tree: Tree): Tree = {
+    @tailrec def _transformInline(tree: Tree, acc: Int = 0):Tree = transformApplications(tree) match {
+      case newTree if tree equalsStructure newTree => newTree
+      case newTree: Tree if acc >= INLINE_FIXED_POINT_LIMIT =>
+        abort(tree.pos, s"Inlining did not reach a fixed point after $acc iterations for $tree")
+        tree
+      case newTree: Tree => _transformInline(newTree, acc + 1)
+    }
+    _transformInline(tree)
+  }
+
+
+  /** Runtime annotation helper, extracts a list of [[AssignOrNamedArg]]s from
+    * a given [[Tree]].
+    *
+    * @return a list of annotation arguments as [[AssignOrNamedArg]]
+    */
+  private[emma] def extractArgs: Tree => List[AssignOrNamedArg] = {
+    case Apply(Select(New(TypeTree()), termNames.CONSTRUCTOR), lst: List[_]) =>
+      lst.asInstanceOf[List[AssignOrNamedArg]]
+    case _ => List.empty
+  }
+
+  /** Returns the right-hand-side of an annotation argument if it exists.
+    *
+    * @param a the annotation
+    * @param tn the [[TermName]]
+    * @return [[Some]] [[Tree]] if the [[TermName]] was found, [[None]] else
+    */
+  private[emma] def findArg(a: Annotation, tn: TermName): Option[Tree] = extractArgs(a.tree).collectFirst {
+    case AssignOrNamedArg(Ident(`tn`), rhs) => rhs
+  }
+}

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/utility/InlineMacros.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/utility/InlineMacros.scala
@@ -1,0 +1,69 @@
+package eu.stratosphere.emma.macros.utility
+
+import eu.stratosphere.emma.api.Inlined
+import eu.stratosphere.emma.compiler.MacroUtil
+import scala.language.experimental.macros
+import scala.reflect.macros.whitebox
+
+/**
+  * The @emma.inline annotation macro
+  *
+  * @param c a whitebox context
+  */
+class InlineMacros(val c: whitebox.Context) extends MacroUtil {
+  import universe._
+  private val inlineBlacklist = Set("<init>") // do not inline these functions
+
+  /** The implementation of the @emma.inline macro.
+    *
+    * 1. If the annottee is an object, all methods on that object will be extended
+    * 2. If the annottee is a method, only the single method will be extended
+    *
+    * @param annottees a list with (currently) exactly one element (only objects and methods can be currently annotated)
+    * @return the resulting tree with the replacement
+    */
+  def inlineImpl(annottees: Expr[Any]*):Expr[Any] = {
+    def mkInlinedFunName(name: String) = Term.name.fresh(s"${name}__expr").toString
+    def extendFunction: Tree =?> List[Tree] = {
+      case df @ q"""def ${tn @ TermName(defName)}[..$types](...${args: List[List[ValDef]]}):$rt = $body"""
+        if !inlineBlacklist.contains(defName) && // TODO find solution, does not work /w symbols
+          Symbol.annotation[Inlined](df.symbol).isEmpty =>
+        val argsAndBody = args.foldRight(body)(Function(_, _))
+        val newName = mkInlinedFunName(defName)
+        val annot = q"""new Inlined(forwardTo=$newName)"""
+        val oldFun = q"@$annot def $tn[..$types](...$args): $rt = $body"
+        val uniType = tq"scala.reflect.api.Universe"
+        val newFun = q"def ${TermName(newName)}[..$types](u: $uniType) = u.reify({$argsAndBody})"
+        oldFun :: newFun :: Nil
+    }
+    def extendAllFunctions: Tree =?> Tree = {
+      case md @ ModuleDef(modifiers, tn, Template(parents, self, body)) =>
+        val newBody = body.flatMap(extendFunction orElse { case x => x :: Nil } )
+        ModuleDef(modifiers, tn, Template(parents, self, newBody))
+    }
+    val preamble = q"import eu.stratosphere.emma.api.Inlined"
+
+    val expandFunction: Tree =?> Tree = extendFunction andThen { t =>
+      q"""
+         ..$preamble
+         ..$t
+        """
+    }
+    val extendModule: Tree =?> Tree = extendAllFunctions andThen { t =>
+      q"""
+         ..$preamble
+         $t
+       """
+    }
+    val warn: Tree =?> Tree = { case x: Tree =>
+      c.warning(c.enclosingPosition,
+        "@emma.inline can only be applied to methods or modules, skipping this")
+      x
+    }
+    val annottee :: _ = annottees
+    c.Expr((
+      expandFunction orElse
+      extendModule orElse
+      warn) (annottee.tree))
+  }
+}

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/ir/library/LibrarySpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/ir/library/LibrarySpec.scala
@@ -1,0 +1,200 @@
+package eu.stratosphere.emma.compiler.ir.library
+
+import eu.stratosphere.emma.api.{CSVOutputFormat, TextInputFormat, _}
+import eu.stratosphere.emma.compiler.BaseCompilerSpec
+import eu.stratosphere.emma.compiler.ir.library.LibrarySpec.PartialUtils
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class LibrarySpec extends BaseCompilerSpec {
+  import compiler._
+  import universe._
+
+  def withTypeCheckAndOwnerRepair[T]: (Tree => Tree) => Expr[T] => Tree = { f =>
+    { (_: Expr[T]).tree } andThen
+    { Type.check(_) } andThen
+    { f } andThen
+    { Owner.at(Owner.enclosing) }
+  }
+
+  def typeCheckAndBetaReduce[T]: Expr[T] => Tree = withTypeCheckAndOwnerRepair {
+    { Core.resolveNameClashes(_) } andThen
+    { time(betaReduce(_), "ß-reducing") }
+  }
+
+  def typeCheckOnly = withTypeCheckAndOwnerRepair { identity }
+
+  def typeCheckAndInlineOnce = withTypeCheckAndOwnerRepair { transformApplications }
+
+  def typeCheckInlineBetaReduce = withTypeCheckAndOwnerRepair {
+    { time(transformInline(_), "inlining") } andThen
+    { betaReduce }
+  }
+
+  "The @emma.inline annotation" - {
+    val singletonMembers = List("plus")
+    val inlineSingletonMembers = singletonMembers.map { _ + "__expr$1"}
+    val overloadedMembers = List("geq", "lt", "between")
+    val inlinedOverloadedMembers = for {
+      ol <- overloadedMembers
+      no <- 1 to 2
+    } yield s"${ol}__expr$$${no}"
+
+    val expectedInlineMembers = inlineSingletonMembers ::: inlinedOverloadedMembers
+    "should extend all methods if annottee is a module" in {
+      for (genMember <- expectedInlineMembers; tn = TermName(genMember))
+        typeOf[LibrarySpec.Util.type].member(tn).isMethod shouldBe true
+    }
+    "should extend only one method if annottee is a method " in {
+      val partialInlineModuleType = typeOf[PartialUtils.type]
+      val expectedMember = TermName("hello__expr$1")
+      partialInlineModuleType.member(expectedMember).isMethod shouldBe true
+      val nonExpectedMember = TermName("someMethod__expr$1") // should not exist
+      partialInlineModuleType.member(nonExpectedMember).isMethod shouldBe false
+    }
+  }
+  "Library Compiler" - {
+    "can perform ß-reduction" in {
+      val act = typeCheckAndBetaReduce(reify {
+        val lo = 23
+        val hi = 66
+        val between = ((lo: Int, hi: Int) => (x: Int) => lo <= x && x < hi)(lo, hi)(42)
+      })
+      val exp = typeCheckOnly(reify {
+        val lo = 23
+        val hi = 66
+        val between = lo <= 42 && 42 < hi
+      })
+      act shouldBe alphaEqTo(exp)
+    }
+    "can reflect and execute a reified method" in {
+      val mir = tb.mirror
+      val utilSymbol = mir.staticModule("eu.stratosphere.emma.compiler.ir.library.LibrarySpec.Util")
+      val moduleMirror = mir.reflectModule(utilSymbol)
+      val moduleInstanceMirror = mir.reflect(moduleMirror.instance)
+      val methodSymbol = utilSymbol.info.decl(TermName("lt__expr$1")).asMethod
+      val methodMirror = moduleInstanceMirror.reflectMethod(methodSymbol)
+      methodMirror(universe) match {
+        case e: Expr[_] => Type.check(e.tree)
+        case x => fail(s"Not an expression: $x")
+      }
+    }
+    "should splice in until a fixpoint is reached" in {
+      val act = typeCheckInlineBetaReduce(reify {
+        val lo = 23
+        val hi = 66
+        val x = 42
+        val isBetween = LibrarySpec.Util.between(lo, hi)(x)
+        val loD = 23.0
+        val hiD = 66.0
+        val xD = 42.0
+        val isBetweenD = LibrarySpec.Util.between(loD, hiD)(xD)
+      })
+      val exp = typeCheckOnly(reify {
+        val lo = 23
+        val hi = 66
+        val x = 42
+        val isBetween = lo <= x && x < hi
+        val loD = 23.0
+        val hiD = 66.0
+        val xD = 42.0
+        val isBetweenD = loD <= xD && xD < hiD
+      })
+      act shouldBe alphaEqTo(exp)
+    }
+    "should work in a comprehensions" in {
+      val act = typeCheckInlineBetaReduce(reify {
+        val xs = for {
+          x <- DataBag(1 to 1000) if LibrarySpec.Util.between(500, 600)(x)
+        } yield x
+      })
+      val exp = typeCheckOnly(reify{
+        val xs = DataBag(1 to 1000)
+          .withFilter(x => 500 <= x && x < 600)
+          .map(x => x)
+      })
+      act shouldBe alphaEqTo(exp)
+    }
+    "should splice using the method-only annotations" in {
+      val act = typeCheckInlineBetaReduce(reify {
+        val hw = PartialUtils.hello("world")
+      })
+      val exp = typeCheckOnly(reify {
+        val hw = StringContext("", " ", "").s("Hello", "world")
+      })
+      act shouldBe alphaEqTo(exp)
+    }
+    "should work on the classic WordCount example" in {
+      import LibrarySpec.PartialUtils._
+      val inPath = "/some/Path/"
+      val outPath = "some/otherPath"
+      val act = typeCheckInlineBetaReduce(reify {
+        // read the input files and split them into lowercased words
+        val words = loadWords(inPath)
+        // group the words by their identity and count the occurrence of each word
+        val counts = for {
+          group <- words.groupBy[String] { identity }
+        } yield (group.key, group.values.size)
+
+        // write the results into a CSV file
+        write(outPath,new CSVOutputFormat[(String, Long)])(counts)
+      })
+      val exp = typeCheckOnly(reify {
+        // read the input files and split them into lowercased words
+        val words = for {
+          line <- read(inPath, new TextInputFormat[String]('\n'))
+          word <- DataBag[String](line.toLowerCase.split("\\W+"))
+        } yield word
+
+        // group the words by their identity and count the occurrence of each word
+        val counts = for {
+          group <- words.groupBy[String] { identity }
+        } yield (group.key, group.values.size)
+
+        // write the results into a CSV file
+        write(outPath,new CSVOutputFormat[(String, Long)])(counts)
+      })
+      act shouldBe alphaEqTo(exp)
+    }
+  }
+}
+
+object LibrarySpec {
+  @emma.inline object Util {
+    def geq(lower: Int)(i: Int) = lower <= i
+
+    def lt(upper: Int)(i: Int) = i < upper
+
+    //  @RuntimeAnnotationForwardToThis(func=plus__expr) // or string // showCode // rekursiv einsplicen
+    def between(lower: Int, upper: Int)(x: Int): Boolean =
+      geq(lower)(x) && lt(upper)(x)
+
+    def geq(lower: Double)(x: Double) = lower <= x
+
+    def lt(upper: Double)(x: Double) = x < upper
+
+    def between(lower: Double, upper: Double)(x: Double): Boolean =
+      geq(lower)(x) && lt(upper)(x)
+
+    def plus[T: Numeric](i: T, j: T) = {
+      // (implicit n:Numeric[T])
+      val n = implicitly[Numeric[T]]
+      n.plus(i, j)
+    }
+  }
+
+  object PartialUtils {
+    def someMethod: String = "Hello World"
+    @emma.inline def salute(): String = "Hello"
+    @emma.inline def hello(s: String): String = s"${salute()} $s"
+    @emma.inline def loadWords(inPath: String): DataBag[String] = {
+      for {
+        line <- read(inPath, new TextInputFormat[String]('\n'))
+        word <- DataBag[String](splitByWords(line))
+      } yield word
+    }
+    @emma.inline def wordSeparator(): String = "\\W+"
+    @emma.inline def splitByWords(line: String) = line.toLowerCase.split(wordSeparator())
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,15 @@
     </repositories>
     -->
 
+    <repositories>
+        <repository>
+            <id>oss.sonatype.org</id>
+            <name>sonatype sapshots</name>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        </repository>
+    </repositories>
+
+
     <dependencyManagement>
         <dependencies>
             <!-- Scala -->
@@ -315,6 +324,13 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <compilerPlugins>
+                        <compilerPlugin>
+                            <groupId>org.scalamacros</groupId>
+                            <artifactId>paradise_${scala.version}</artifactId>
+                            <version>2.1.0</version>
+                        </compilerPlugin>
+                    </compilerPlugins>
                     <recompileMode>incremental</recompileMode>
                     <useZincServer>true</useZincServer>
                     <jvmArgs>


### PR DESCRIPTION
# Library Functions (`@emma.inline` Annotation)

Work in progress, some things work, some things don't. Comments and hints are very much appreciated!

- [x] Inlining of public methods on annotated objects (`@emma.inline object Util { /*[...] */ }`)
- [x] Inlining of annotated methods (`object SomeUtil { @emma.inline def myFunc /* [...] */ }`)
- [x] Overloading 
- [ ] Type parameters
- [ ] Non public modifiers

## Limitations 

- Cannot `@emma.inline` a top-level object (a limitation of macro annotations)

## Next steps

- More efficient inlining at runtime --> Non hack-y repair of `Select(This(_), name)` artifacts
- Type parameters

## Dependencies

- Macro Paradise (due to Macro Annotations)

## Alternatives

- Perform the bulk of inlining at annotation / static time. Was not possible due to `Tree`-shenanigans involving multiple universes and weird compiler infinite loops while creating a Type.checked version to resolve overloading (working on that as well). 