### PR TITLE
[IR] Added order disambiguation.

### DIFF
--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/ast/Trees.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/ast/Trees.scala
@@ -139,6 +139,10 @@ trait Trees { this: AST =>
           else TypeSym.fresh(sym.asType)
         }): _*)
 
+      /** Refreshes all `symbols` in a tree that are defined within (including the symbols of lambdas). */
+      def refreshAll(tree: u.Tree): u.Tree =
+        refresh((defs(tree) ++ lambdas(tree)).toSeq: _*)(tree)
+
       /** Replaces a sequence of term symbols with references to their `aliases`. */
       def rename(aliases: (u.Symbol, u.Symbol)*): u.Tree => u.Tree =
         if (aliases.isEmpty) identity else {

--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/Common.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/Common.scala
@@ -82,6 +82,8 @@ trait Common extends AST {
 
     val cross                 = module.info.decl(TermName("cross")).asMethod
     val equiJoin              = module.info.decl(TermName("equiJoin")).asMethod
+
+    val methods               = Set(cross, equiJoin)
     //@formatter:on
   }
 

--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/Compiler.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/Compiler.scala
@@ -4,6 +4,7 @@ package compiler
 import lang.AlphaEq
 import lang.core.Core
 import lang.source.Source
+import lang.backend.Backend
 
 import scala.reflect.api.Universe
 
@@ -13,7 +14,7 @@ import scala.reflect.api.Universe
  * This trait has to be instantiated with an underlying universe and works for both runtime and
  * compile time reflection.
  */
-trait Compiler extends AlphaEq with Source with Core {
+trait Compiler extends AlphaEq with Source with Core with Backend {
 
   /** The underlying universe object. */
   override val universe: Universe

--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/lang/backend/Backend.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/lang/backend/Backend.scala
@@ -1,0 +1,20 @@
+package eu.stratosphere.emma
+package compiler.lang.backend
+
+import compiler.Common
+import compiler.lang.core.Core
+
+/** Backend-related (but backend-agnostic) transformations. */
+trait Backend extends Common
+  with Order {
+  this: Core =>
+
+  import UniverseImplicits._
+
+  object Backend {
+
+    /** Delegates to [[Order.disambiguate]]. */
+    lazy val order = Order.disambiguate
+
+  }
+}

--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/lang/backend/Order.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/lang/backend/Order.scala
@@ -1,0 +1,164 @@
+package eu.stratosphere.emma
+package compiler.lang.backend
+
+import cats.std.all._
+import compiler.Common
+import compiler.lang.core.Core
+import util.Monoids
+import shapeless._
+
+/**
+ * Determining which parts of the code might be called from a higher-order context, that is from a UDF of a combinator.
+ * Note that some code might be executed both at the driver and in UDFs, which need to be disambiguated, because
+ * we will later transform higher-order code differently than first-order code.
+ *
+ * Note: This code assumes that DataBags don't contain functions. (E.g. it handles a DataBag[Int => Int] incorrectly.)
+ */
+private[backend] trait Order extends Common {
+  self: Backend with Core =>
+
+  import Core.{Lang => core}
+  import UniverseImplicits._
+
+  private[backend] object Order {
+
+    /**
+     * If a lambda is given as an argument to one of these methods,
+     * then that lambda will be called from higher-order context.
+     */
+    val combinators = API.methods ++ ComprehensionCombinators.methods
+
+    /**
+     * Disambiguates order in a tree and gives information on which parts of the code might be executed
+     * from a higher-order context.
+     *
+     * == Preconditions ==
+     *
+     * - Input must be in ANF.
+     * - DataBags don't contain functions. (TODO: Maybe add a check for this in some place like CoreValidate)
+     *
+     * == Postconditions ==
+     *
+     * Returns a (disambiguatedTree, highFuns) pair, where
+     * disambiguatedTree is an ANF tree where it has been decided for every piece of code whether to treat it
+     * as driver-only or high (that is, it can be called from a higher-order context). (Some ValDefs have been
+     * duplicated for this.)
+     *
+     * highFuns contains those TermSymbol which are functions that might be called from higher-order context
+     * (see isHighContext and its usage for how to make an inherited attribute from it).
+     * Note, that highFuns might contain false positives, i.e. it might contain for code that is only executed
+     * in the driver.
+     *
+     * Algorithm:
+     * 1. Collect symbols of all function ValDefs. (funs)
+     * 2. Build a graph of funs referencing funs. (funGraph)
+     * 3. Collect funs that are given as arguments to combinators. (topLevRefs)
+     * 4. Collect funs referenced from top-level. (combRefs)
+     * 5. Do graph traversals on funGraph from combRefs and topLevRefs to get all high and
+     *    driver-only funs, respectively. (highFuns0, driverFuns)
+     * 6. The intersection of highFuns0 and driverFuns are the ambiguous ones. Create new ValDefs
+     *    for these, and modify refs to them in high code to the newly created vals.
+     */
+    lazy val disambiguate: u.Tree => (u.Tree, Set[u.TermSymbol]) = tree => {
+
+      def isFun(sym: u.TermSymbol) = api.Sym.funs(api.Type.of(sym).typeSymbol)
+
+      // The Set of symbols of ValDefs of functions
+      val funs = tree.collect {
+        case core.ValDef(sym, _, _) if isFun(sym) => sym
+      }.toSet
+
+      val Attr.all(_, topLevRefs :: combRefs :: _, _, funGraph :: _) =
+        api.TopDown
+        // Fun Refs
+        .synthesize(Attr.collect[Vector, u.TermSymbol]{
+          case api.ValRef(sym) if funs contains sym =>
+            sym
+        })
+        // funGraph
+        .synthesizeWith[Map[u.TermSymbol, Set[u.TermSymbol]]] {
+          case Attr.syn(api.ValDef(sym, rhs, _), _ :: funRefs :: _) if isFun(sym) =>
+            Map(sym -> funRefs.toSet)
+        }
+        // Am I inside a lambda?
+        .inherit {
+          case api.Lambda(_,_,_) => true
+        }(Monoids.disj)
+        // Am I inside a combinator call?
+        .inherit {
+          case api.DefCall(_, method, _, _) if combinators contains method => true
+        }(Monoids.disj)
+        // Funs given as arguments to combinators (combRefs)
+        .accumulateWith[Vector[u.TermSymbol]] {
+          case Attr.inh(api.ValRef(sym), insideCombinator :: _)
+            if insideCombinator && (funs contains sym) => Vector(sym)
+        }
+        // Funs referenced from top-level (topLevRefs)
+        .accumulateWith[Vector[u.TermSymbol]] {
+          case Attr.inh(api.ValRef(sym), insideCombinator :: insideLambda :: _)
+            if !insideLambda && !insideCombinator && (funs contains sym) =>
+            Vector(sym)
+        }
+          .traverseAny(tree)
+
+      // BFS on funGraph, starting from `start`
+      def funReachability(start: Vector[u.TermSymbol]): Set[u.TermSymbol] = {
+        var reached = start.toSet
+        var frontier = start
+        while (frontier.nonEmpty) {
+          frontier = for {
+            u <- frontier
+            v <- funGraph(u)
+            if !reached(v)
+          } yield v
+          reached ++= frontier
+        }
+        reached
+      }
+
+      // The Set of symbols of ValDefs of functions
+      val lambdas = tree.collect {
+        case core.ValDef(sym, api.Lambda(_,_,_), _) => sym
+      }.toSet
+
+      val driverFuns = funReachability(topLevRefs)
+      // highFuns0 will also contain the ambiguous ones, which we will soon eliminate
+      val highFuns0 = funReachability(combRefs)
+      val ambiguousFuns = driverFuns intersect highFuns0
+      // Create a map from the ambiguous lambdas to the newly created $high versions
+      val ambiguousFunMap = Map((ambiguousFuns map {
+        sym => sym -> api.TermSym.free(api.TermName.fresh(sym.name.toString ++ "$high"), sym.typeSignature)
+      }).toSeq: _*)
+      val newFuns = ambiguousFunMap.values
+      val highFuns = highFuns0 -- ambiguousFuns ++ newFuns
+
+      // Note that if a fun is defined inside a high lambda, then it won't be in highFuns,
+      // because of the refresh. But this is not a problem, since isHighContext will be inherited to it anyway.
+      val isHighContext: u.Tree =?> Boolean = {
+        case core.ValDef(sym, _, _) if highFuns contains sym => true
+        case api.DefCall(_, method, _, _) if combinators contains method => true
+      }
+
+      val disambiguatedTree = api.TopDown
+        .inherit(isHighContext)(Monoids.disj)
+        .transformWith {
+
+          case Attr.none(core.Let(vals, defs, expr)) =>
+            val newVals = vals flatMap { case v@core.ValDef(lhs, rhs, flags) =>
+              if (ambiguousFuns contains lhs) {
+                Seq(v, core.ValDef(ambiguousFunMap(lhs), api.Tree.refreshAll(rhs), flags))
+              } else {
+                Seq(v)
+              }
+            }
+            core.Let(newVals: _*)(defs: _*)(expr)
+
+          case Attr.inh(api.ValRef(sym), true :: _) if ambiguousFuns(sym) => api.ValRef(ambiguousFunMap(sym))
+
+        }(tree).tree
+
+      (disambiguatedTree, highFuns)
+    }
+
+  }
+}

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/comprehension/CombinationSpec.scala
@@ -36,7 +36,7 @@ class CombinationSpec extends BaseCompilerSpec {
   def applyOnce(rule: u.Tree =?> u.Tree): u.Expr[Any] => u.Tree =
     compiler.pipeline(typeCheck = true)(
       Core.lnf,
-      tree => api.TopDown.transform(rule)(tree).tree,
+      tree => time(api.TopDown.transform(rule)(tree).tree, "match rule"),
       Core.flatten
     ).compose(_.tree)
 

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/OrderSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/OrderSpec.scala
@@ -1,0 +1,189 @@
+package eu.stratosphere.emma
+package compiler.lang.core
+
+import api.DataBag
+import compiler.BaseCompilerSpec
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+/** A spec for order disambiguation. */
+@RunWith(classOf[JUnitRunner])
+class OrderSpec extends BaseCompilerSpec {
+
+  import compiler._
+
+  val liftPipeline: u.Expr[Any] => u.Tree =
+    compiler.pipeline(typeCheck = true)(
+      Core.lnf
+    ).compose(_.tree)
+
+  val dis: u.Tree => u.Tree = tree => Backend.order(tree)._1
+
+  val disamb: u.Expr[Any] => u.Tree =
+    compiler.pipeline(typeCheck = true)(
+      Core.lnf,
+      tree => time(dis(tree), "disambiguate")
+    ).compose(_.tree)
+
+  "order disambiguation" - {
+
+    "only driver" in {
+
+      val inp = u.reify {
+        val f = (x: Int) => x + 1
+        f(41)
+      }
+
+      val exp = inp
+
+      disamb(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "ambiguous" in {
+
+      val inp = u.reify {
+        val f = (x: Int) => x + 1
+        val x = f(6)
+        val b = DataBag(Seq(1))
+        b.map(f)
+      }
+
+      val exp = u.reify {
+        val f = (x: Int) => x + 1
+        val f$high = (x: Int) => x + 1
+        val x = f(6)
+        val b = DataBag(Seq(1))
+        b.map(f$high)
+      }
+
+      disamb(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "chain of lambda refs" in {
+
+      val inp = u.reify {
+        val g = (x: Int) => x + 2
+        val f = (x: Int) => x + g(4)
+        val x = g(6)
+        val b = DataBag(Seq(1))
+        b.map(f)
+      }
+
+      val exp = u.reify {
+        val g = (x: Int) => x + 2
+        val g$high = (x: Int) => x + 2
+        val f = (x: Int) => x + g$high(4)
+        val x = g(6)
+        val b = DataBag(Seq(1))
+        b.map(f)
+      }
+
+      disamb(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "long chain of lambda refs" in {
+
+      val inp = u.reify {
+        val h = (x: Int) => x + 3
+        val g = (x: Int) => h(x)
+        val f = (x: Int) => x + g(4)
+        val y = h(5)
+        val x = g(6)
+        val b = DataBag(Seq(1))
+        b.map(f)
+      }
+
+      val exp = u.reify {
+        val h = (x: Int) => x + 3
+        val h$high = (x: Int) => x + 3
+        val g = (x: Int) => h(x)
+        val g$high = (x: Int) => h$high(x)
+        val f = (x: Int) => x + g$high(4)
+        val y = h(5)
+        val x = g(6)
+        val b = DataBag(Seq(1))
+        b.map(f)
+      }
+
+      disamb(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "higher-order function executed in driver" in {
+
+      val inp = u.reify {
+        val h = (l: Int => Int) => {
+          val ir = (x: Int) => l(x)
+          ir
+        }
+        val g = (x: Int) => x + 2
+        val f = h(g)
+        val x = g(6)
+        val b = DataBag(Seq(1))
+        b.map(f)
+      }
+
+      val exp = u.reify {
+        val h = (l: Int => Int) => {
+          val ir = (x: Int) => l(x)
+          val ir$high = (x: Int) => l(x)
+          ir
+        }
+        val h$high = (l: Int => Int) => {
+          val ir = (x: Int) => l(x)
+          ir
+        }
+        val g = (x: Int) => x + 2
+        val g$high = (x: Int) => x + 2
+        val f = h$high(g$high) // Note that this is a false positive for h: ideally this should be h(g$high)
+        val x = g(6)
+        val b = DataBag(Seq(1))
+        b.map(f)
+      }
+
+      disamb(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "higher-order function called from high" in {
+
+      val inp = u.reify {
+        val h = (l: Int => Int) => {
+          val ir = (x: Int) => l(x)
+          ir
+        }
+        val m = (x: Int) => x + 3
+        val g = (x: Int) => h(m)(x)
+        val f = h(g)
+        val x = g(6)
+        val b = DataBag(Seq(1))
+        b.map(f)
+      }
+
+      val exp = u.reify {
+        val h = (l: Int => Int) => {
+          val ir = (x: Int) => l(x)
+          val ir$high = (x: Int) => l(x)
+          ir
+        }
+        val h$high = (l: Int => Int) => {
+          val ir = (x: Int) => l(x)
+          ir
+        }
+        val m = (x: Int) => x + 3
+        val m$high = (x: Int) => x + 3
+        val g = (x: Int) => {
+          val ir = h(m)
+          val ir$high = h$high(m$high)
+          ir(x)
+        }
+        val g$high = (x: Int) => h$high(m$high)(x)
+        val f = h$high(g$high) // false positive, see above
+        val x = g(6)
+        val b = DataBag(Seq(1))
+        b.map(f)
+      }
+
+      disamb(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+  }
+}


### PR DESCRIPTION
When translating to Flink or Spark, we have to know for every piece of code whether it will be executed in the driver, or in a higher-order context (UDF). This PR adds the `Order` trait to `core`, which makes this decision, and disambiguates when necessary (that is, duplicates code that might get called both from the driver and from UDFs).

Unfortunately it has some false positives, i.e. it says that some code is high, when in fact it will only be  executed in the driver, but I don't think it's worth it to spend more time now on this, because making this perfect would be very hard.