### PR TITLE
[API] Made specific folds an explicit part of the new `DataBag` API.

### DIFF
--- a/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
@@ -28,6 +28,8 @@ class FlinkDataSet[A: Meta] private[api](@transient private val rep: DataSet[A])
 
   import FlinkDataSet.{typeInfoForType, wrap}
 
+  @transient override val m = implicitly[Meta[A]]
+
   // -----------------------------------------------------
   // Structural recursion
   // -----------------------------------------------------

--- a/emma-language/src/main/scala/org/emmalanguage/api/ScalaTraversable.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/ScalaTraversable.scala
@@ -18,12 +18,22 @@ package api
 
 import io.csv.{CSV, CSVConverter, CSVScalaSupport}
 
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
 import scala.language.{higherKinds, implicitConversions}
 
 /** A `DataBag` implementation backed by a Scala `Traversable`. */
 class ScalaTraversable[A] private[api](private val rep: Traversable[A]) extends DataBag[A] {
 
   import ScalaTraversable.wrap
+
+  //@formatter:off
+  @transient override val m = new Meta[A] {
+    override def ctag: ClassTag[A] = null
+    override def ttag: TypeTag[A] = null
+  }
+  //@formatter:on
 
   // -----------------------------------------------------
   // Structural recursion

--- a/emma-language/src/main/scala/org/emmalanguage/api/package.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/package.scala
@@ -16,7 +16,6 @@
 package org.emmalanguage
 
 import io.csv.{CSVConverter, CSVConverterMacro}
-import eu.stratosphere.emma.macros.Folds
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._
@@ -90,17 +89,6 @@ package object api {
   // -----------------------------------------------------
   // Converters
   // -----------------------------------------------------
-
-  /**
-   * Extend the [[DataBag]] type with methods from [[Folds]] via the "pimp my library" pattern.
-   * This is a value class, which means that in most cases, the allocation of an instance can be
-   * avoided when using the defined methods.
-   *
-   * @param self the actual [[DataBag]] instance
-   * @tparam A the type of elements to fold over
-   */
-  implicit final class DataBagFolds[A] private[api](val self: DataBag[A])
-    extends AnyVal with Folds[A]
 
   implicit def materializeCSVConverter[T]: CSVConverter[T] =
     macro CSVConverterMacro.materialize[T]

--- a/emma-language/src/test/scala/org/emmalanguage/api/DataBagSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/api/DataBagSpec.scala
@@ -29,9 +29,7 @@ import java.nio.file.{Files, Paths}
 
 trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBagEquality {
 
-  // FIXME: intOrd should have a static owner
-  // implicit val intOrd = implicitly[Ordering[Int]]
-  import DataBagSpec.{TestRecord, intOrd}
+  import DataBagSpec.TestRecord
 
   // ---------------------------------------------------------------------------
   // abstract trait methods
@@ -69,33 +67,26 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
         val ys = Bag(hhCrts.map(DataBagSpec.f))
         val zs = Bag(Seq.empty[Double])
 
-        // FIXME: these predicates have to be defined externally in order to be a serializable part of the fold closure
-        // FIXME: However, hard-coding the expanded version of the problematic folds (find, count) resolves the issue
-        val p1 = (c: Character) => c.name startsWith "Zaphod"
-        val p2 = (c: Character) => c.name startsWith "Ford"
-        val p3 = (c: Character) => c.name startsWith "Marvin"
-        val p4 = (c: Double) => c < 42.0
-
         Seq(
           //@formatter:off
           "isEmpty"     -> xs.isEmpty,
           "nonEmpty"    -> xs.nonEmpty,
-          "min"         -> ys.fold(IntLimits.max)(x => x, (x, y) => intOrd.min(x, y)), // FIXME: ys.min does not work
-          "max"         -> ys.fold(IntLimits.min)(x => x, (x, y) => intOrd.max(x, y)), // FIXME: ys.max does not work
+          "min"         -> ys.min,
+          "max"         -> ys.max,
           "sum (1)"     -> ys.sum,
           "sum (2)"     -> zs.sum,
           "product (1)" -> ys.product,
           "product (2)" -> zs.product,
           "size (1)"    -> xs.size,
           "size (2)"    -> zs.size,
-          "count (1)"   -> xs.count(p1), // FIXME: fold macro needs externally defiend lambda
-          "count (2)"   -> zs.count(p4), // FIXME: fold macro needs externally defiend lambda
+          "count (1)"   -> xs.count(_.name startsWith "Zaphod"),
+          "count (2)"   -> zs.count(_ < 42.0),
           "existsP"     -> xs.exists(_.name startsWith "Arthur"),
           "existsN"     -> xs.exists(_.name startsWith "Marvin"),
           "forallP"     -> xs.forall(_.name startsWith "Arthur"),
           "forallN"     -> xs.forall(_.name startsWith "Trillian"),
-          "findP"       -> xs.find(p2), // FIXME: fold macro needs externally defiend lambda
-          "findN"       -> xs.find(p3), // FIXME: fold macro needs externally defiend lambda
+          "findP"       -> xs.find(_.name startsWith "Ford"),
+          "findN"       -> xs.find(_.name startsWith "Marvin"),
           "bottom"      -> ys.bottom(1),
           "top"         -> ys.top(2)
           //@formatter:on
@@ -291,7 +282,6 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
 }
 
 object DataBagSpec {
-  implicit val intOrd = implicitly[Ordering[Int]]
 
   val f = (c: Character) => c.book.title.length
 

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
@@ -27,6 +27,8 @@ class SparkDataset[A: Meta] private[api](@transient private val rep: Dataset[A])
 
   import SparkDataset.{encoderForType, wrap}
 
+  @transient override val m = implicitly[Meta[A]]
+
   // -----------------------------------------------------
   // Structural recursion
   // -----------------------------------------------------

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
@@ -29,6 +29,8 @@ class SparkRDD[A: Meta] private[api](@transient private val rep: RDD[A])(implici
 
   import SparkRDD.{encoderForType, wrap}
 
+  @transient override val m = implicitly[Meta[A]]
+
   // -----------------------------------------------------
   // Structural recursion
   // -----------------------------------------------------


### PR DESCRIPTION
This basically inlines the `FoldMacros` from the old API directly within the `DataBag` API.

I think that it might be beneficial to hold on to the combinator form for a while and not bluntly substitute before entering the compiler pipeline.

In addition, the proposed changes allow for resolving various FIXME comments in the "structural recursion" spec.
