### PR TITLE
[IR] Fixed `Tree.rename` and `Owner.at` via `Sym.subst`

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
@@ -404,7 +404,7 @@ trait CommonAST {
 
     /** Does `tree` have an owner? */
     def owner(tree: Tree): Boolean =
-      has.owner(tree.symbol)
+      tree.exists(is.owner)
 
     /** Does `tpe` have an owner? */
     def owner(tpe: Type): Boolean = has.owner {

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
@@ -434,7 +434,7 @@ trait Terms { this: AST =>
         val tpe = Type.fun(parTs: _*)(body.tpe)
         val fun = TermSym.free(TermName.lambda, tpe)
         val aliases = for ((p, t) <- params zip parTs) yield ParSym(fun, p.name, t)
-        val rhs = Owner.at(fun)(Tree.renameUnsafe(params zip aliases: _*)(body))
+        val rhs = Sym.subst(fun, params zip aliases: _*)(body)
         val lambda = u.Function(aliases.map(ParDef(_)).toList, rhs)
         set(lambda, sym = fun, tpe = tpe)
         lambda

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
@@ -36,7 +36,7 @@ trait Compiler extends AlphaEq with Source with Core with Backend {
 
   /** Standard pipeline prefix. Brings a tree into a form convenient for transformation. */
   lazy val preProcess: Seq[u.Tree => u.Tree] = Seq(
-    fixLambdaTypes,
+    fixSymbolTypes,
     stubTypeTrees,
     unQualifyStatics,
     normalizeStatements,

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/LanguageSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/LanguageSpec.scala
@@ -39,7 +39,7 @@ class LanguageSpec extends BaseCompilerSpec {
 
   /** Example pre-processing pipeline. */
   lazy val pipeline = { api.Type.check(_: u.Tree) }
-    .andThen(compiler.fixLambdaTypes)
+    .andThen(compiler.fixSymbolTypes)
     .andThen(compiler.unQualifyStatics)
     .andThen(compiler.normalizeStatements)
 

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/Foreach2LoopSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/Foreach2LoopSpec.scala
@@ -29,7 +29,7 @@ class Foreach2LoopSpec extends BaseCompilerSpec {
 
   val foreach2loopPipeline: u.Expr[Any] => u.Tree =
     compiler.pipeline(typeCheck = true, withPre = false)(
-      fixLambdaTypes,
+      fixSymbolTypes,
       unQualifyStatics,
       normalizeStatements,
       tree => time(Foreach2Loop.transform(tree), "foreach -> loop")

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/LanguageSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/LanguageSpec.scala
@@ -40,7 +40,7 @@ class LanguageSpec extends BaseCompilerSpec {
 
   /** Example pre-processing pipeline. */
   lazy val pipeline = { api.Type.check(_: u.Tree) }
-    .andThen(compiler.fixLambdaTypes)
+    .andThen(compiler.fixSymbolTypes)
     .andThen(compiler.unQualifyStatics)
     .andThen(compiler.normalizeStatements)
 

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/PatternMatchingSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/PatternMatchingSpec.scala
@@ -30,7 +30,7 @@ class PatternMatchingSpec extends BaseCompilerSpec {
 
   val destructPatternMatchesPipeline: u.Expr[Any] => u.Tree =
     compiler.pipeline(typeCheck = true, withPre = false)(
-      fixLambdaTypes,
+      fixSymbolTypes,
       unQualifyStatics,
       normalizeStatements,
       tree => time(PatternMatching.destruct(tree), "destruct irrefutable pattern matches")
@@ -38,7 +38,7 @@ class PatternMatchingSpec extends BaseCompilerSpec {
 
   val noopPipeline: u.Expr[Any] => u.Tree =
     compiler.pipeline(typeCheck = true, withPre = false)(
-      fixLambdaTypes,
+      fixSymbolTypes,
       unQualifyStatics,
       normalizeStatements
     ).compose(_.tree)


### PR DESCRIPTION
It turned out that replacing symbols and changing the owner are related operations with similar implementation, therefore I fused them in `Sym.subst`. `Tree.rename` and `Owner.at` just forward to it. Hopefully, this will solve our issues related to method symbols and (type) parameters.

fixes #255 