### PR TITLE
[IR] Modify CommonAST.eval to not fail for typechecked trees.

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
@@ -62,7 +62,10 @@ trait CommonAST {
   // Parsing and type-checking
   // ---------------------------
 
-  /** Evaluates a snippet of code and returns a value of type `T`. */
+  /**
+   * Evaluates a snippet of code and returns a value of type `T`.
+   * Note: this can be called on typechecked trees (as opposed to the eval method in ToolBox).
+   */
   private[emmalanguage] def eval[T](code: Tree): T
 
   /** Parses a snippet of source code and returns the AST. */

--- a/emma-language/src/main/scala/org/emmalanguage/ast/JavaAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/JavaAST.scala
@@ -54,19 +54,30 @@ trait JavaAST extends AST {
   // ---------------------------
 
   private[emmalanguage] def eval[T](code: Tree): T =
-    tb.eval(code).asInstanceOf[T]
+    compile(unTypeCheck(code))().asInstanceOf[T]
 
   private[emmalanguage] override def parse(code: String): Tree =
     tb.parse(code)
 
   private[emmalanguage] override def typeCheck(tree: Tree, typeMode: Boolean = false): Tree =
-    if (typeMode) tb.typecheck(tree, tb.TYPEmode) else tb.typecheck(tree)
+    try if (typeMode) tb.typecheck(tree, tb.TYPEmode) else tb.typecheck(tree)
+    catch {
+      case ex: scala.tools.reflect.ToolBoxError => throw scala.tools.reflect.ToolBoxError(
+        s"Typecheck failed for tree:\n================\n${api.Tree.show(tree)}\n================\n", ex)
+    }
 
   private[emmalanguage] override def inferImplicit(tpe: Type): Tree =
     tb.inferImplicitValue(tpe)
 
-  private[emmalanguage] def compile(tree: Tree) =
-    tb.compile(tree)
+  private[emmalanguage] def compile(tree: Tree): () => Any =
+    try {
+      val res = tb.compile(tree)
+      typeCheck(u.reify {}.tree) // This is a workaround for https://issues.scala-lang.org/browse/SI-9932
+      res
+    } catch {
+      case ex: scala.tools.reflect.ToolBoxError => throw scala.tools.reflect.ToolBoxError(
+        s"Compilation failed for tree:\n================\n${api.Tree.show(tree)}\n================\n", ex)
+    }
 
   // ------------------------
   // Abstract wrapper methods

--- a/emma-language/src/main/scala/org/emmalanguage/ast/MacroAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/MacroAST.scala
@@ -57,7 +57,7 @@ trait MacroAST extends AST {
   // ---------------------------
 
   private[emmalanguage] def eval[T](code: Tree): T =
-    c.eval[T](c.Expr[T](code))
+    c.eval[T](c.Expr[T](unTypeCheck(code)))
 
   private[emmalanguage] override def parse(code: String): Tree =
     c.parse(code)


### PR DESCRIPTION
Also, print the tree when `JavaAST.compile` or `JavaAST.typeCheck` fails.
Also, add a workaround for https://issues.scala-lang.org/browse/SI-9932 in `JavaAST.compile`.