### PR TITLE
[IR] Added different suffix to fresh names between MacroAST and JavaAST.

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/ast/AST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/AST.scala
@@ -183,4 +183,6 @@ trait AST extends CommonAST
     if defs.size > 1
     dfn <- defs.tail
   } yield dfn
+
+  private[ast] def freshNameSuffix: Char
 }

--- a/emma-language/src/main/scala/org/emmalanguage/ast/JavaAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/JavaAST.scala
@@ -49,6 +49,8 @@ trait JavaAST extends AST {
   override def warning(msg: String, pos: Position = NoPosition): Unit =
     logger.warn(s"Warning at $pos: $msg")
 
+  override private[ast] def freshNameSuffix: Char = 'r'
+
   // ---------------------------
   // Parsing and type-checking
   // ---------------------------

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Loops.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Loops.scala
@@ -83,7 +83,7 @@ trait Loops { this: AST =>
         lazy val Cond = Type.of(cond)
         assert(Cond =:= Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
 
-        val nme = TermName.While()
+        val nme = TermName.fresh("while")
         val lbl = LabelSym(u.NoSymbol, nme)
         val rhs = WhileBody(lbl, cond, asStat(body))
         val dfn = u.LabelDef(nme, Nil, rhs)
@@ -113,7 +113,7 @@ trait Loops { this: AST =>
         lazy val Cond = Type.of(cond)
         assert(Cond =:= Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
 
-        val nme = TermName.DoWhile()
+        val nme = TermName.fresh("doWhile")
         val lbl = LabelSym(u.NoSymbol, nme)
         val rhs = DoWhileBody(lbl, cond, asStat(body))
         val dfn = u.LabelDef(nme, Nil, rhs)

--- a/emma-language/src/main/scala/org/emmalanguage/ast/MacroAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/MacroAST.scala
@@ -52,6 +52,8 @@ trait MacroAST extends AST {
   override def warning(msg: String, pos: Position = NoPosition): Unit =
     c.warning(pos, msg)
 
+  override private[ast] def freshNameSuffix: Char = 'm'
+
   // ---------------------------
   // Parsing and type-checking
   // ---------------------------

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
@@ -62,8 +62,8 @@ trait Terms { this: AST =>
 
       /** Creates a fresh term name with the given `prefix`. */
       def fresh(prefix: String): u.TermName = apply {
-        if (prefix.nonEmpty && prefix.last == '$') freshTermName(prefix)
-        else freshTermName(s"$prefix$$")
+        assert(prefix.nonEmpty, "Cannot create a fresh name with empty prefix")
+        freshTermName(s"$prefix$$$freshNameSuffix")
       }
 
       /** Creates a fresh term name with the given `prefix`. */
@@ -81,45 +81,6 @@ trait Terms { this: AST =>
 
       def unapply(name: u.TermName): Option[String] =
         for (name <- Option(name) if is.defined(name)) yield name.toString
-
-      /** Names generated during eta expansion. */
-      object Eta extends Node {
-
-        /** Creates a fresh `eta` name. */
-        def apply(): u.TermName =
-          fresh("eta$")
-
-        def unapply(name: u.TermName): Option[String] = name match {
-          case TermName(str) if str.matches("""eta(\$\d+)+""") => Some(str)
-          case _ => None
-        }
-      }
-
-      /** Names for `while` loop labels. */
-      object While extends Node {
-
-        /** Creates a fresh `while` name. */
-        def apply(): u.TermName =
-          fresh("while$")
-
-        def unapply(name: u.TermName): Option[String] = name match {
-          case TermName(str) if str.matches("""while(\$\d+)+""") => Some(str)
-          case _ => None
-        }
-      }
-
-      /** Names for `do-while` loop labels. */
-      object DoWhile extends Node {
-
-        /** Creates a fresh `do-while` name. */
-        def apply(): u.TermName =
-          fresh("doWhile$")
-
-        def unapply(name: u.TermName): Option[String] = name match {
-          case TermName(str) if str.matches("""doWhile(\$\d+)+""") => Some(str)
-          case _ => None
-        }
-      }
     }
 
     /** Term symbols. */

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Types.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Types.scala
@@ -55,8 +55,8 @@ trait Types { this: AST =>
 
       /** Creates a fresh type name with the given `prefix`. */
       def fresh(prefix: String): u.TypeName = apply {
-        if (prefix.nonEmpty && prefix.last == '$') freshTypeName(prefix)
-        else freshTypeName(s"$prefix$$")
+        assert(prefix.nonEmpty, "Cannot create a fresh name with empty prefix")
+        freshTypeName(s"$prefix$$$freshNameSuffix")
       }
 
       /** Creates a fresh type name with the given `prefix`. */

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
@@ -209,7 +209,7 @@ private[core] trait DSCF extends Common {
               val loopVars = mods(loop)
               val loopArgs = varArgs(loopVars)
               val loopPars = varPars(loopVars)
-              val loopMeth = api.DefSym(owner, api.TermName.While())()(loopPars)(tpe)
+              val loopMeth = api.DefSym(owner, api.TermName.fresh("while"))()(loopPars)(tpe)
               val loopCall = core.DefCall()(loopMeth)(loopArgs)
 
               // Suffix
@@ -244,7 +244,7 @@ private[core] trait DSCF extends Common {
               val loopVars = mods(loop)
               val loopArgs = varArgs(loopVars)
               val loopPars = varPars(loopVars)
-              val loopMeth = api.DefSym(owner, api.TermName.DoWhile())()(loopPars)(tpe)
+              val loopMeth = api.DefSym(owner, api.TermName.fresh("doWhile"))()(loopPars)(tpe)
               val loopCall = core.DefCall()(loopMeth)(loopArgs)
 
               // Suffix


### PR DESCRIPTION
Also, removed etaCompact, etaExpand, TermName.Eta, TermName.While, TermName.DoWhile.

Fixes #265.
