### PR TITLE
[IR] Try compiling at the end of spec pipelines.

### DIFF
--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/ast/JavaAST.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/ast/JavaAST.scala
@@ -47,6 +47,9 @@ trait JavaAST extends AST {
   private[emma] override def inferImplicit(tpe: Type): Tree =
     tb.inferImplicitValue(tpe)
 
+  private[emma] def compile(tree: Tree) =
+    tb.compile(tree)
+
   // ------------------------
   // Abstract wrapper methods
   // ------------------------

--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/ast/Trees.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/ast/Trees.scala
@@ -72,7 +72,7 @@ trait Trees { this: AST =>
 
       /** Returns the closure of `tree` as a set. */
       def closure(tree: u.Tree): Set[u.TermSymbol] =
-        refs(tree) diff defs(tree)
+        refs(tree) diff defs(tree) filterNot (_.isStatic)
 
       /** Returns a set of all binding definitions in `tree`. */
       def bindings(tree: u.Tree): Set[u.TermSymbol] = tree.collect {

--- a/emma-examples/pom.xml
+++ b/emma-examples/pom.xml
@@ -181,24 +181,6 @@
                 </dependency>
             </dependencies>
         </profile>
-
-        <!-- profile that activates integration tests -->
-        <profile>
-            <id>IT</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>${maven-surefire-plugin.version}</version>
-                        <configuration>
-                            <!-- An empty element doesn't overwrite, so I'm using an interface here which no one will ever use -->
-                            <excludedGroups>java.io.Serializable</excludedGroups>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 
     <build>

--- a/emma-language/pom.xml
+++ b/emma-language/pom.xml
@@ -100,5 +100,12 @@
                 </executions>
             </plugin>
         </plugins>
+
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </testResource>
+        </testResources>
     </build>
 </project>

--- a/emma-language/pom.xml
+++ b/emma-language/pom.xml
@@ -63,6 +63,13 @@
             <artifactId>scalactic_${scala.tools.version}</artifactId>
         </dependency>
 
+        <!-- Auto-Resource Management -->
+        <dependency>
+            <groupId>com.jsuereth</groupId>
+            <artifactId>scala-arm_${scala.tools.version}</artifactId>
+            <version>${scala-arm.version}</version>
+        </dependency>
+
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>

--- a/emma-language/src/main/scala/eu/stratosphere/emma/compiler/Compiler.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/compiler/Compiler.scala
@@ -19,7 +19,7 @@ trait Compiler extends AlphaEq with Source with Core with Backend {
   /** The underlying universe object. */
   override val universe: Universe
 
-  /** Standard pipeline prefix. Brings a tree into form convenient for transformation. */
+  /** Standard pipeline prefix. Brings a tree into a form convenient for transformation. */
   lazy val preProcess: Seq[u.Tree => u.Tree] = Seq(
     fixLambdaTypes,
     unQualifyStatics,
@@ -28,7 +28,7 @@ trait Compiler extends AlphaEq with Source with Core with Backend {
     resolveNameClashes
   )
 
-  /** Standard pipelien suffix. Brings a tree into a form acceptable for `scalac` after being transformed. */
+  /** Standard pipeline suffix. Brings a tree into a form acceptable for `scalac` after being transformed. */
   lazy val postProcess: Seq[u.Tree => u.Tree] = Seq(
     qualifyStatics,
     api.Owner.at(get.enclosingOwner)

--- a/emma-language/src/test/resources/test_config.properties
+++ b/emma-language/src/test/resources/test_config.properties
@@ -1,0 +1,3 @@
+# Try toolbox compilation at the end of spec pipelines (can be used to catch bugs early)
+# see `BaseCompilerSpec.compileSpecPipelines`
+compile-spec-pipelines=${compile-spec-pipelines}

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/BaseCompilerSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/BaseCompilerSpec.scala
@@ -6,6 +6,7 @@ import lang.TreeMatchers
 
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FreeSpec, Matchers}
+import java.util.{Properties, UUID}
 
 /**
  * Common methods and mixins for all compier specs
@@ -20,8 +21,33 @@ trait BaseCompilerSpec extends FreeSpec with Matchers with PropertyChecks with T
   // Common transformation pipelines
   // ---------------------------------------------------------------------------
 
-  val idPipeline: u.Expr[Any] => u.Tree =
-    compiler.identity(typeCheck = true).compose(_.tree)
+  /** Checks if the given tree compiles, and returns the given tree. */
+  val checkCompile: u.Tree => u.Tree = (tree: u.Tree) => {
+    if (BaseCompilerSpec.compileSpecPipelines) {
+      val wrapped = wrapInClass(tree)
+      val showed = u.showCode(wrapped)
+      compiler.compile(parse(showed))
+      compiler.typeCheck(u.reify {}.tree) // This is a workaround for https://issues.scala-lang.org/browse/SI-9932
+    }
+    tree
+  }
+
+  val idPipeline: u.Expr[Any] => u.Tree = {
+      (_: u.Expr[Any]).tree
+    } andThen {
+      compiler.identity(typeCheck = true)
+    } andThen {
+      checkCompile
+    }
+
+  /**
+   * Combines a sequence of `transformations` into a pipeline with pre- and post-processing.
+   * If the IT maven profile is set, then it also checks if the resulting code is valid by compiling it.
+   */
+  def pipeline(typeCheck: Boolean = false, withPre: Boolean = true, withPost: Boolean = true)
+              (transformations: (u.Tree => u.Tree)*): u.Tree => u.Tree = {
+    compiler.pipeline(typeCheck, withPre, withPost)(transformations: _*) andThen checkCompile
+  }
 
   // ---------------------------------------------------------------------------
   // Common value definitions used in compiler tests
@@ -42,5 +68,44 @@ trait BaseCompilerSpec extends FreeSpec with Matchers with PropertyChecks with T
     val ret = f
     println(s"$name time: ${(System.nanoTime - s) / 1e6}ms".trim)
     ret
+  }
+
+  private def wrapInClass(tree: u.Tree): u.Tree = {
+    import universe._
+    val params = api.Tree.closure(tree).map{ sym =>
+      val name = sym.name
+      val tpt = sym.typeSignature
+      q"val $name: $tpt"
+    }
+    q"""
+      class ${api.TypeName(UUID.randomUUID().toString)} {
+        def run(..$params) = {
+          $tree
+        }
+      }
+     """
+  }
+}
+
+object BaseCompilerSpec {
+
+  import resource._
+
+  val configLocation = "/test_config.properties"
+
+  /**
+   * Whether spec pipelines should try a toolbox compilation at the end, to potentially catch more bugs.
+   * (Set by the IT maven profile; makes specs run about 5 times slower.)
+   */
+  lazy val compileSpecPipelines = props
+    .getProperty("compile-spec-pipelines")
+    .toBoolean
+
+  lazy val props = {
+    val p = new Properties()
+    for {
+      r <- managed(classOf[BaseCompilerSpec].getResourceAsStream(configLocation))
+    } p.load(r)
+    p
   }
 }

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/comprehension/CombinationSpec.scala
@@ -22,19 +22,19 @@ class CombinationSpec extends BaseCompilerSpec {
   // ---------------------------------------------------------------------------
 
   val liftPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf
     ).compose(_.tree)
 
   val combine: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       tree => time(Comprehension.combine(tree), "combine"),
       Core.flatten
     ).compose(_.tree)
 
   def applyOnce(rule: u.Tree =?> u.Tree): u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       tree => time(api.TopDown.transform(rule)(tree).tree, "match rule"),
       Core.flatten
@@ -455,7 +455,6 @@ class CombinationSpec extends BaseCompilerSpec {
           }
         }
       }
