### PR TITLE
[LINALG] adds KMeansMatrix + Idx + Indexed matrix/vector transformations + tests

### DIFF
--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/DenseMatrix.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/DenseMatrix.scala
@@ -1,5 +1,6 @@
 package eu.stratosphere.emma.api.lara
 
+import eu.stratosphere.emma.api.linalg.ir.{VIdx, Idx}
 import spire.implicits._
 import spire.math._
 
@@ -158,6 +159,29 @@ private[emma] class DenseMatrix[A: Numeric : ClassTag](override val numRows: Int
     val arr = Array.ofDim[B](numRows * numCols)
     for (i <- rRange) {
       val newVec = f(row(i))
+      require(newVec.length == numCols)
+      for (j <- newVec.Range) {
+        arr(index(i, j)) = newVec.get(j)
+      }
+    }
+    Matrix[B](numRows, numCols, arr)
+  }
+
+  override
+  def indexedRows[B: Numeric : ClassTag](f: Idx[Int, Vector[A]] => B): Vector[B] = {
+    val arr = Array.ofDim[B](numRows)
+    for (i <- rRange) {
+      arr(i) = f(VIdx(i, row(i)))
+    }
+    Vector[B](arr, isRowVector = true)
+  }
+
+  override
+  def indexedRows[B: Numeric : ClassTag](f: Idx[Int, Vector[A]] => Vector[B]): Matrix[B] = {
+    val arr = Array.ofDim[B](numRows * numCols)
+    for (i <- rRange) {
+      val newVec = f(VIdx(i,row(i)))
+      require(newVec.length == numCols)
       for (j <- newVec.Range) {
         arr(index(i, j)) = newVec.get(j)
       }
@@ -179,6 +203,29 @@ private[emma] class DenseMatrix[A: Numeric : ClassTag](override val numRows: Int
     val arr = Array.ofDim[B](numRows * numCols)
     for (j <- cRange) {
       val newVec = f(column(j))
+      require(newVec.length == numRows)
+      for (i <- newVec.Range) {
+        arr(index(i, j)) = newVec.get(i)
+      }
+    }
+    Matrix[B](numRows, numCols, arr)
+  }
+
+  override
+  def indexedCols[B: Numeric : ClassTag](f: Idx[Int, Vector[A]] => B): Vector[B] = {
+    val arr = Array.ofDim[B](numCols)
+    for (i <- cRange) {
+      arr(i) = f(VIdx(i, column(i)))
+    }
+    Vector[B](arr, isRowVector = false)
+  }
+
+  override
+  def indexedCols[B: Numeric : ClassTag](f: Idx[Int, Vector[A]] => Vector[B]): Matrix[B] = {
+    val arr = Array.ofDim[B](numRows * numCols)
+    for (j <- cRange) {
+      val newVec = f(VIdx(j,column(j)))
+      require(newVec.length == numRows)
       for (i <- newVec.Range) {
         arr(index(i, j)) = newVec.get(i)
       }

--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/DenseVector.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/DenseVector.scala
@@ -1,5 +1,6 @@
 package eu.stratosphere.emma.api.lara
 
+import eu.stratosphere.emma.api.linalg.ir.{VIdx, Idx}
 import spire.implicits._
 import spire.math._
 
@@ -92,6 +93,11 @@ private[emma] class DenseVector[A: Numeric : ClassTag](override val length: Int,
   override
   def fold[B](z: B)(s: A => B, p: (B, B) => B): B = {
     values.foldLeft(z)((acc, x) => p(s(x), acc))
+  }
+
+  override
+  def indexedFold[B](z: B)(s: Idx[Int, A] => B, p: (B, B) => B): B = {
+    values.zipWithIndex.foldLeft(z)((acc, x) => p(acc,s(VIdx(x._2,x._1))))
   }
 
   override

--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/Idx.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/Idx.scala
@@ -1,0 +1,70 @@
+package eu.stratosphere.emma.api.linalg.ir
+
+import spire.math._
+
+import scala.reflect.ClassTag
+
+/**
+  * Representation for values with an index.
+  *
+  * @tparam I the index type
+  * @tparam V the value type
+  */
+// TODO: Solve problem with ordering
+//trait Idx[I <: Idx[I, _], V] extends Ordered[I] {
+trait Idx[I, V] {
+  def id: I
+
+  def value: V
+
+  def map[B](f: (V) => B): Idx[I, B]
+
+  override
+  def toString: String = s"($id, $value)"
+}
+
+object VIdx {
+
+  private[ir] class IntIdx[V](i: Int, v: V) extends Idx[Int, V] {
+    override def id = i
+
+    override def value = v
+
+    //    override def compare(that: Int): Int = this.id - that
+
+    override def map[B](f: (V) => B): Idx[Int, B] = VIdx(id, f(value))
+  }
+
+  def apply[V](idx: Int, v: V) = new IntIdx[V](idx, v)
+
+  def apply[V : Numeric : ClassTag](idx: V => Int, v: V) = new IntIdx[V](idx(v), v)
+
+  def project[V, N](idx: V => Int, vle: V => N, v: V) = new IntIdx[N](idx(v), vle(v))
+}
+
+object MIdx {
+
+  class IntxIntIdx[V](i: (Int, Int), v: V) extends Idx[(Int, Int), V] {
+    override def id = i
+
+    override def value = v
+
+    /** Defines a row major ordering */
+    //    override def compare(that: (Int, Int)): Int = {
+    //      val res = this.id._1 - that._1
+    //      if (res == 0) {
+    //        this.id._2 - that._2
+    //      } else {
+    //        res
+    //      }
+    //    }
+
+    override def map[B](f: (V) => B): Idx[(Int, Int), B] = MIdx(id, f(value))
+  }
+
+  def apply[V](idx: (Int, Int), v: V) = new IntxIntIdx[V](idx, v)
+
+  def apply[V](idx: V => (Int, Int), v: V) = new IntxIntIdx[V](idx(v), v)
+
+  def project[V, N](idx: V => (Int, Int), vle: V => N, v: V) = new IntxIntIdx[N](idx(v), vle(v))
+}

--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/Matrix.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/Matrix.scala
@@ -1,5 +1,6 @@
 package eu.stratosphere.emma.api.lara
 
+import eu.stratosphere.emma.api.linalg.ir.Idx
 import spire.math.Numeric
 
 import scala.reflect.ClassTag
@@ -77,9 +78,17 @@ trait Matrix[A] {
 
   def rows[B: Numeric : ClassTag](f: Vector[A] => Vector[B]): Matrix[B]
 
+  def indexedRows[B: Numeric : ClassTag](f: Idx[Int, Vector[A]] => B): Vector[B]
+
+  def indexedRows[B: Numeric : ClassTag](f: Idx[Int, Vector[A]] => Vector[B]): Matrix[B]
+
   def cols[B: Numeric : ClassTag](f: Vector[A] => B): Vector[B]
 
   def cols[B: Numeric : ClassTag](f: Vector[A] => Vector[B]): Matrix[B]
+
+  def indexedCols[B: Numeric : ClassTag](f: Idx[Int, Vector[A]] => B): Vector[B]
+
+  def indexedCols[B: Numeric : ClassTag](f: Idx[Int, Vector[A]] => Vector[B]): Matrix[B]
 
   // No order guarantees
   def elements[B](z: B)(s: A => B, p: (B, B) => B): B

--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/Vector.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/lara/Vector.scala
@@ -1,5 +1,6 @@
 package eu.stratosphere.emma.api.lara
 
+import eu.stratosphere.emma.api.linalg.ir.Idx
 import spire.math.Numeric
 
 import scala.collection.immutable.NumericRange
@@ -80,6 +81,8 @@ trait Vector[A] {
   def aggregate(f: (A, A) => A): A
 
   def fold[B](z: B)(s: A => B, p: (B, B) => B): B
+
+  def indexedFold[B](z: B)(s: Idx[Int, A] => B, p: (B, B) => B): B
 
   def map[B: Numeric : ClassTag](f: (A) => B): Vector[B]
 

--- a/emma-common/src/test/scala/eu/stratosphere/emma/api/lara/MatrixTest.scala
+++ b/emma-common/src/test/scala/eu/stratosphere/emma/api/lara/MatrixTest.scala
@@ -253,6 +253,25 @@ class MatrixTest extends BaseTest {
       res.numCols shouldBe 5
       res.toArray shouldBe values.map(_ * 3)
     }
+    "indexed rows to scalar" in {
+      val res: Vector[Int] = matrix.indexedRows(idx => idx.value.get(2) + idx.id)
+      val expected : Array[Int] = Array(3,9,15)
+
+      res.rowVector shouldBe true
+      res.length shouldBe 3
+      res.toArray shouldBe expected
+    }
+    "indexed rows to vector" in {
+      val res: Matrix[Int] = matrix.indexedRows(idx => idx.id + idx.value)
+      val expected : Array[Int] = Array(
+        1, 2, 3, 4, 5,
+        7, 8, 9, 10, 11,
+        13, 14, 15, 16, 17
+      )
+      res.numRows shouldBe 3
+      res.numCols shouldBe 5
+      res.toArray shouldBe expected
+    }
     "cols to scalar" in {
       val res: Vector[Int] = matrix.cols(v => v.aggregate(_ + _))
 
@@ -269,6 +288,25 @@ class MatrixTest extends BaseTest {
       res.numRows shouldBe 3
       res.numCols shouldBe 5
       res.toArray shouldBe values.map(_ * 3)
+    }
+    "indexed cols to scalar" in {
+      val res: Vector[Int] = matrix.indexedCols(idx => idx.value.get(2) + idx.id)
+      val expected : Array[Int] = Array(11,13,15,17,19)
+
+      res.rowVector shouldBe false
+      res.length shouldBe 5
+      res.toArray shouldBe expected
+    }
+    "indexed cols to vector" in {
+      val res: Matrix[Int] = matrix.indexedCols(idx => idx.id + idx.value)
+      val expected : Array[Int] = Array(
+        1, 3, 5, 7, 9,
+        6, 8, 10, 12, 14,
+        11, 13, 15, 17, 19
+      )
+      res.numCols shouldBe 5
+      res.numRows shouldBe 3
+      res.toArray shouldBe expected
     }
     "elements" in {
       val res = matrix.elements(0)(e => e, (a, b) => a + b)

--- a/emma-common/src/test/scala/eu/stratosphere/emma/api/lara/VectorTest.scala
+++ b/emma-common/src/test/scala/eu/stratosphere/emma/api/lara/VectorTest.scala
@@ -94,6 +94,35 @@ class VectorTest extends BaseTest {
         values.foldLeft[Double](0.0)((d, i) => d * i * 3.0)
       }
     }
+    "fold with index" in {
+      val v = Vector(Array(5,2,3,1,6,1))
+      val (firstMinIdx,firstMin) = v.indexedFold[(Int,Double)]((-1,Int.MaxValue))(
+        s => (s.id,s.value),
+        (l,r) =>
+          if (l._2 < r._2) {l}
+          else if (r._2 < l._2) {r}
+          else if (l._1 < r._1) {l}
+          else {r}
+      )
+      val (lastMinIdx,lastMin) = v.indexedFold[(Int,Double)]((-1,Int.MaxValue))(
+        s => (s.id,s.value),
+        (l,r) =>
+          if (l._2 < r._2) {l}
+          else if (r._2 < l._2) {r}
+          else if (l._1 < r._1) {r}
+          else {l}
+      )
+      val (maxIdx, max) = v.indexedFold[(Int,Double)]((-1,Int.MinValue))(
+        s => (s.id, s.value),
+        (l,r) => if (l._2 > r._2) l else r
+      )
+      firstMinIdx shouldBe 3
+      firstMin shouldBe 1
+      lastMinIdx shouldBe 5
+      lastMin shouldBe 1
+      maxIdx shouldBe 4
+      max shouldBe 6
+    }
     "transpose" in {
       vector.rowVector should be(false)
       val transposed = vector.transpose()

--- a/emma-examples/src/main/scala/eu/stratosphere/emma/examples/lara/KMeansMatrix.scala
+++ b/emma-examples/src/main/scala/eu/stratosphere/emma/examples/lara/KMeansMatrix.scala
@@ -1,0 +1,81 @@
+package eu.stratosphere.emma.examples.lara
+
+import eu.stratosphere.emma.api.lara.{Matrix, Vector}
+
+import scala.util.Random
+
+/**
+  * KMeans example implemented with the matrix abstraction of Emma
+  */
+
+object KMeansMatrix {
+
+  /**
+    * @param x matrix representing the points. Each row corresponds to a point
+    * @param k number of clusters
+    * @param maxIterations maximum steps before the algorithm stops if it has not converged
+    * @param epsilon convergence criterion
+    * @return centroids matrix with k rows where each row corresponds to a trained centroid
+    */
+  def kMeans(x: Matrix[Double], k: Int, maxIterations: Int, epsilon: Double): Matrix[Double] = {
+
+    val m = x.numRows
+    val n = x.numCols
+    var change = 0.0
+    var currentIteration = 0
+
+    //initialisation of the centroids with k random points
+    var centroids : Matrix[Double] = Matrix.fillColumns(n,k)(j => x.row(Random.nextInt(m)))
+    var newCentroids : Matrix[Double] = centroids
+
+    do {
+      //computation of the matrix of the square distances
+      val distances : Matrix[Double] = Matrix.fill(m,k)((i,j) =>
+        (x.row(i) - newCentroids.column(j)).fold(0.0)(s => s * s, (l,r) => l + r)
+      )
+
+      //get the id of the nearest centroid for each point
+      val minIdx = Vector.fill(m)( i =>
+        distances.row(i).indexedFold((-1,Double.MaxValue))(
+          s => (s.id,s.value),
+          (l,r) => if (l._2 < r._2) l else r)._1
+      )
+
+      //computation of the matrix indicating where the points belong
+      var z : Matrix[Double] = Matrix.fill(m,k)((i,j) => if (j == minIdx.get(i)) 1.0 else 0.0)
+      //vector indicating the size of each cluster
+      val clusterSizes = Vector.fill(k)(i => z.column(i).fold(0.0)(s => s, (l,r) => l + r))
+
+      //build the list of alone centroids
+      val emptyClusters = clusterSizes.indexedFold(List[Int]())(s =>
+        if (s.value == 0) List(s.id) else List(),
+        (l,r) => l:::r)
+
+      //if there are empty clusters, the corresponding centroids are replaced by random points
+      if (emptyClusters.nonEmpty) {
+        z = Matrix.fillColumns(m,k)(j =>
+          if (emptyClusters.contains(j)) {
+            val c = Random.nextInt(m)
+            Vector.fill(m)(v => if (v==c) 1.0 else 0.0)
+          }
+          else z.column(j)
+        )
+      }
+      //compute new centroids
+      centroids = newCentroids
+      newCentroids = (x.transpose() %*% z).indexedCols(idx =>
+        if (clusterSizes.get(idx.id) == 0.0) idx.value else idx.value / clusterSizes.get(idx.id)
+      )
+      currentIteration += 1
+
+      //compute change
+      change = Vector.fill(k)(i => (centroids.column(i) - newCentroids.column(i)).fold(0.0)(
+        s => s * s, (l,r) => l + r)
+        ).fold(0.0)( s => s, (l,r) => l + r)
+
+    } while (change > epsilon && currentIteration < maxIterations )
+
+    // return the trained model
+    newCentroids.transpose()
+  }
+}

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/lara/KMeansMatrixTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/lara/KMeansMatrixTest.scala
@@ -1,0 +1,64 @@
+package eu.stratosphere.emma.examples.lara
+
+import eu.stratosphere.emma.api.lara.{BaseTest, Matrix, Vector}
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.util.Random
+
+@RunWith(classOf[JUnitRunner])
+class KMeansMatrixTest extends BaseTest{
+
+  //parameters
+  val variance = 8
+  val maxIterations = 100
+  val numPoints = 1000
+  val epsilon = 0.000001
+
+  //generate data with 2 clusters
+  val x2 = Matrix.fill(numPoints,2)((i,j) =>
+    if (i < numPoints/2 ) 0 + variance * Random.nextDouble()
+    else 10 + variance * Random.nextDouble()
+  )
+
+  //generate data with 3 clusters
+  val x3 = Matrix.fill(numPoints,2)((i,j) =>
+    if (i < numPoints / 3) {0 + variance * Random.nextDouble()}
+    else if (i < 2 * (numPoints / 3)) {10 + variance * Random.nextDouble()}
+    else {20 + variance * Random.nextDouble()}
+  )
+
+  //compute the true centroids for x2 and k = 2
+  val c1Points = Matrix.fillRows(numPoints/2, 2)(i => x2.row(i))
+  val c2Points = Matrix.fillRows(numPoints/2 + numPoints % 2,2)(i => x2.row(numPoints/2 + i))
+  val c1 = Vector.fill(2)(j => c1Points.column(j).fold(0.0)(s => s, (l,r) => l + r)) / (numPoints / 2)
+  val c2 = Vector.fill(2)(j => c2Points.column(j).fold(0.0)(s => s, (l,r) => l + r)) / (numPoints / 2 + numPoints % 2)
+  val trueCentroidsX2 = List(c1.toArray.toList,c2.toArray.toList)
+
+  //compute the true centroids for x3 and k = 3
+  val c1x3Points = Matrix.fillRows(numPoints/3, 2)(i => x3.row(i))
+  val c2x3Points = Matrix.fillRows(numPoints/3, 2)(i => x3.row(numPoints/3 + i))
+  val c3x3Points = Matrix.fillRows(numPoints/3 + numPoints % 3,2)(i => x3.row(2 * (numPoints/3) + i))
+  val c1x3 = Vector.fill(2)(j => c1x3Points.column(j).fold(0.0)(s=>s,(l,r) => l + r)) / (numPoints/3)
+  val c2x3 = Vector.fill(2)(j => c2x3Points.column(j).fold(0.0)(s=>s,(l,r) => l + r)) / (numPoints/3)
+  val c3x3 = Vector.fill(2)(j => c3x3Points.column(j).fold(0.0)(s=>s,(l,r) => l + r)) / (numPoints/3 + numPoints%3)
+  val trueCentroidsX3 = List(c1x3.toArray.toList,c2x3.toArray.toList,c3x3.toArray.toList)
+
+  //compute the trained centroids
+  val centroids2 = KMeansMatrix.kMeans(x2,2,maxIterations,epsilon)
+  val centroids3 = KMeansMatrix.kMeans(x3,3,maxIterations,epsilon)
+
+  //test adequation with the true centroids
+  "Trained centroids" - {
+    "2 clusters" in {
+      for (i <- 0 until 2) {
+        trueCentroidsX2.contains(centroids2.row(i).toArray.toList) shouldBe true
+      }
+    }
+    "3 clusters" in {
+      for (i <- 0 until 3) {
+        trueCentroidsX3.contains(centroids3.row(i).toArray.toList) shouldBe true
+      }
+    }
+  }
+}

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/lara/KMeansMatrixTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/lara/KMeansMatrixTest.scala
@@ -15,50 +15,73 @@ class KMeansMatrixTest extends BaseTest{
   val numPoints = 1000
   val epsilon = 0.000001
 
-  //generate data with 2 clusters
-  val x2 = Matrix.fill(numPoints,2)((i,j) =>
-    if (i < numPoints/2 ) 0 + variance * Random.nextDouble()
-    else 10 + variance * Random.nextDouble()
-  )
 
-  //generate data with 3 clusters
-  val x3 = Matrix.fill(numPoints,2)((i,j) =>
-    if (i < numPoints / 3) {0 + variance * Random.nextDouble()}
-    else if (i < 2 * (numPoints / 3)) {10 + variance * Random.nextDouble()}
-    else {20 + variance * Random.nextDouble()}
-  )
-
-  //compute the true centroids for x2 and k = 2
-  val c1Points = Matrix.fillRows(numPoints/2, 2)(i => x2.row(i))
-  val c2Points = Matrix.fillRows(numPoints/2 + numPoints % 2,2)(i => x2.row(numPoints/2 + i))
-  val c1 = Vector.fill(2)(j => c1Points.column(j).fold(0.0)(s => s, (l,r) => l + r)) / (numPoints / 2)
-  val c2 = Vector.fill(2)(j => c2Points.column(j).fold(0.0)(s => s, (l,r) => l + r)) / (numPoints / 2 + numPoints % 2)
-  val trueCentroidsX2 = List(c1.toArray.toList,c2.toArray.toList)
-
-  //compute the true centroids for x3 and k = 3
-  val c1x3Points = Matrix.fillRows(numPoints/3, 2)(i => x3.row(i))
-  val c2x3Points = Matrix.fillRows(numPoints/3, 2)(i => x3.row(numPoints/3 + i))
-  val c3x3Points = Matrix.fillRows(numPoints/3 + numPoints % 3,2)(i => x3.row(2 * (numPoints/3) + i))
-  val c1x3 = Vector.fill(2)(j => c1x3Points.column(j).fold(0.0)(s=>s,(l,r) => l + r)) / (numPoints/3)
-  val c2x3 = Vector.fill(2)(j => c2x3Points.column(j).fold(0.0)(s=>s,(l,r) => l + r)) / (numPoints/3)
-  val c3x3 = Vector.fill(2)(j => c3x3Points.column(j).fold(0.0)(s=>s,(l,r) => l + r)) / (numPoints/3 + numPoints%3)
-  val trueCentroidsX3 = List(c1x3.toArray.toList,c2x3.toArray.toList,c3x3.toArray.toList)
-
-  //compute the trained centroids
-  val centroids2 = KMeansMatrix.kMeans(x2,2,maxIterations,epsilon)
-  val centroids3 = KMeansMatrix.kMeans(x3,3,maxIterations,epsilon)
-
-  //test adequation with the true centroids
   "Trained centroids" - {
+
     "2 clusters" in {
-      for (i <- 0 until 2) {
-        trueCentroidsX2.contains(centroids2.row(i).toArray.toList) shouldBe true
-      }
+      //generate data with 2 clusters
+      val x2 = Matrix.fill(numPoints, 2)((i, j) =>
+        if (i < numPoints / 2) 0 + variance * Random.nextDouble()
+        else 10 + variance * Random.nextDouble()
+      )
+
+      //compute the true centroids for x2 and k = 2
+      val c1Points = Matrix.fillRows(numPoints / 2, 2)(i => x2.row(i))
+      val c2Points = Matrix.fillRows(numPoints / 2 + numPoints % 2, 2)(i => x2.row(numPoints / 2 + i))
+      val c1 = Vector.fill(2)(j => c1Points.column(j).aggregate(_ + _)) / (numPoints / 2)
+      val c2 = Vector.fill(2)(j => c2Points.column(j).aggregate(_ + _)) / (numPoints / 2 + numPoints % 2)
+      val trueCentroidsX2 = Set(c1.transpose(), c2.transpose())
+
+      //compute the trained centroids
+      val centroids2 = KMeansMatrix.kMeans(x2, 2, maxIterations, epsilon)
+
+      centroids2.numRows shouldBe 2
+      centroids2.numCols shouldBe 2
+      Set(centroids2.row(0), centroids2.row(1)) shouldBe trueCentroidsX2
     }
+
     "3 clusters" in {
-      for (i <- 0 until 3) {
-        trueCentroidsX3.contains(centroids3.row(i).toArray.toList) shouldBe true
-      }
+      //generate data with 3 clusters
+      val x3 = Matrix.fill(numPoints,2)((i,j) =>
+        if (i < numPoints / 3) {0 + variance * Random.nextDouble()}
+        else if (i < 2 * (numPoints / 3)) {10 + variance * Random.nextDouble()}
+        else {20 + variance * Random.nextDouble()}
+      )
+      //compute the true centroids for x3 and k = 3
+      val c1x3Points = Matrix.fillRows(numPoints/3, 2)(i => x3.row(i))
+      val c2x3Points = Matrix.fillRows(numPoints/3, 2)(i => x3.row(numPoints/3 + i))
+      val c3x3Points = Matrix.fillRows(numPoints/3 + numPoints % 3,2)(i => x3.row(2 * (numPoints/3) + i))
+      val c1x3 = Vector.fill(2)(j => c1x3Points.column(j).aggregate(_ + _)) / (numPoints/3)
+      val c2x3 = Vector.fill(2)(j => c2x3Points.column(j).aggregate(_ + _)) / (numPoints/3)
+      val c3x3 = Vector.fill(2)(j => c3x3Points.column(j).aggregate(_ + _)) / (numPoints/3 + numPoints%3)
+      val trueCentroidsX3 = Set(c1x3.transpose(),c2x3.transpose(),c3x3.transpose())
+
+      //compute the trained centroids
+      val centroids3 = KMeansMatrix.kMeans(x3,3,maxIterations,epsilon)
+
+      //check adequation
+      centroids3.numRows shouldBe 3
+      centroids3.numCols shouldBe 2
+      Set(centroids3.row(0),centroids3.row(1),centroids3.row(2)) shouldBe trueCentroidsX3
+    }
+
+    "with empty clusters" in {
+      //generate matrix representing 10 points
+      val x = Matrix.fill(10,2)((i,j) => (i + j).toDouble)
+      //with k >= 10, the true centroids should be the points themselves
+      var trueCentroidsSet: Set[Vector[Double]] = Set.empty
+      for (i <- 0 until 10) trueCentroidsSet = trueCentroidsSet + x.row(i)
+
+      //compute trained centroids with k = 11 so one cluster (at least) will always be empty
+      val trainedCentroids = KMeansMatrix.kMeans(x,11,maxIterations,epsilon)
+      var trainedCentroidsSet: Set[Vector[Double]] = Set.empty
+      for (i <- 0 until 11) trainedCentroidsSet = trainedCentroidsSet + trainedCentroids.row(i)
+
+      //trained centroids should contain the 10 points + some duplicates so trainedSet and trueSet should be equal
+      trainedCentroids.numRows shouldBe 11
+      trainedCentroids.numCols shouldBe 2
+      trainedCentroidsSet.size shouldBe 10
+      trainedCentroidsSet shouldBe trueCentroidsSet
     }
   }
 }


### PR DESCRIPTION
KMeansMatrix is the KMeans algorithm implemented with the Matrix abstraction instead of the DataBag abstraction.

Idx trait introduces Matrix/Vectors indexes to implement indexed transformations like
indexedFold, indexedCols and indexedRows. These methods, allow to keep track of the indexes during transformations. For example, it is useful when you want to find the index of the minimum in a vector instead of the minimum itself. This can not be done with the vector fold function alone.