### PR TITLE
Add CSV support to the new DataBag API

### DIFF
--- a/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/ConvertersMacros.scala
+++ b/emma-common-macros/src/main/scala/eu/stratosphere/emma/macros/ConvertersMacros.scala
@@ -13,10 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.emmalanguage
-package macros
+package eu.stratosphere.emma.macros
 
-import ast.MacroAST
+import org.emmalanguage.ast.MacroAST
 
 import scala.reflect.macros.blackbox
 

--- a/emma-common/pom.xml
+++ b/emma-common/pom.xml
@@ -50,6 +50,13 @@
             <artifactId>emma-common-macros</artifactId>
         </dependency>
 
+        <!-- Auto-Resource Management -->
+        <dependency>
+            <groupId>com.jsuereth</groupId>
+            <artifactId>scala-arm_${scala.tools.version}</artifactId>
+            <version>${scala-arm.version}</version>
+        </dependency>
+
         <!-- HDFS -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/emma-common/src/main/scala/eu/stratosphere/emma/api/package.scala
+++ b/emma-common/src/main/scala/eu/stratosphere/emma/api/package.scala
@@ -20,7 +20,7 @@ import java.net.URI
 
 import eu.stratosphere.emma.api.model.Identity
 import eu.stratosphere.emma.macros.Folds
-import org.emmalanguage.macros.ConvertersMacros
+import eu.stratosphere.emma.macros.ConvertersMacros
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.{FileSystem, Path}
 

--- a/emma-common/src/main/scala/org/emmalanguage/api/DataBag.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/api/DataBag.scala
@@ -16,6 +16,8 @@
 package org.emmalanguage
 package api
 