-
 
       applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/comprehension/NormalizeSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/comprehension/NormalizeSpec.scala
@@ -18,20 +18,20 @@ class NormalizeSpec extends BaseCompilerSpec {
   import compiler._
 
   val lnfPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       Core.inlineLetExprs
     ).compose(_.tree)
 
   val resugarPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       Comprehension.resugar(API.bagSymbol),
       Core.inlineLetExprs
     ).compose(_.tree)
 
   val normalizePipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       Comprehension.resugar(API.bagSymbol),
       Core.inlineLetExprs,

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/comprehension/ReDeSugarSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/comprehension/ReDeSugarSpec.scala
@@ -20,13 +20,13 @@ class ReDeSugarSpec extends BaseCompilerSpec {
   // ---------------------------------------------------------------------------
 
   val anfPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf
     ).compose(_.tree)
 
   val resugarPipeline: u.Expr[Any] => u.Tree = {
     val resugar = Comprehension.resugar(API.bagSymbol)
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       tree => time(resugar(tree), "resugar")
     ).compose(_.tree)
@@ -34,7 +34,7 @@ class ReDeSugarSpec extends BaseCompilerSpec {
 
   val desugarPipeline: u.Expr[Any] => u.Tree = {
     val desugar = Comprehension.desugar(API.bagSymbol)
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       tree => time(desugar(tree), "desugar")
     ).compose(_.tree)

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/ANFSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/ANFSpec.scala
@@ -17,7 +17,7 @@ class ANFSpec extends BaseCompilerSpec {
   import compiler._
   
   val anfPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       tree => time(ANF.transform(tree), "anf")
     ).compose(_.tree)
 

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/CSESpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/CSESpec.scala
@@ -16,13 +16,13 @@ class CSESpec extends BaseCompilerSpec {
   import compiler._
 
   val csePipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       tree => time(Core.cse(tree), "cse")
     ).compose(_.tree)
 
   val lnfPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf
     ).compose(_.tree)
 

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/DCESpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/DCESpec.scala
@@ -13,7 +13,7 @@ class DCESpec extends BaseCompilerSpec {
   import compiler._
 
   val dcePipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       tree => time(DCE.transform(tree), "dce")
     ).compose(_.tree)

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/DSCFSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/DSCFSpec.scala
@@ -13,13 +13,13 @@ class DSCFSpec extends BaseCompilerSpec {
   import compiler._
 
   val dscfPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.anf,
       tree => time(DSCF.transform(tree), "dscf")
     ).compose(_.tree)
 
   val anfPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.anf
     ).compose(_.tree)
 

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/OrderSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/OrderSpec.scala
@@ -13,14 +13,14 @@ class OrderSpec extends BaseCompilerSpec {
   import compiler._
 
   val liftPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf
     ).compose(_.tree)
 
   val dis: u.Tree => u.Tree = tree => Backend.order(tree)._1
 
   val disamb: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       tree => time(dis(tree), "disambiguate")
     ).compose(_.tree)

