### PR TITLE
Add argument for longer filenames to maven scala plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -344,6 +344,8 @@
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
                         <arg>-Yrangepos</arg>
+                        <arg>-Xmax-classfile-name</arg>
+                        <arg>140</arg>
                         <!--<arg>-Xdisable-assertions</arg>-->
                     </args>
                 </configuration>


### PR DESCRIPTION
The project doesn't compile on Ubuntu with disk-encryption because of a long classfile name. The additional parameter fixes that.