+import io.csv.{CSV, CSVConverter}
+
 /** An abstraction for homogeneous distributed collections. */
 trait DataBag[A] extends Serializable {
 
@@ -127,6 +129,15 @@ trait DataBag[A] extends Serializable {
   // -----------------------------------------------------
 
   /**
+   * Writes a DataBag into the specified `path` in a CSV format.
+   *
+   * @param path      The location where the data will be written.
+   * @param format    The CSV format configuration
+   * @param converter A converter to use for element serialization.
+   */
+  def writeCSV(path: String, format: CSV)(implicit converter: CSVConverter[A]): Unit
+
+  /**
    * Converts a DataBag abstraction back into a scala sequence.
    *
    * @return The contents of the DataBag as a scala sequence.
@@ -135,6 +146,10 @@ trait DataBag[A] extends Serializable {
 }
 
 object DataBag {
+
+  // -----------------------------------------------------
+  // Constructors & Sources
+  // -----------------------------------------------------
 
   /**
    * Empty constructor.
@@ -152,4 +167,13 @@ object DataBag {
    * @return A DataBag containing the elements of the `values` sequence.
    */
   def apply[A: Meta](values: Seq[A]): DataBag[A] = ScalaTraversable(values)
+
+  /**
+   * Reads a DataBag into the specified `path` using in a CSV format.
+   *
+   * @param path   The location where the data will be read from.
+   * @param format The CSV format configuration.
+   * @tparam A the type of elements to read.
+   */
+  def readCSV[A: Meta : CSVConverter](path: String, format: CSV): DataBag[A] = ScalaTraversable.readCSV[A](path, format)
 }

--- a/emma-common/src/main/scala/org/emmalanguage/api/package.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/api/package.scala
@@ -15,6 +15,7 @@
  */
 package org.emmalanguage
 
+import io.csv.{CSVConverter, CSVConverterMacro}
 import eu.stratosphere.emma.macros.Folds
 
 import scala.reflect.ClassTag
@@ -35,7 +36,7 @@ package object api {
     def ttag: TypeTag[T]
   }
 
-  implicit def typeMeta[T : ClassTag : TypeTag] = new Meta[T] {
+  implicit def meta[T : ClassTag : TypeTag] = new Meta[T] {
     override def ctag = implicitly[ClassTag[T]]
     override def ttag = implicitly[TypeTag[T]]
   }
@@ -100,6 +101,9 @@ package object api {
    */
   implicit final class DataBagFolds[A] private[api](val self: DataBag[A])
     extends AnyVal with Folds[A]
+
+  implicit def materializeCSVConverter[T]: CSVConverter[T] =
+    macro CSVConverterMacro.materialize[T]
 
   def comparing[A](lt: (A, A) => Boolean): Ordering[A] =
     Ordering.fromLessThan(lt)

--- a/emma-common/src/main/scala/org/emmalanguage/io/Format.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/io/Format.scala
@@ -14,24 +14,7 @@
  * limitations under the License.
  */
 package org.emmalanguage
-package api
+package io
 
-import io.csv.{CSV, CSVConverter}
-
-class ScalaTraversableSpec extends DataBagSpec {
-
-  override type Bag[A] = ScalaTraversable[A]
-  override type BackendContext = Unit
-
-  override def withBackendContext[T](f: BackendContext => T): T =
-    f(Unit)
-
-  override def Bag[A: Meta](implicit unit: BackendContext): Bag[A] =
-    ScalaTraversable[A]
-
-  override def Bag[A: Meta](seq: Seq[A])(implicit unit: BackendContext): Bag[A] =
-    ScalaTraversable(seq)
-
-  override def readCSV[A: Meta : CSVConverter](path: String, format: CSV)(implicit unit: BackendContext): DataBag[A] =
-    ScalaTraversable.readCSV(path, format)
-}
+/** An abstract trait implemented by all supported formats. */
+trait Format extends Product

--- a/emma-common/src/main/scala/org/emmalanguage/io/ScalaSupport.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/io/ScalaSupport.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.{FileSystem, Path => HadoopPath}
+
+import java.io._
+import java.net.URI
+import java.nio.file.Paths
+
+/** An abstract interface for local IO support. */
+abstract class ScalaSupport[A, F <: Format] {
+
+  import ScalaSupport.hdfs
+
+  /** The concrete class of the underlying format. */
+  def format: F
+
+  /** Invoked by the `read` methods of local [[api.DataBag]] implementations. */
+  private[emmalanguage] def read(path: String): TraversableOnce[A]
+
+  /** Invoked by the `write` methods of local [[api.DataBag]] implementations. */
+  private[emmalanguage] def write(path: String)(xs: Traversable[A]): Unit
+
+  protected def inpStream(uri: URI): InputStream = uri.getScheme match {
+    case "hdfs" =>
+      val path = new HadoopPath(uri)
+      hdfs.open(path)
+    case _ =>
+      val path = Paths.get(uri)
+      new FileInputStream(path.toFile)
+  }
+
+  protected def outStream(uri: URI): OutputStream = uri.getScheme match {
+    case "hdfs" =>
+      val path = new HadoopPath(uri)
+      hdfs.create(path, true)
+    case _ =>
+      val path = Paths.get(uri)
+      deleteRecursive(path.toFile)
+      new FileOutputStream(path.toFile)
+  }
+
+  protected def deleteRecursive(path: File): Boolean = {
+    val ret = if (path.isDirectory) {
+      path.listFiles().toSeq.foldLeft(true)((r, f) => deleteRecursive(f))
+    } else /* regular file */ {
+      true
+    }
+    ret && path.delete()
+  }
+}
+
+private object ScalaSupport {
+
+  /** A local instance of the Hadoop file system. */
+  lazy val hdfs = FileSystem.get(new Configuration())
+
+}

--- a/emma-common/src/main/scala/org/emmalanguage/io/csv/CSV.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/io/csv/CSV.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.csv
+
+import io.Format
+
+import java.nio.charset.{Charset, StandardCharsets}
+
+import CSV._
+
+/** CSV format. */
+case class CSV
+(
+  //@formatter:off
+  header    : Boolean      = DEFAULT_HEADER,     // Indicate the presence of a CSV header (to be ignored)
+  delimiter : Char         = DEFAULT_DELIMITER,  // Column delimiter character
+  charset   : Charset      = DEFAULT_CHARSET,    // Character set
+  quote     : Option[Char] = DEFAULT_QUOTE,      // Delimiters inside quotes are ignored
+  escape    : Option[Char] = DEFAULT_ESCAPE,     // Escaped quote characters are ignored
+  comment   : Option[Char] = DEFAULT_COMMENT,    // Disable comments by setting this to None
+  nullValue : String       = DEFAULT_NULLVALUE   // Fields matching this string will be set as nulls
+  //@formatter:on
+) extends Format
+
+object CSV {
+  //@formatter:off
+  val DEFAULT_HEADER       = false
+  val DEFAULT_DELIMITER    = '\t'
+  val DEFAULT_CHARSET      = StandardCharsets.UTF_8
+  val DEFAULT_QUOTE        = Some('"')
+  val DEFAULT_ESCAPE       = Some('\\')
+  val DEFAULT_COMMENT      = None
+  val DEFAULT_NULLVALUE    = ""
+  //@formatter:on
+}

--- a/emma-common/src/main/scala/org/emmalanguage/io/csv/CSVConverter.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/io/csv/CSVConverter.scala
@@ -14,24 +14,27 @@
  * limitations under the License.
  */
 package org.emmalanguage
-package api
+package io.csv
 
-import io.csv.{CSV, CSVConverter}
+/** Serialization format for encoding to / decoding from CSV records. */
+trait CSVConverter[T] {
 
-class ScalaTraversableSpec extends DataBagSpec {
+  /** Parses and returns the value encoded in `record`. */
+  def from(record: Array[String]): T
 
-  override type Bag[A] = ScalaTraversable[A]
-  override type BackendContext = Unit
+  /** Serializes `value` using `sep` as field delimiter. */
+  def to(value: T): Array[String]
+}
 
-  override def withBackendContext[T](f: BackendContext => T): T =
-    f(Unit)
+object CSVConverter {
 
-  override def Bag[A: Meta](implicit unit: BackendContext): Bag[A] =
-    ScalaTraversable[A]
+  def apply[T](_from: Array[String] => T)(_to: T => Array[String]): CSVConverter[T] =
+    new CSVConverter[T] {
 
-  override def Bag[A: Meta](seq: Seq[A])(implicit unit: BackendContext): Bag[A] =
-    ScalaTraversable(seq)
+      override def from(record: Array[String]): T =
+        _from(record)
 
-  override def readCSV[A: Meta : CSVConverter](path: String, format: CSV)(implicit unit: BackendContext): DataBag[A] =
-    ScalaTraversable.readCSV(path, format)
+      override def to(value: T): Array[String] =
+        _to(value)
+    }
 }

--- a/emma-common/src/main/scala/org/emmalanguage/io/csv/CSVConverterMacro.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/io/csv/CSVConverterMacro.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.csv
+
+import ast.MacroAST
+
+import scala.reflect.macros.blackbox
+
+/** Automatic derivation of CSV encoding / decoding for primitives and [[scala.Product]] types. */
+// TODO: add DateTime support
+class CSVConverterMacro(val c: blackbox.Context) extends MacroAST {
+
+  import universe._
+  import api.Type._
+
+  private val iter = api.TermName.fresh("iter")
+  private val const = q"${api.Tree.Scala}.Function.const"
+  private val seq = q"${api.Tree.Scala}.collection.Seq"
+  private val emma = q"_root_.org.emmalanguage"
+
+  def materialize[T: c.WeakTypeTag] = api.Type.check {
+    val T = api.Type.weak[T]
+    val value = api.TermName.fresh("value")
+
+    val from =
+      q"""
+        ($value: ${arrayOf(string)}) => {
+          val $iter = $value.iterator
+          ${fromCSV(T, q"$iter.next")}
+        }
+       """
+
+    val to =
+      q"""
+        ($value: $T) => {
+          ${toCSV(T, q"$value")}.toArray
+        }
+       """
+
+    q"""$emma.io.csv.CSVConverter[$T]($from)($to)"""
+  }
+
+  def fromCSV(T: Type, value: Tree): Tree =
+    if (T <:< api.Type[Product]) {
+      val method = T.decl(api.TermName.init).alternatives.head.asMethod
+      val params = method.typeSignatureIn(T).paramLists.head
+      val args = for (p <- params) yield fromCSV(api.Type.of(p), value)
+      q"new $T(..$args)"
+    } else {
+      if (T =:= unit || T =:= Java.void) api.Term.unit
+      else if (T =:= bool || T =:= Java.bool) q"$value.toBoolean"
+      else if (T =:= char || T =:= Java.char) q"$value.head"
+      else if (T =:= byte || T =:= Java.byte) q"$value.toByte"
+      else if (T =:= short || T =:= Java.short) q"$value.toShort"
+      else if (T =:= int || T =:= Java.int) q"$value.toInt"
+      else if (T =:= long || T =:= Java.long) q"$value.toLong"
+      else if (T =:= float || T =:= Java.float) q"$value.toFloat"
+      else if (T =:= double || T =:= Java.double) q"$value.toDouble"
+      else if (T =:= bigInt) q"${api.Tree.Scala}.BigInt($value)"
+      else if (T =:= bigDec) q"${api.Tree.Scala}.BigDecimal($value)"
+      else if (T =:= Java.bigInt) q"new ${api.Tree.Java}.math.BigInteger($value)"
+      else if (T =:= Java.bigDec) q"new ${api.Tree.Java}.math.BigDecimal($value)"
+      else if (T =:= string) q"$value"
+      else q"$const(null.asInstanceOf[$T])($value)"
+    }
+
+  def toCSV(T: Type, value: Tree): Tree = {
+    if (T <:< api.Type[Product]) {
+      val method = T.decl(api.TermName.init).alternatives.head.asMethod
+      val params = method.typeSignatureIn(T).paramLists.head
+      val fields = for {
+        param <- params
+        method <- T.members
+        if method.isMethod
+        if method.asMethod.isGetter
+        if method.toString == param.toString
+      } yield toCSV(api.Type.result(method.infoIn(T)), q"$value.$method")
+
+      q"$seq(..$fields).flatten"
+    } else {
+      q"$seq($value.toString)"
+    }
+  }
+}

--- a/emma-common/src/main/scala/org/emmalanguage/io/csv/CSVScalaSupport.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/io/csv/CSVScalaSupport.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.csv
+
+import io.{Format, ScalaSupport}
+
+import au.com.bytecode.opencsv.{CSVReader, CSVWriter}
+import resource._
+
+import scala.language.experimental.macros
+
+import java.io._
+import java.net.URI
+
+/** A [[ScalaSupport]] implementation for the [[CSV]] [[Format]]. */
+class CSVScalaSupport[A: CSVConverter](override val format: CSV) extends ScalaSupport[A, CSV] {
+
+  override private[emmalanguage] def read(path: String): TraversableOnce[A] =
+    new Traversable[A] {
+
+      val conv = implicitly[CSVConverter[A]]
+
+      override def foreach[U](f: (A) => U): Unit =
+        for {
+          inp <- managed(inpStream(new URI(path)))
+          bis <- managed(new BufferedInputStream(inp))
+          isr <- managed(new InputStreamReader(bis, format.charset))
+          csv <- managed(new CSVReader(isr, format.delimiter, quoteChar(format), escapeChar(format)))
+        } {
+          var r = csv.readNext()
+          while (r != null) {
+            f(conv.from(r))
+            r = csv.readNext()
+          }
+        }
+    }
+
+  override private[emmalanguage] def write(path: String)(xs: Traversable[A]): Unit =
+    for {
+      out <- managed(outStream(new URI(path)))
+      bos <- managed(new BufferedOutputStream(out))
+      osw <- managed(new OutputStreamWriter(bos, format.charset))
+      csv <- managed(new CSVWriter(osw, format.delimiter, quoteChar(format), escapeChar(format)))
+    } {
+
+      val conv = implicitly[CSVConverter[A]]
+
+      for (x <- xs) {
+        val r = conv.to(x)
+        csv.writeNext(r)
+      }
+    }
+
+  // ---------------------------------------------------------------------------
+  // Helper functions for reading
+  // ---------------------------------------------------------------------------
+
+  private def quoteChar(format: CSV): Char =
+    format.quote.getOrElse(CSVWriter.NO_QUOTE_CHARACTER)
+
+  private def escapeChar(format: CSV): Char =
+    format.escape.getOrElse(CSVWriter.NO_ESCAPE_CHARACTER)
+}
+
+/** Companion object. */
+object CSVScalaSupport {
+
+  def apply[A: CSVConverter](format: CSV): CSVScalaSupport[A] =
+    new CSVScalaSupport[A](format)
+}

--- a/emma-common/src/main/scala/org/emmalanguage/io/parquet/Parquet.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/io/parquet/Parquet.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.parquet
+
+import io.Format
+
+import java.nio.charset.{Charset, StandardCharsets}
+
+/** CSV format. */
+case class Parquet
+(
+  //@formatter:off
+  header    : Boolean      = false,                  // Indicate the presence of a CSV header (to be ignored)
+  delimiter : Char         = '\t',                   // Column delimiter character
+  charset   : Charset      = StandardCharsets.UTF_8, // Character set
+  quote     : Option[Char] = Some('"'),              // Delimiters inside quotes are ignored
+  escape    : Option[Char] = Some('\\'),             // Escaped quote characters are ignored
+  comment   : Option[Char] = Some('#'),              // Disable comments by setting this to None
+  nullValue : String       = ""                      // Fields matching this string will be set as nulls
+  //@formatter:on
+) extends Format

--- a/emma-common/src/main/scala/org/emmalanguage/util/Toolbox.scala
+++ b/emma-common/src/main/scala/org/emmalanguage/util/Toolbox.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package util
+
+import scala.tools.reflect.ToolBox
+
+private[emmalanguage] object Toolbox {
+
+  import java.nio.file.{Files, Paths}
+
+  final private lazy val codeGenDirDefault = Paths
+    .get(sys.props("java.io.tmpdir"), "emma", "codegen")
+    .toAbsolutePath.toString
+
+  /** The directory where the toolbox will store runtime-generated code. */
+  final private lazy val codeGenDir = {
+    val path = Paths.get(sys.props.getOrElse("emma.codegen.dir", codeGenDirDefault))
+    // Make sure that generated class directory exists
+    Files.createDirectories(path)
+    path.toAbsolutePath.toString
+  }
+
+  final val mirror = scala.reflect.runtime.currentMirror
+
+  final val universe = mirror.universe
+
+  final lazy val toolbox = mirror.mkToolBox(options = s"-d $codeGenDir")
+
+}

--- a/emma-common/src/test/scala/org/emmalanguage/api/DataBagSpec.scala
+++ b/emma-common/src/test/scala/org/emmalanguage/api/DataBagSpec.scala
@@ -53,7 +53,7 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
   // ---------------------------------------------------------------------------
 
   "structural recursion" in {
-    withBackendContext { implicit sc =>
+    withBackendContext { implicit ctx =>
       val act = {
         val xs = Bag(hhCrts)
         val ys = Bag(hhCrts.map(DataBagSpec.f))
@@ -121,7 +121,7 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
   "monad ops" - {
 
     "map" in {
-      withBackendContext { implicit sc =>
+      withBackendContext { implicit ctx =>
         val act = Bag(hhCrts)
           .map(c => c.name)
 
@@ -133,7 +133,7 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
     }
 
     "flatMap" in {
-      withBackendContext { implicit sc =>
+      withBackendContext { implicit ctx =>
         val act = Bag(Seq((hhBook, hhCrts)))
           .flatMap { case (b, cs) => DataBag(cs) }
 
@@ -157,7 +157,7 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
     }
 
     "for-comprehensions" in {
-      withBackendContext { implicit sc =>
+      withBackendContext { implicit ctx =>
         val act = for {
           b <- Bag(Seq(hhBook))
           c <- ScalaTraversable(hhCrts) // nested DataBag cannot be RDDDataBag, as those are not serializable
@@ -178,7 +178,7 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
   }
 
   "grouping" in {
-    withBackendContext { implicit sc =>
+    withBackendContext { implicit ctx =>
       val act = Bag(hhCrts).groupBy(_.book)
 
       val exp = hhCrts.groupBy(_.book).toSeq.map {
@@ -195,7 +195,7 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
     val ys = Seq("fuu", "bin", "bar", "bur", "lez", "liz", "lag")
 
     "union" in {
-      withBackendContext { implicit sc =>
+      withBackendContext { implicit ctx =>
         val act = Bag(xs) union Bag(ys)
         val exp = xs union ys
 
@@ -204,7 +204,7 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
     }
 
     "distinct" in {
-      withBackendContext { implicit sc =>
+      withBackendContext { implicit ctx =>
         val acts = Seq(Bag(xs).distinct, Bag(ys).distinct)
         val exps = Seq(xs.distinct, ys.distinct)
 

--- a/emma-common/src/test/scala/org/emmalanguage/api/DataBagSpec.scala
+++ b/emma-common/src/test/scala/org/emmalanguage/api/DataBagSpec.scala
@@ -16,7 +16,7 @@
 package org.emmalanguage
 package api
 
-import testschema.Literature._
+import test.schema.Literature._
 
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FreeSpec, Matchers}

--- a/emma-common/src/test/scala/org/emmalanguage/test/schema/Literature.scala
+++ b/emma-common/src/test/scala/org/emmalanguage/test/schema/Literature.scala
@@ -14,11 +14,22 @@
  * limitations under the License.
  */
 package org.emmalanguage
-package testschema
+package test.schema
 
-/** A simple domain for mathematical analysis. */
-object Math {
+object Literature {
 
-  case class Point(x: Int, y: Int)
+  case class Book(title: String, author: String)
 
+  case class Character(name: String, book: Book)
+
+  // ---------------------------------------------------------------------------
+  // The Hitchhiker's Guide to the Galaxy
+  // ---------------------------------------------------------------------------
+
+  val hhBook = Book("The Hitchhiker's Guide to the Galaxy", "Douglas Adams")
+
+  val hhCrts = Seq(
+    Character("Arthur Dent", hhBook),
+    Character("Zaphod Beeblebrox", hhBook),
+    Character("Prostetnic Vogon Jeltz", hhBook))
 }

--- a/emma-common/src/test/scala/org/emmalanguage/test/schema/Marketing.scala
+++ b/emma-common/src/test/scala/org/emmalanguage/test/schema/Marketing.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 package org.emmalanguage
-package testschema
+package test.schema
 
 import java.time.Instant
 

--- a/emma-common/src/test/scala/org/emmalanguage/test/schema/Math.scala
+++ b/emma-common/src/test/scala/org/emmalanguage/test/schema/Math.scala
@@ -14,22 +14,11 @@
  * limitations under the License.
  */
 package org.emmalanguage
-package testschema
+package test.schema
 
-object Literature {
+/** A simple domain for mathematical analysis. */
+object Math {
 
-  case class Book(title: String, author: String)
+  case class Point(x: Int, y: Int)
 
-  case class Character(name: String, book: Book)
-
-  // ---------------------------------------------------------------------------
-  // The Hitchhiker's Guide to the Galaxy
-  // ---------------------------------------------------------------------------
-
-  val hhBook = Book("The Hitchhiker's Guide to the Galaxy", "Douglas Adams")
-
-  val hhCrts = Seq(
-    Character("Arthur Dent", hhBook),
-    Character("Zaphod Beeblebrox", hhBook),
-    Character("Prostetnic Vogon Jeltz", hhBook))
 }

--- a/emma-common/src/test/scala/org/emmalanguage/test/util.scala
+++ b/emma-common/src/test/scala/org/emmalanguage/test/util.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package test
+
+import org.apache.commons.io.FilenameUtils
+import resource._
+
+import java.nio.file.{Files, Paths, StandardCopyOption}
+
+object util {
+
+  def basePath =
+    s"${System.getProperty("java.io.tmpdir")}/emma"
+
+  /**
+   * Copies the resource located at the given path to the emma temp folder.
+   *
+   * @param resourcePath The resource to be copied
+   * @return The path to the materialized version of the resource.
+   */
+  def materializeResource(resourcePath: String) = (for {
+    is <- managed(getClass.getResourceAsStream(resourcePath))
+  } yield {
+    val outputPath = Paths.get(s"$basePath/$resourcePath")
+    Files.createDirectories(outputPath.getParent)
+    Files.copy(is, outputPath, StandardCopyOption.REPLACE_EXISTING)
+
+    outputPath.toString
+  }).acquireAndGet(identity)
+
+  /** Creates a demp output path with the given `suffix`. */
+  def tempPath(suffix: String) = FilenameUtils
+    .separatorsToUnix(Paths.get(s"$basePath/$suffix").toString)
+
+  /**
+   * Reads The contents from file (or folder containing a list of files) as a string.
+   *
+   * @param path The path of the file (or folder containing a list of files) to be read.
+   * @return A sorted list of the read contents.
+   */
+  def fromPath(path: String): List[String] = fromPath(new java.io.File(path))
+
+  /**
+   * Reads The contents from file (or folder containing a list of files) as a string.
+   *
+   * @param path The path of the file (or folder containing a list of files) to be read.
+   * @return A sorted list of the read contents.
+   */
+  def fromPath(path: java.io.File): List[String] = {
+    val entries =
+      if (path.isDirectory) path.listFiles.filter(x => !(x.getName.startsWith(".") || x.getName.startsWith("_")))
+      else Array(path)
+    (entries flatMap (x => scala.io.Source.fromFile(x.getAbsolutePath).getLines().toStream.toList)).toList.sorted
+  }
+
+  /** Deletes a file recursively. */
+  def deleteRecursive(path: java.io.File): Boolean = {
+    val ret = if (path.isDirectory) {
+      path.listFiles().toSeq.foldLeft(true)((r, f) => deleteRecursive(f))
+    } else /* regular file */ {
+      true
+    }
+    ret && path.delete()
+  }
+}

--- a/emma-examples/pom.xml
+++ b/emma-examples/pom.xml
@@ -128,12 +128,6 @@
             <artifactId>reflections</artifactId>
         </dependency>
 
-        <!-- Auto-Resource Management -->
-        <dependency>
-            <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_${scala.tools.version}</artifactId>
-        </dependency>
-
         <!-- Breeze -->
         <dependency>
             <groupId>org.scalanlp</groupId>

--- a/emma-flink/src/test/scala/org/emmalanguage/api/FlinkDataSetSpec.scala
+++ b/emma-flink/src/test/scala/org/emmalanguage/api/FlinkDataSetSpec.scala
@@ -16,19 +16,24 @@
 package org.emmalanguage
 package api
 
-import org.apache.flink.api.scala.ExecutionEnvironment
+import org.emmalanguage.io.csv.{CSV, CSVConverter}
+
+import org.apache.flink.api.scala.{ExecutionEnvironment => FlinkEnv}
 
 class FlinkDataSetSpec extends DataBagSpec {
 
   override type Bag[A] = FlinkDataSet[A]
-  override type BackendContext = ExecutionEnvironment
+  override type BackendContext = FlinkEnv
 
   override def withBackendContext[T](f: BackendContext => T): T =
-    f(ExecutionEnvironment.getExecutionEnvironment)
+    f(FlinkEnv.getExecutionEnvironment)
 
-  override def Bag[A: Meta](implicit flink: ExecutionEnvironment): Bag[A] =
+  override def Bag[A: Meta](implicit flink: FlinkEnv): Bag[A] =
     FlinkDataSet[A]
 
-  override def Bag[A: Meta](seq: Seq[A])(implicit flink: ExecutionEnvironment): Bag[A] =
+  override def Bag[A: Meta](seq: Seq[A])(implicit flink: FlinkEnv): Bag[A] =
     FlinkDataSet(seq)
+
+  override def readCSV[A: Meta : CSVConverter](path: String, format: CSV)(implicit flink: FlinkEnv): DataBag[A] =
+    FlinkDataSet.readCSV(path, format)
 }

--- a/emma-language/pom.xml
+++ b/emma-language/pom.xml
@@ -80,13 +80,6 @@
             <artifactId>scalactic_${scala.tools.version}</artifactId>
         </dependency>
 
-        <!-- Auto-Resource Management -->
-        <dependency>
-            <groupId>com.jsuereth</groupId>
-            <artifactId>scala-arm_${scala.tools.version}</artifactId>
-            <version>${scala-arm.version}</version>
-        </dependency>
-
         <!-- Test -->
         <dependency>
             <groupId>junit</groupId>

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
@@ -20,7 +20,7 @@ import eu.stratosphere.emma.api.DataBag
 import compiler.BaseCompilerSpec
 import compiler.ir.ComprehensionSyntax._
 import compiler.ir.ComprehensionCombinators._
-import testschema.Marketing._
+import test.schema.Marketing._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/NormalizeSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/NormalizeSpec.scala
@@ -19,7 +19,7 @@ package compiler.lang.comprehension
 import eu.stratosphere.emma.api.DataBag
 import compiler.BaseCompilerSpec
 import compiler.ir.ComprehensionSyntax._
-import testschema.Marketing._
+import test.schema.Marketing._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugarSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugarSpec.scala
@@ -19,7 +19,7 @@ package compiler.lang.comprehension
 import eu.stratosphere.emma.api.DataBag
 import compiler.BaseCompilerSpec
 import compiler.ir.ComprehensionSyntax._
-import testschema.Marketing._
+import test.schema.Marketing._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/ANFSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/ANFSpec.scala
@@ -19,8 +19,8 @@ package compiler.lang.core
 import eu.stratosphere.emma.api.DataBag
 import compiler.BaseCompilerSpec
 import compiler.ir.ComprehensionSyntax._
-import testschema.Marketing._
-import testschema.Math._
+import test.schema.Marketing._
+import test.schema.Math._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/CSESpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/CSESpec.scala
@@ -19,7 +19,7 @@ package compiler.lang.core
 import compiler.BaseCompilerSpec
 import compiler.ir.ComprehensionSyntax._
 import eu.stratosphere.emma.api.DataBag
-import testschema.Literature._
+import test.schema.Literature._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/LanguageSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/LanguageSpec.scala
@@ -18,7 +18,7 @@ package compiler.lang.core
 
 import eu.stratosphere.emma.api._
 import compiler.BaseCompilerSpec
-import testschema.Marketing._
+import test.schema.Marketing._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/PrettyPrintSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/PrettyPrintSpec.scala
@@ -19,7 +19,7 @@ package compiler.lang.core
 import eu.stratosphere.emma.api.{DataBag, emma}
 import compiler.ir.ComprehensionSyntax._
 import compiler.BaseCompilerSpec
-import testschema.Marketing._
+import test.schema.Marketing._
 
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/LanguageSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/LanguageSpec.scala
@@ -19,7 +19,7 @@ package lang
 package source
 
 import eu.stratosphere.emma.api.DataBag
-import testschema.Marketing._
+import test.schema.Marketing._
 
 import org.example.foo.{Bar, Baz}
 import org.junit.runner.RunWith

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
@@ -16,15 +16,18 @@
 package org.emmalanguage
 package api
 
-import org.apache.spark.SparkContext
+import io.csv.{CSV, CSVConverter}
+
 import org.apache.spark.rdd._
+import org.apache.spark.sql.SparkSession
 
 import scala.language.{higherKinds, implicitConversions}
 
 /** A `DataBag` implementation backed by a Spark `RDD`. */
-class SparkRDD[A: Meta] private[api](@transient private val rep: RDD[A]) extends DataBag[A] {
+class SparkRDD[A: Meta] private[api](@transient private val rep: RDD[A])(implicit spark: SparkSession)
+  extends DataBag[A] {
 
-  import SparkRDD.wrap
+  import SparkRDD.{encoderForType, wrap}
 
   // -----------------------------------------------------
   // Structural recursion
@@ -68,18 +71,56 @@ class SparkRDD[A: Meta] private[api](@transient private val rep: RDD[A]) extends
   // Sinks
   // -----------------------------------------------------
 
+  override def writeCSV(path: String, format: CSV)(implicit converter: CSVConverter[A]): Unit = {
+    spark
+      .createDataset(rep).write
+      .option("header", format.header)
+      .option("delimiter", format.delimiter)
+      .option("quote", format.quote.getOrElse('"').toString)
+      .option("escape", format.escape.getOrElse('\\').toString)
+      .option("nullValue", format.nullValue)
+      .mode("overwrite")
+      .csv(path)
+  }
+
   def fetch(): Seq[A] =
     rep.collect()
 }
 
 object SparkRDD {
 
-  implicit def wrap[A: Meta](rep: RDD[A]): SparkRDD[A] =
+  import org.apache.spark.sql.Encoder
+  import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+
+  implicit def encoderForType[T: Meta]: Encoder[T] =
+    ExpressionEncoder[T]
+
+  // ---------------------------------------------------------------------------
+  // Constructors
+  // ---------------------------------------------------------------------------
+
+  def apply[A: Meta]()(implicit spark: SparkSession): SparkRDD[A] =
+    spark.sparkContext.emptyRDD[A]
+
+  def apply[A: Meta](seq: Seq[A])(implicit spark: SparkSession): SparkRDD[A] =
+    spark.sparkContext.parallelize(seq)
+
+  def readCSV[A: Meta : CSVConverter](path: String, format: CSV)(implicit spark: SparkSession): SparkDataset[A] =
+    spark.read
+      .option("header", format.header)
+      .option("delimiter", format.delimiter)
+      .option("charset", format.charset.toString)
+      .option("quote", format.quote.getOrElse('"').toString)
+      .option("escape", format.escape.getOrElse('\\').toString)
+      .option("nullValue", format.nullValue)
+      .schema(encoderForType[A].schema)
+      .csv(path)
+      .as[A]
+
+  // ---------------------------------------------------------------------------
+  // Implicit Rep -> DataBag conversion
+  // ---------------------------------------------------------------------------
+
+  implicit def wrap[A: Meta](rep: RDD[A])(implicit spark: SparkSession): SparkRDD[A] =
     new SparkRDD(rep)
-
-  def apply[A: Meta]()(implicit sc: SparkContext): SparkRDD[A] =
-    sc.emptyRDD[A]
-
-  def apply[A: Meta](seq: Seq[A])(implicit sc: SparkContext): SparkRDD[A] =
-    sc.parallelize(seq)
 }

--- a/emma-spark/src/test/scala/org/emmalanguage/api/SparkDatasetSpec.scala
+++ b/emma-spark/src/test/scala/org/emmalanguage/api/SparkDatasetSpec.scala
@@ -16,6 +16,8 @@
 package org.emmalanguage
 package api
 
+import io.csv.{CSV, CSVConverter}
+
 import org.apache.spark.sql.SparkSession
 
 class SparkDatasetSpec extends DataBagSpec {
@@ -31,4 +33,7 @@ class SparkDatasetSpec extends DataBagSpec {
 
   override def Bag[A: Meta](seq: Seq[A])(implicit spark: SparkSession): Bag[A] =
     SparkDataset(seq)
+
+  override def readCSV[A: Meta : CSVConverter](path: String, format: CSV)(implicit spark: SparkSession): DataBag[A] =
+    SparkDataset.readCSV(path, format)
 }

--- a/emma-spark/src/test/scala/org/emmalanguage/api/SparkRDDSpec.scala
+++ b/emma-spark/src/test/scala/org/emmalanguage/api/SparkRDDSpec.scala
@@ -16,19 +16,24 @@
 package org.emmalanguage
 package api
 
-import org.apache.spark.SparkContext
+import io.csv.{CSV, CSVConverter}
+
+import org.apache.spark.sql.SparkSession
 
 class SparkRDDSpec extends DataBagSpec {
 
   override type Bag[A] = SparkRDD[A]
-  override type BackendContext = SparkContext
+  override type BackendContext = SparkSession
 
   override def withBackendContext[T](f: BackendContext => T): T =
-    LocalSparkSession.withSparkContext(f)
+    LocalSparkSession.withSparkSession(f)
 
-  override def Bag[A: Meta](implicit sc: BackendContext): Bag[A] =
+  override def Bag[A: Meta](implicit spark: BackendContext): Bag[A] =
     SparkRDD[A]
 
-  override def Bag[A: Meta](seq: Seq[A])(implicit sc: BackendContext): Bag[A] =
+  override def Bag[A: Meta](seq: Seq[A])(implicit spark: BackendContext): Bag[A] =
     SparkRDD(seq)
+
+  override def readCSV[A : Meta : CSVConverter](path: String, format: CSV)(implicit ctx: BackendContext): DataBag[A] =
+    SparkRDD.readCSV[A](path, format)
 }


### PR DESCRIPTION
This PR adds basic read / write support to the new `DataBag` API.

Open problems:

- I have not verified that the output is consistent across backends, e.g. that a file written with Flink can be read back with Scala using the same `CSV` option.
- Type support is limited by the least common denominator (set by Flink) and is restricted only to tuple types, hence the commented out `write and read(Seq(1, 2, 3))`.
- Similarly, the supported options are limited (and again the least friendly backend was Flink). In case of incompatible options in the `CSV` instance, a runtime exception due to validating `require` condition will be thrown.
- Each format has its own `read${fmt}` and `write${fmt}` pair of methods and its own type-class (e.g., `CSVConverter` for the `CSV` format).