### PR TITLE
[IR] Fixed Tree.rename

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/ast/Methods.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Methods.scala
@@ -189,7 +189,7 @@ trait Methods { this: AST =>
         val tpeTree = TypeQuote(resT)
         val original = tparams ++ paramss.flatten
         val aliases = sym.typeParams ++ sym.paramLists.flatten
-        val rhs = Owner.at(sym)(Tree.rename(original zip aliases: _*)(body))
+        val rhs = Owner.at(sym)(Tree.renameUnsafe(original zip aliases: _*)(body))
         val method = u.DefDef(mods, sym.name, tpeDefs, parDefs, tpeTree, rhs)
         set(method, sym = sym)
         method

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
@@ -434,7 +434,7 @@ trait Terms { this: AST =>
         val tpe = Type.fun(parTs: _*)(body.tpe)
         val fun = TermSym.free(TermName.lambda, tpe)
         val aliases = for ((p, t) <- params zip parTs) yield ParSym(fun, p.name, t)
-        val rhs = Owner.at(fun)(Tree.rename(params zip aliases: _*)(body))
+        val rhs = Owner.at(fun)(Tree.renameUnsafe(params zip aliases: _*)(body))
         val lambda = u.Function(aliases.map(ParDef(_)).toList, rhs)
         set(lambda, sym = fun, tpe = tpe)
         lambda


### PR DESCRIPTION
- Optimized `Sym.copy` in case of no changes.
- Optimized `Tree.copy` as shallow instead of deep.
- Split `Tree.rename` into:
  * `Tree.rename` - substitutes only known aliases;
  * `Tree.renameTransitive` - substitutes aliases and their transitive closure.

Fixes #246 