--- a/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/PrettyPrintSpec.scala
+++ b/emma-language/src/test/scala/eu/stratosphere/emma/compiler/lang/core/PrettyPrintSpec.scala
@@ -19,7 +19,7 @@ class PrettyPrintSpec extends BaseCompilerSpec {
   import Core.{Lang => core}
 
   val liftPipeline: u.Expr[Any] => u.Tree =
-    compiler.pipeline(typeCheck = true)(
+    pipeline(typeCheck = true)(
       Core.lnf,
       Core.inlineLetExprs
     ) andThen unQualifyStatics compose (_.tree)

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,9 @@
         <reflections.version>0.9.9</reflections.version>
         <scala.graph-core.version>1.9.0</scala.graph-core.version>
         <scala-arm.version>1.4</scala-arm.version>
+
+        <!-- Test configuration -->
+        <compile-spec-pipelines>false</compile-spec-pipelines>
     </properties>
 
     <!-- Enable Apache Development Snapshot Repository -->
@@ -301,6 +304,31 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
+    <profiles>
+        <!-- Profile that activates integration tests and compile-spec-pipelines -->
+        <profile>
+            <id>IT</id>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-surefire-plugin</artifactId>
+                            <version>${maven-surefire-plugin.version}</version>
+                            <configuration>
+                                <!-- An empty element doesn't overwrite, so I'm using an interface here which no one will ever use -->
+                                <excludedGroups>java.io.Serializable</excludedGroups>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+            <properties>
+                <compile-spec-pipelines>true</compile-spec-pipelines>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>


### PR DESCRIPTION
This can be enabled by the IT maven profile. Makes specs run about 4 times slower.

Modified Tree.closure to not return statics.