### PR TITLE
[IR] Re-using `scala.reflect.runtime.universe` in `RuntimeUtil` inste…

### DIFF
--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/compiler/RuntimeUtil.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/compiler/RuntimeUtil.scala
@@ -15,7 +15,7 @@ import scala.tools.reflect.ToolBox
  */
 trait RuntimeUtil extends ReflectUtil {
 
-  val universe: JavaUniverse = new JavaUniverse
+  val universe: JavaUniverse = scala.reflect.runtime.universe.asInstanceOf[JavaUniverse]
   val tb: ToolBox[universe.type]
   import universe._
 


### PR DESCRIPTION
Using trees from different instances of `JavaUniverse` creates some problems regarding traversal and type checking of trees (specifically matching the `EmptyTree` from two different instances of `JavaUniverse`). 

`JavaUniverse` docs: `Should not be instantiated directly, use [[scala.reflect.runtime.universe]] instead`. 
