### PR TITLE
[IR] Reworked DCE based on compiler.ast

### DIFF
--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/lang/core/Core.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/lang/core/Core.scala
@@ -293,15 +293,14 @@ trait Core extends Common
     // DCE API
     // -------------------------------------------------------------------------
 
-    /** Delegates to [[DCE.dce()]]. */
-    def dce(tree: u.Tree): u.Tree =
-      DCE.dce(tree)
+    /** Delegates to [[DCE.transform]]. */
+    lazy val dce = DCE.transform
 
     // -------------------------------------------------------------------------
     // CSE API
     // -------------------------------------------------------------------------
 
-    /** Delegates to [[DCE.dce()]]. */
+    /** Delegates to [[CSE.cse()]]. */
     def cse(tree: u.Tree): u.Tree =
       CSE.cse(tree)
 

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/DCESpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/DCESpec.scala
@@ -15,7 +15,7 @@ class DCESpec extends BaseCompilerSpec {
   val dcePipeline: u.Expr[Any] => u.Tree =
     compiler.pipeline(typeCheck = true)(
       ANF.transform,
-      tree => time(DCE.dce(tree), "dce")
+      tree => time(DCE.transform(tree), "dce")
     ).compose(_.tree)
 
   "eliminate unused valdefs" - {


### PR DESCRIPTION
A note about side effects: DCE will remove any purely side-effecting method calls like `println`, because their return values are never used. To prevent this, we would need to wrap such calls in some kind of `effectful[T](eff: T): T` that is bypassed in transformations like ANF, DCE and CSE.