### PR TITLE
[LINALG] Added Matrix constructors : fillColumns and fillRows

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/Matrix.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/Matrix.scala
@@ -129,6 +129,7 @@ object Matrix {
     val array = new Array[A](rows * cols)
     for (i <-0 until rows) {
       val row = rowGen(i)
+      require(row.length == cols)
       for (j <- 0 until cols) {
         array((i * cols) + j) = row.get(j)
       }
@@ -141,6 +142,7 @@ object Matrix {
     val array = new Array[A](rows * cols)
     for (j <- 0 until cols) {
       val col = columnGen(j)
+      require(col.length == rows)
       for (i <- 0 until rows) {
         array((i * cols) + j) = col.get(i)
       }

--- a/emma-common/src/test/scala/eu/stratosphere/emma/api/lara/MatrixFactoriesTest.scala
+++ b/emma-common/src/test/scala/eu/stratosphere/emma/api/lara/MatrixFactoriesTest.scala
@@ -59,11 +59,25 @@ class MatrixFactoriesTest extends BaseTest {
       matrixFillRows.numCols shouldBe 3
     }
     "fields" in {
-      for (i <- 0 until 5 ; j <- 0 until 3) {
-        matrix.get(i, j) shouldBe matrixValues(i*3 + j)
-        matrixFill.get(i, j) shouldBe matrixValues(i*3 + j)
-        matrixFillCols.get(i, j) shouldBe matrixValues(i*3 + j)
-        matrixFillRows.get(i, j) shouldBe matrixValues(i*3 + j)
+      for (i <- 0 until 5; j <- 0 until 3) {
+        matrix.get(i, j) shouldBe matrixValues(i * 3 + j)
+        matrixFill.get(i, j) shouldBe matrixValues(i * 3 + j)
+        matrixFillCols.get(i, j) shouldBe matrixValues(i * 3 + j)
+        matrixFillRows.get(i, j) shouldBe matrixValues(i * 3 + j)
+      }
+    }
+    "correct vector length in gen function" in {
+      a[IllegalArgumentException] should be thrownBy {
+        Matrix.fillColumns(5,3)(i => Vector.zeros[Int](6))
+      }
+      a[IllegalArgumentException] should be thrownBy {
+        Matrix.fillRows(5,3)(i => Vector.zeros[Int](6))
+      }
+      a[IllegalArgumentException] should be thrownBy {
+        Matrix.fillColumns(5,3)(i => Vector.zeros[Int](2))
+      }
+      a[IllegalArgumentException] should be thrownBy {
+        Matrix.fillRows(5,3)(i => Vector.zeros[Int](2))
       }
     }
   }


### PR DESCRIPTION
Added 2 Matrix constructors _fillColumns_ and _fillRows_ to Matrix.scala.
The _fill_ constructor appeared to be insufficient in some situations. For example, when we want to create a matrix by copying some random rows from an other matrix, we want to choose one random number per row (not more !). This was quite tricky to do with only the _fill_ constructor.
