### PR TITLE
(WIP) Tree traversal / transformation with attr

### DIFF
--- a/emma-common-macros/pom.xml
+++ b/emma-common-macros/pom.xml
@@ -27,6 +27,16 @@
             <artifactId>scala-compiler</artifactId>
         </dependency>
 
+        <!-- Type-level -->
+        <dependency>
+            <groupId>org.typelevel</groupId>
+            <artifactId>cats_${scala.tools.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.chuusai</groupId>
+            <artifactId>shapeless_${scala.tools.version}</artifactId>
+        </dependency>
+
         <!-- CSV -->
         <dependency>
             <groupId>net.sf.opencsv</groupId>

--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/compiler/ReflectUtil.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/compiler/ReflectUtil.scala
@@ -3,7 +3,7 @@ package compiler
 
 /** Default macro extensions for trees, types and symbols. */
 trait ReflectUtil extends Util
-  with Trees with Terms with Types with Symbols {
+  with Trees with Terms with Types with Symbols with Transducers {
 
   import universe._
   import Tree._

--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/compiler/Transducers.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/compiler/Transducers.scala
@@ -1,0 +1,469 @@
+package eu.stratosphere
+package emma.compiler
+
+import emma.util.Memo
+import emma.util.Monoids
+
+import cats._
+import cats.implicits._
+import shapeless._
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
+import scala.Function.const
+import scala.language.higherKinds
+
+trait Transducers extends Util { this: ReflectUtil =>
+
+  import universe._
+  import Monoids._
+
+  private def unit[A]: A => Unit =
+    const(()) _
+
+  private def complete[A, R](pf: A =?> R)(args: A)(default: => R): R =
+    pf.applyOrElse(args, (_: A) => default)
+
+  private def extend
+    [A, H, T <: HList]
+    (pf: (A, T) =?> T)
+    (ext: (A, H :: T) =?> H)
+    (implicit Mh: Monoid[H], Mt: Monoid[T])
+    : (A, H :: T) =?> (H :: T) = {
+
+    case args @ (a, _ :: t) if pf.isDefinedAt(a, t) || ext.isDefinedAt(args) =>
+      complete(ext)(args)(Mh.empty) :: complete(pf)(a, t)(Mt.empty)
+  }
+
+  case class Attr[
+    Acc <: HList : Monoid,
+    Inh <: HList : Monoid,
+    Syn <: HList : Monoid](
+      accumulation: (Tree, Acc) =?> Acc = PartialFunction.empty,
+      inheritance: (Tree, Inh) =?> Inh = PartialFunction.empty,
+      synthesis: (Tree, Syn) =?> Syn = PartialFunction.empty,
+      synth: Boolean = false /* Skip if not specified */) {
+
+    val MAcc = Monoid[Acc]
+    val MInh = Monoid[Inh]
+    val MSyn = Monoid[Syn]
+
+    def accumulate[A]
+      (acc: (Tree, A :: Acc) =?> A)
+      (implicit M: Monoid[A])
+      : Attr[A :: Acc, Inh, Syn] = {
+
+      copy(accumulation = extend(accumulation)(acc))
+    }
+
+    def inherit[I]
+      (inh: (Tree, I :: Inh) =?> I)
+      (implicit M: Monoid[I])
+      : Attr[Acc, I :: Inh, Syn] = {
+
+      copy(inheritance = extend(inheritance)(inh))
+    }
+
+    def synthesize[S]
+      (syn: (Tree, S :: Syn) =?> S)
+      (implicit M: Monoid[S])
+      : Attr[Acc, Inh, S :: Syn] = {
+
+      copy(synthesis = extend(synthesis)(syn), synth = true)
+    }
+  }
+
+  object Attr {
+
+    object at {
+
+      lazy val any: (Tree, Any, Any, Any) =?> Unit =
+        PartialFunction(unit)
+
+      def apply[R](pf: Tree =?> R): (Tree, Any, Any, Any) =?> R =
+        tree(pf)
+
+      def tree[R](pf: Tree =?> R): (Tree, Any, Any, Any) =?> R = {
+        case (tree, _, _, _) if pf.isDefinedAt(tree) => pf(tree)
+      }
+
+      def acc[A, R](pf: (Tree, A) =?> R): (Tree, A, Any, Any) =?> R = {
+        case (tree, acc, _, _) if pf.isDefinedAt(tree, acc) => pf(tree, acc)
+      }
+
+      def inh[I, R](pf: (Tree, I) =?> R): (Tree, Any, I, Any) =?> R = {
+        case (tree, _, inh, _) if pf.isDefinedAt(tree, inh) => pf(tree, inh)
+      }
+
+      def syn[S, R](pf: (Tree, S) =?> R): (Tree, Any, Any, S) =?> R = {
+        case (tree, _, _, syn) if pf.isDefinedAt(tree, syn) => pf(tree, syn)
+      }
+    }
+
+    def collect[Col[x] <: Traversable[x], El, T <: HList]
+      (elem: (Tree, Col[El] :: T) =?> El)
+      (implicit from: CanBuildFrom[Nothing, El, Col[El]])
+      : (Tree, Col[El] :: T) =?> Col[El] = {
+
+      case args if elem.isDefinedAt(args) =>
+        val builder = from()
+        builder += elem(args)
+        builder.result()
+    }
+
+    def group[K, V, T <: HList]
+      (kv: (Tree, Map[K, V] :: T) =?> (K, V))
+      : (Tree, Map[K, V] :: T) =?> Map[K, V] = {
+
+      case args if kv.isDefinedAt(args) =>
+        Map(kv(args))
+    }
+  }
+
+  trait ManagedAttr[Acc <: HList, Inh <: HList, Syn <: HList] {
+
+    def attr: Attr[Acc, Inh, Syn]
+    def callback: (Tree, Acc, Inh, Syn) =?> Any = PartialFunction.empty
+    def template: (Tree, Acc, Inh, Syn) =?> Tree = PartialFunction.empty
+
+    implicit def MAcc = attr.MAcc
+    implicit def MInh = attr.MInh
+    implicit def MSyn = attr.MSyn
+
+    protected var state = MAcc.empty
+    protected var stack = MInh.empty :: Nil
+    protected val cache = mutable.Map.empty[Tree, Syn]
+
+    def acc: Acc = state
+    def inh: Inh = stack.head
+
+    lazy val syn: Tree => Syn = Memo.recur[Tree, Syn]({ syn => tree =>
+      val prev = tree.children.map(syn).foldLeft(MSyn.empty)(MSyn.combine)
+      complete(attr.synthesis)(tree, prev)(prev)
+    }, cache)
+
+    protected def ann(tree: Tree): (Tree, Acc, Inh, Syn) =
+      (tree, acc, inh, if (attr.synth) syn(tree) else MSyn.empty)
+
+    protected lazy val accumulation: Tree =?> Acc = {
+      case tree if attr.accumulation.isDefinedAt(tree, acc) =>
+        attr.accumulation(tree, acc)
+    }
+
+    protected lazy val inheritance: Tree =?> Inh = {
+      case tree if attr.inheritance.isDefinedAt(tree, inh) =>
+        attr.inheritance(tree, inh)
+    }
+
+    protected lazy val traversal: Tree =?> Unit = {
+      case tree if callback.isDefinedAt(ann(tree)) =>
+        callback(ann(tree))
+    }
+
+    protected lazy val transformation: Tree =?> Tree = {
+      case tree if template.isDefinedAt(ann(tree)) =>
+        template(ann(tree))
+    }
+
+    protected def at[A](tree: Tree)(f: => A): A =
+      if (inheritance.isDefinedAt(tree)) {
+        stack ::= inh |+| inheritance(tree)
+        val result = f
+        stack = stack.tail
+        result
+      } else f
+
+    protected def accumulate(tree: Tree): Unit =
+      if (accumulation.isDefinedAt(tree)) {
+        state = acc |+| accumulation(tree)
+      }
+  }
+
+  case class Strategy[A <: HList, I <: HList, S <: HList](
+      attr: Attr[A, I, S], factory: TransFactory) {
+
+    type Acc = A
+    type Inh = I
+    type Syn = S
+
+    def accumulate[A: Monoid](acc: (Tree, A :: Acc) =?> A): Strategy[A :: Acc, Inh, Syn] =
+      copy(attr = attr.accumulate(acc))
+
+    def inherit[I: Monoid](inh: (Tree, I :: Inh) =?> I): Strategy[Acc, I :: Inh, Syn] =
+      copy(attr = attr.inherit(inh))
+
+    def synthesize[S: Monoid](syn: (Tree, S :: Syn) =?> S): Strategy[Acc, Inh, S :: Syn] =
+      copy(attr = attr.synthesize(syn))
+
+    def traverse[U](callback: (Tree, Acc, Inh, Syn) =?> U): Tree => (Acc, Syn) =
+      factory.traversal(attr)(callback)
+
+    def transform(template: (Tree, Acc, Inh, Syn) =?> Tree): Tree => (Tree, Acc, Syn) =
+      factory.transform(attr)(template)
+
+    def withAncestors = inherit[Vector[Tree]] {
+      case (tree, _) => Vector(tree)
+    }
+
+    def withParent = inherit[Tree] {
+      case (tree, _) => tree
+    } (Monoids.right(EmptyTree))
+
+    def withOwner = inherit[Symbol] {
+      case (tree, _) if isOwner(tree) => tree.symbol
+    } (Monoids.right(NoSymbol))
+
+    private def isOwner(tree: Tree) = tree match {
+      case _: Function => true
+      case tree: Tree => tree.isDef
+      case _ => false
+    }
+
+    def withValDefs = synthesize[Map[TermSymbol, ValDef]] {
+      case (value @ Tree.val_(lhs, _, _), defs :: _) =>
+        defs + (lhs -> value)
+    }
+
+    def withTermRefs = synthesize[Map[TermSymbol, Int]] {
+      case (Term.ref(target), refs :: _) =>
+        refs + (target -> (refs(target) + 1))
+    } (Monoids.merge)
+  }
+
+  abstract class Transform[A <: HList, I <: HList, S <: HList]
+    (val attr: Attr[A, I, S], override val template: (Tree, A, I, S) =?> Tree)
+    extends Transformer with ManagedAttr[A, I, S] with (Tree => (Tree, A, S)) {
+
+    override def apply(tree: Tree): (Tree, A, S) = {
+      state = MAcc.empty
+      stack = MInh.empty :: Nil
+      cache.clear()
+      val (t, a, _, s) = ann(transform(tree))
+      (t, a, s)
+    }
+
+    override def transform(tree: Tree): Tree = at(tree)(tree match {
+      // NOTE: `TypeTree.original` is not transformed by default
+      case tpt: TypeTree if tpt.original != null =>
+        val original = transform(tpt.original)
+        if (original eq tpt.original) tpt else {
+          val copy = treeCopy.TypeTree(tpt)
+          setOriginal(copy, original)
+          copy
+        }
+
+      case _ =>
+        super.transform(tree)
+    })
+  }
+
+  abstract class Traversal[A <: HList, I <: HList, S <: HList]
+    (val attr: Attr[A, I, S], override val callback: (Tree, A, I, S) =?> Any)
+    extends Traverser with ManagedAttr[A, I, S] with (Tree => (A, S)) {
+
+    override def apply(tree: Tree): (A, S) = {
+      state = MAcc.empty
+      stack = MInh.empty :: Nil
+      cache.clear()
+      traverse(tree)
+      val (_, a, _, s) = ann(tree)
+      (a, s)
+    }
+
+    override def traverse(tree: Tree): Unit = at(tree)(tree match {
+      // NOTE: TypeTree.original is not traversed by default
+      case tpt: TypeTree if tpt.original != null => traverse(tpt.original)
+      case _ => super.traverse(tree)
+    })
+  }
+
+  trait TransFactory {
+
+    def traversal[A <: HList, I <: HList, S <: HList, U]
+      (attr: Attr[A, I, S])(callback: (Tree, A, I, S) =?> U): Traversal[A, I, S]
+
+    def transform[A <: HList, I <: HList, S <: HList]
+      (attr: Attr[A, I, S])(template: (Tree, A, I, S) =?> Tree): Transform[A, I, S]
+  }
+
+  object TransFactory {
+
+    object topDown extends TransFactory {
+
+      override def traversal[A <: HList, I <: HList, S <: HList, U]
+        (attr: Attr[A, I, S])(callback: (Tree, A, I, S) =?> U): Traversal[A, I, S] =
+        Traversal.topDown(attr)(callback)
+
+      override def transform[A <: HList, I <: HList, S <: HList]
+        (attr: Attr[A, I, S])(template: (Tree, A, I, S) =?> Tree): Transform[A, I, S] =
+        Transform.topDown(attr)(template)
+
+      object break extends TransFactory {
+
+        override def traversal[A <: HList, I <: HList, S <: HList, U]
+          (attr: Attr[A, I, S])(callback: (Tree, A, I, S) =?> U): Traversal[A, I, S] =
+          Traversal.topDown.break(attr)(callback)
+
+        override def transform[A <: HList, I <: HList, S <: HList]
+          (attr: Attr[A, I, S])(template: (Tree, A, I, S) =?> Tree): Transform[A, I, S] =
+          Transform.topDown.break(attr)(template)
+      }
+    }
+
+    object bottomUp extends TransFactory {
+
+      override def traversal[A <: HList, I <: HList, S <: HList, U]
+        (attr: Attr[A, I, S])(callback: (Tree, A, I, S) =?> U): Traversal[A, I, S] =
+        Traversal.bottomUp(attr)(callback)
+
+      override def transform[A <: HList, I <: HList, S <: HList]
+        (attr: Attr[A, I, S])(template: (Tree, A, I, S) =?> Tree): Transform[A, I, S] =
+        Transform.bottomUp(attr)(template)
+
+      object break extends TransFactory {
+
+        override def traversal[A <: HList, I <: HList, S <: HList, U]
+          (attr: Attr[A, I, S])(callback: (Tree, A, I, S) =?> U): Traversal[A, I, S] =
+          Traversal.bottomUp.break(attr)(callback)
+
+        override def transform[A <: HList, I <: HList, S <: HList]
+          (attr: Attr[A, I, S])(template: (Tree, A, I, S) =?> Tree): Transform[A, I, S] =
+          Transform.bottomUp.break(attr)(template)
+      }
+    }
+  }
+
+  object Transform {
+
+    object topDown {
+
+      def apply[A <: HList, I <: HList, S <: HList]
+        (attr: Attr[A, I, S])(template: (Tree, A, I, S) =?> Tree)
+        : Transform[A, I, S] = new Transform[A, I, S](attr, template) {
+          override final def transform(tree: Tree): Tree = {
+            accumulate(tree)
+            super.transform(complete(transformation)(tree)(tree))
+          }
+        }
+
+      def break[A <: HList, I <: HList, S <: HList]
+        (attr: Attr[A, I, S])(template: (Tree, A, I, S) =?> Tree)
+        : Transform[A, I, S] = new Transform[A, I, S](attr, template) {
+          override final def transform(tree: Tree): Tree = {
+            accumulate(tree)
+            transformation.applyOrElse(tree, super.transform)
+          }
+        }
+    }
+
+    object bottomUp {
+
+      def apply[A <: HList, I <: HList, S <: HList]
+        (attr: Attr[A, I, S])(template: (Tree, A, I, S) =?> Tree)
+        : Transform[A, I, S] = new Transform[A, I, S](attr, template) {
+          override final def transform(tree: Tree): Tree = {
+            val recur = super.transform(tree)
+            accumulate(recur)
+            complete(transformation)(recur)(recur)
+          }
+        }
+
+      def break[A <: HList, I <: HList, S <: HList]
+        (attr: Attr[A, I, S])(template: (Tree, A, I, S) =?> Tree)
+        : Transform[A, I, S] = new Transform[A, I, S](attr, template) {
+          val matches: mutable.Set[Tree] = mutable.Set.empty
+          override final def transform(tree: Tree): Tree = {
+            val recur = super.transform(tree)
+            val children = tree.children
+            if (children.exists(matches)) {
+              matches --= children
+              matches += recur
+              recur
+            } else {
+              accumulate(recur)
+              if (transformation.isDefinedAt(recur)) {
+                matches += recur
+                transformation(recur)
+              } else recur
+            }
+          }
+        }
+    }
+  }
+
+  object Traversal {
+
+    object topDown {
+
+      def apply[A <: HList, I <: HList, S <: HList, U]
+        (attr: Attr[A, I, S])(callback: (Tree, A, I, S) =?> U)
+        : Traversal[A, I, S] = new Traversal[A, I, S](attr, callback) {
+          override final def traverse(tree: Tree): Unit = {
+            accumulate(tree)
+            traversal.applyOrElse(tree, unit[Tree])
+            super.traverse(tree)
+          }
+        }
+
+      def break[A <: HList, I <: HList, S <: HList, U]
+        (attr: Attr[A, I, S])(callback: (Tree, A, I, S) =?> U)
+        : Traversal[A, I, S] = new Traversal[A, I, S](attr, callback) {
+          override final def traverse(tree: Tree): Unit = {
+            accumulate(tree)
+            traversal.applyOrElse(tree, super.traverse)
+          }
+        }
+    }
+
+    object bottomUp {
+
+      def apply[A <: HList, I <: HList, S <: HList, U]
+        (attr: Attr[A, I, S])(callback: (Tree, A, I, S) =?> U)
+        : Traversal[A, I, S] = new Traversal[A, I, S](attr, callback) {
+          override final def traverse(tree: Tree): Unit = {
+            super.traverse(tree)
+            accumulate(tree)
+            traversal.applyOrElse(tree, unit[Tree])
+          }
+        }
+
+      def break[A <: HList, I <: HList, S <: HList, U]
+        (attr: Attr[A, I, S])(callback: (Tree, A, I, S) =?> U)
+        : Traversal[A, I, S] = new Traversal[A, I, S](attr, callback) {
+          val matches: mutable.Set[Tree] = mutable.Set.empty
+          override final def traverse(tree: Tree): Unit = {
+            super.traverse(tree)
+            val children = tree.children
+            if (children.exists(matches)) {
+              matches --= children
+              matches += tree
+            } else {
+              accumulate(tree)
+              if (traversal.isDefinedAt(tree)) {
+                matches += tree
+                traversal(tree)
+              }
+            }
+          }
+        }
+    }
+  }
+
+  object TopDown extends Strategy[HNil, HNil, HNil](
+      Attr[HNil, HNil, HNil](),
+      TransFactory.topDown) {
+
+    object break extends Strategy[HNil, HNil, HNil](
+        Attr[HNil, HNil, HNil](),
+        TransFactory.topDown.break)
+  }
+
+  object BottomUp extends Strategy[HNil, HNil, HNil](
+      Attr[HNil, HNil, HNil](),
+      TransFactory.bottomUp) {
+
+    object break extends Strategy[HNil, HNil, HNil](
+        Attr[HNil, HNil, HNil](),
+        TransFactory.bottomUp.break)
+  }
+}

--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/util/Memo.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/util/Memo.scala
@@ -1,0 +1,48 @@
+package eu.stratosphere
+package emma.util
+
+import scala.collection.mutable
+
+/**
+ * Memoizing different types of functions.
+ *
+ * Calling a memoized function with a set of arguments for the first time will save the result in a
+ * cache - a [[mutable.Map]], possibly user-provided. Calling it with the same set of arguments
+ * subsequently will not perform the computation, but retrieve the cached value instead.
+ *
+ * This is useful for computations that are expensive and are performed many times with the same
+ * arguments.
+ *
+ * However, functions need to be referentially transparent (i.e. have no side effects) to preserve
+ * correctness.
+ */
+object Memo {
+
+  /** Memoize a simple referentially transparent function */
+  def apply[A, R](f: A => R,
+    cache: mutable.Map[A, R] = mutable.Map.empty[A, R]): A => R = {
+
+    arg => cache.getOrElseUpdate(arg, f(arg))
+  }
+
+  /**
+   * Memoize a recursive function. Recursive invocations will also go through the cache, therefore
+   * the function must accept it's cached variant as argument.
+   *
+   * Memoization of recursive functions is equivalent to dynamic programming.
+   *
+   * WARNING: Not stack safe.
+   */
+  def recur[A, R](f: (A => R) => A => R,
+    cache: mutable.Map[A, R] = mutable.Map.empty[A, R]): A => R = {
+
+    lazy val recur: A => R = apply[A, R](f(recur)(_), cache)
+    recur
+  }
+
+  /** Memoize a commutative function (the order of arguments doesn't matter). */
+  def commutative[A, R](f: (A, A) => R,
+    cache: mutable.Map[(A, A), R] = mutable.Map.empty[(A, A), R]): (A, A) => R = {
+      case (x, y) => cache.getOrElse(y -> x, cache.getOrElseUpdate(x -> y, f(x, y)))
+    }
+}

--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/util/Monoids.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/util/Monoids.scala
@@ -1,0 +1,50 @@
+package eu.stratosphere
+package emma.util
+
+import cats.Monoid
+import cats.implicits._
+import shapeless._
+
+/** Missing instances of [[cats.Monoid]]. */
+object Monoids {
+
+  /** [[shapeless.HNil]] is an empty monoid. */
+  implicit val hnil: Monoid[HNil] = new Monoid[HNil] {
+    override def empty: HNil = HNil
+    override def combine(x: HNil, y: HNil): HNil = HNil
+  }
+
+  /** [[shapeless.HList]] is a generic product. */
+  implicit def hcons[H, T <: HList](implicit Mh: Monoid[H], Mt: Monoid[T]): Monoid[H :: T] =
+    new Monoid[H :: T] {
+      override lazy val empty: H :: T = Mh.empty :: Mt.empty
+      override def combine(x: H :: T, y: H :: T): H :: T =
+        Mh.combine(x.head, y.head) :: Mt.combine(x.tail, y.tail)
+    }
+
+  /** Trivial monoid with bias to the left. */
+  def left[A](zero: => A): Monoid[A] = new Monoid[A] {
+    override lazy val empty: A = zero
+    override def combine(x: A, y: A): A = if (x == empty) y else x
+  }
+
+  /** Trivial monoid with bias to the right. */
+  def right[A](zero: => A): Monoid[A] = new Monoid[A] {
+    override lazy val empty: A = zero
+    override def combine(x: A, y: A): A = if (y == empty) x else y
+  }
+
+  /** Monoid for [[Map]]s that overwrites previous values. */
+  implicit def overwrite[K, V]: Monoid[Map[K, V]] = new Monoid[Map[K, V]] {
+    override def empty: Map[K, V] = Map.empty
+    override def combine(x: Map[K, V], y: Map[K, V]): Map[K, V] = x ++ y
+  }
+
+  /** Monoid for [[Map]]s that merges previous values via an underlying monoid. */
+  def merge[K, V](implicit M: Monoid[V]): Monoid[Map[K, V]] = new Monoid[Map[K, V]] {
+    private def augment(map: Map[K, V]) = map.withDefaultValue(M.empty)
+    override lazy val empty: Map[K, V] = augment(Map.empty)
+    override def combine(x: Map[K, V], y: Map[K, V]): Map[K, V] =
+      y.foldLeft(augment(x)) { case (map, (k, v)) => map + (k -> (map(k) |+| v)) }
+  }
+}

--- a/emma-common-macros/src/test/scala/eu/stratosphere/emma/util/HListArb.scala
+++ b/emma-common-macros/src/test/scala/eu/stratosphere/emma/util/HListArb.scala
@@ -1,0 +1,23 @@
+package eu.stratosphere.emma.util
+
+import shapeless._
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
+
+trait HListArb {
+
+  implicit val hnilArb: Arbitrary[HNil] =
+    Arbitrary(Gen.const(HNil))
+
+  implicit def hconsArb[H, T <: HList]
+    (implicit HArb: Arbitrary[H], TArb: Arbitrary[T]): Arbitrary[H :: T] = {
+
+    Arbitrary(for {
+      h <- HArb.arbitrary
+      t <- TArb.arbitrary
+    } yield h :: t)
+  }
+}
+
+object HListArb extends HListArb

--- a/emma-common-macros/src/test/scala/eu/stratosphere/emma/util/HListEq.scala
+++ b/emma-common-macros/src/test/scala/eu/stratosphere/emma/util/HListEq.scala
@@ -1,0 +1,20 @@
+package eu.stratosphere
+package emma.util
+
+import cats.Eq
+import shapeless._
+
+trait HListEq {
+
+  implicit val hnilEq: Eq[HNil] = new Eq[HNil] {
+    override def eqv(x: HNil, y: HNil): Boolean = true
+  }
+
+  implicit def hconsEq[H, T <: HList](implicit HEq: Eq[H], TEq: Eq[T]): Eq[H :: T] =
+    new Eq[H :: T] {
+      override def eqv(x: H :: T, y: H :: T): Boolean =
+        HEq.eqv(x.head, y.head) && TEq.eqv(x.tail, y.tail)
+    }
+}
+
+object HListEq extends HListEq

--- a/emma-common-macros/src/test/scala/eu/stratosphere/emma/util/MemoSpec.scala
+++ b/emma-common-macros/src/test/scala/eu/stratosphere/emma/util/MemoSpec.scala
@@ -1,0 +1,74 @@
+package eu.stratosphere
+package emma.util
+
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+
+import scala.collection.mutable
+
+@RunWith(classOf[JUnitRunner])
+class MemoSpec extends FreeSpec with Matchers {
+
+  "Momoization" - {
+
+    "of simple functions" in {
+      val string = "the quick brown fox jumps over the lazy dog"
+      val cache = mutable.Map.empty[Char, Int]
+      var computed = Vector.empty[Char]
+
+      val indexOf = Memo[Char, Int]({ ch =>
+        computed :+= ch
+        string.indexOf(ch)
+      }, cache)
+
+      val result = "this is a string with duplicate characters"
+        .map(ch => ch -> indexOf(ch)).toMap
+
+      computed should contain theSameElementsAs cache.keys
+      result should contain theSameElementsAs cache
+    }
+
+    "of recursive functions" in {
+      val levenshtein = Memo.recur[(String, String), Int](levenshtein => {
+        case ("", ys) => ys.length
+        case (xs, "") => xs.length
+        case (xs, ys) =>
+          val delta = if (xs.head == ys.head) 0 else 1
+          val (xt, yt) = (xs.tail, ys.tail)
+          Seq(
+            levenshtein(xt, yt) + delta,
+            levenshtein(xt, ys) + 1,
+            levenshtein(xs, yt) + 1
+          ).min
+      })
+
+      levenshtein("", "") should be (0)
+      levenshtein("", "123456") should be (6)
+      levenshtein("xyx", "xyyyx") should be (2)
+      levenshtein("kitten", "sitting") should be (3)
+      levenshtein("closure", "clojure") should be (1)
+      levenshtein("ttttattttctg", "tcaaccctaccat") should be (10)
+      levenshtein("gaattctaatctc", "caaacaaaaaattt") should be (9)
+    }
+
+    "of commutative functions" in {
+      val cache = mutable.Map.empty[(Int, Int), Int]
+      var computed = Vector.empty[(Int, Int)]
+
+      val add = Memo.commutative[Int, Int]({ case (x, y) =>
+        computed +:= (x, y)
+        x + y
+      }, cache)
+
+      val result = (for {
+        x <- 1 to 10
+        y <- 1 to 10
+        if x != y
+      } yield add(x, y)).sum
+
+      computed should contain theSameElementsAs cache.keys
+      result should equal (cache.values.sum * 2)
+    }
+  }
+}

--- a/emma-common-macros/src/test/scala/eu/stratosphere/emma/util/MonoidSpec.scala
+++ b/emma-common-macros/src/test/scala/eu/stratosphere/emma/util/MonoidSpec.scala
@@ -1,0 +1,47 @@
+package eu.stratosphere
+package emma.util
+
+import cats.implicits._
+import cats.kernel.laws.GroupLaws
+import shapeless._
+
+import org.junit.runner.RunWith
+import org.scalatest._
+import org.scalatest.junit.JUnitRunner
+import org.scalatest.prop.Checkers
+
+@RunWith(classOf[JUnitRunner])
+class MonoidSpec extends FreeSpec with Checkers with HListEq with HListArb {
+
+  import Monoids._
+
+  "Monoid laws" - {
+
+    "forgetful" - {
+
+      "with left bias" in {
+        check(GroupLaws[Int].monoid(left(0)).all)
+      }
+
+      "with right bias" in {
+        check(GroupLaws[String].monoid(right("")).all)
+      }
+    }
+
+    "for maps" - {
+
+      "with overwriting" in {
+        check(GroupLaws[Map[Char, Int]].monoid(overwrite).all)
+      }
+
+      "with merging" in {
+        check(GroupLaws[Map[Char, Int]].monoid(merge).all)
+      }
+    }
+
+    "for generic products" in {
+      check(GroupLaws[HNil].monoid.all)
+      check(GroupLaws[Int :: String :: HNil].monoid.all)
+    }
+  }
+}

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/TransducerSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/TransducerSpec.scala
@@ -1,0 +1,100 @@
+package eu.stratosphere
+package emma.compiler
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import cats.implicits._
+import shapeless.HNil
+
+@RunWith(classOf[JUnitRunner])
+class TransducerSpec extends BaseCompilerSpec {
+
+  import compiler._
+  import universe._
+  import Attr._
+
+  val example = reify {
+    val x1 = 1
+    val x2 = {
+      val y1 = 2
+      val y2 = 3
+      y1 + y2
+    }
+    val x3 = {
+      val y3 = 4
+      val y4 = {
+        val z1 = 5
+        val z2 = 6
+        z1 + z2
+      }
+      y3 + y4
+    }
+    x1 + x2 + x3
+  }.tree
+
+  "correct order of" - {
+    "top-down traversal" in {
+      var vals = Vector.empty[String]
+      TopDown.traverse(at {
+        case ValDef(_, name, _, _) => vals :+= name.toString
+      })(example)
+
+      val collected = TopDown.accumulate(collect[Vector, String, HNil] {
+        case (ValDef(_, name, _, _), _) => name.toString
+      }).traverse(at.any)(example)._1.head
+
+      vals should contain theSameElementsInOrderAs collected
+      vals should contain theSameElementsInOrderAs
+        Vector("x1", "x2", "y1", "y2", "x3", "y3", "y4", "z1", "z2")
+    }
+
+    "top-down-break traversal" in {
+      var vals = Vector.empty[String]
+      TopDown.break.traverse(at {
+        case ValDef(_, name, _, _) => vals :+= name.toString
+      })(example)
+
+      val collected = TopDown.break.accumulate(collect[Vector, String, HNil] {
+        case (ValDef(_, name, _, _), _) => name.toString
+      }).traverse(at { case _: ValDef => })(example)._1.head
+
+      vals should contain theSameElementsInOrderAs collected
+      vals should contain theSameElementsInOrderAs Vector("x1", "x2", "x3")
+    }
+
+    "bottom-up traversal" in {
+      var vals = Vector.empty[String]
+      BottomUp.traverse(at {
+        case ValDef(_, name, _, _) => vals :+= name.toString
+      })(example)
+
+      val collected = BottomUp.accumulate(collect[Vector, String, HNil] {
+        case (ValDef(_, name, _, _), _) => name.toString
+      }).traverse(at.any)(example)._1.head
+
+      vals should contain theSameElementsInOrderAs collected
+      vals should contain theSameElementsInOrderAs
+        Vector("x1", "y1", "y2", "x2", "y3", "z1", "z2", "y4", "x3")
+    }
+
+    "bottom-up-break traversal" in {
+      var vals = Vector.empty[String]
+      BottomUp.break.traverse(at {
+        case ValDef(_, name, _, _) => vals :+= name.toString
+      })(example)
+
+      val collected = BottomUp.break.accumulate(collect[Vector, String, HNil] {
+        case (ValDef(_, name, _, _), _) => name.toString
+      }).traverse(at { case _: ValDef => })(example)._1.head
+
+      vals should contain theSameElementsInOrderAs collected
+      vals should contain theSameElementsInOrderAs
+        Vector("x1", "y1", "y2", "y3", "z1", "z2")
+    }
+  }
+
+  "accumulation" - {
+
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,10 @@
         <scala.version>2.11.7</scala.version>
         <scala.tools.version>2.11</scala.tools.version>
 
+        <!-- Type-level -->
+        <cats.version>0.6.0</cats.version>
+        <shapeless.version>2.3.1</shapeless.version>
+
         <!-- Hadoop -->
         <hadoop.version>2.2.0</hadoop.version>
         <!-- Flink -->
@@ -156,6 +160,18 @@
                 <version>${project.version}</version>
                 <type>test-jar</type>
                 <scope>test</scope>
+            </dependency>
+
+            <!-- Type-level -->
+            <dependency>
+                <groupId>org.typelevel</groupId>
+                <artifactId>cats_${scala.tools.version}</artifactId>
+                <version>${cats.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.chuusai</groupId>
+                <artifactId>shapeless_${scala.tools.version}</artifactId>
+                <version>${shapeless.version}</version>
             </dependency>
 
             <!-- Hadoop -->

--- a/scalastyle_config.xml
+++ b/scalastyle_config.xml
@@ -127,7 +127,7 @@
  <check level="warning" class="org.scalastyle.scalariform.EmptyClassChecker" enabled="true"/>
  <check level="warning" class="org.scalastyle.scalariform.ClassTypeParameterChecker" enabled="true">
   <parameters>
-   <parameter name="regex"><![CDATA[^[A-Z_]$]]></parameter>
+   <parameter name="regex"><![CDATA[^[A-Z_][A-Za-z_]*$]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.UnderscoreImportChecker" enabled="false"/>


### PR DESCRIPTION
This is my suggestion for the next iteration of the `Tree` taversers / transformers. There are 4 general strategies depicted on the picture below taken from [here](http://homepages.cwi.nl/~paulk/publications/TOSEM03.pdf) (we don't care about right-to-left):

![screenshot from 2016-06-03 16-32-59](https://cloud.githubusercontent.com/assets/2218841/15782006/e280be24-29a8-11e6-8142-f143a8aac40b.png)

All are implemented by subclassing the default `Traverser` and `Transformer` and calling `super` method in the appropriate order. In addition to that we can generate and access multiple attributes during the same traversal / transformation:

1. **Inherited** (monoids folded on the path from the root to the current node) -> implemented via stack
2. **Synthesized** (monoids folded on all subtrees of the current node) -> implemented via memoized recursive function ~ equivalent to dynamic programming (without the stack safety)
3. **Accumulated** (monoids folded along the traversal path - depending on the stragegy) -> implemented via simple accumulator

#### Advantages

- :+1: No explicit state manipulation / nice API
- :+1: Access generated attributes while tranforming / traversing
- :+1: Guaranteed one-pass complexity (2 if we count the memoized synthesis)
- :+1: Can do anything we did so far and more

#### Disadvantages

- :-1: Not a full-blown query language like TQL
- :-1: Can't combine and compose different traversals / transformations
- :-1: Matching functions become more complex due to the addition of attributes
- :-1: Dependency on [cats](https://github.com/typelevel/cats) for the monoid instances and [shapeless](https://github.com/milessabin/shapeless) for appending attributes

I still need to figure out how to test this.