### PR TITLE
[API] Refactored the Meta implicits to have shorter resolutions.

### DIFF
--- a/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
@@ -27,6 +27,8 @@ import scala.language.{higherKinds, implicitConversions}
 /** A `DataBag` implementation backed by a Flink `DataSet`. */
 class FlinkDataSet[A: Meta] private[api](@transient private val rep: DataSet[A]) extends DataBag[A] {
 
+  import Meta.Implicits._
+
   import FlinkDataSet.{typeInfoForType, wrap}
 
   @transient override val m = implicitly[Meta[A]]
@@ -122,6 +124,8 @@ object FlinkDataSet {
         q"org.apache.flink.api.scala.createTypeInformation[${ttag.tpe.asInstanceOf[Type]}]")
       ).asInstanceOf[TypeInformation[T]]
   }
+
+  import Meta.Implicits._
 
   // ---------------------------------------------------------------------------
   // Constructors

--- a/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
@@ -21,6 +21,8 @@ import io.csv.{CSV, CSVConverter}
 /** An abstraction for homogeneous distributed collections. */
 trait DataBag[A] extends Serializable {
 
+  import Meta.Implicits._
+
   implicit def m: Meta[A]
 
   // -----------------------------------------------------

--- a/emma-language/src/main/scala/org/emmalanguage/api/package.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/package.scala
@@ -41,14 +41,16 @@ package object api {
       override def ctag = implicitly[ClassTag[DataBag[T]]]
       override def ttag = implicitly[TypeTag[DataBag[T]]]
     }
+
+    object Implicits {
+      implicit def ttagFor[T: Meta]: scala.reflect.runtime.universe.TypeTag[T] =
+        implicitly[Meta[T]].ttag
+
+      implicit def ctagFor[T: Meta]: ClassTag[T] =
+        implicitly[Meta[T]].ctag
+    }
   }
   //@formatter:on
-
-  implicit def ttagFor[T: Meta]: TypeTag[T] =
-    implicitly[Meta[T]].ttag
-
-  implicit def ctagFor[T: Meta]: ClassTag[T] =
-    implicitly[Meta[T]].ctag
 
   // -----------------------------------------------------
   // Converters

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
@@ -36,6 +36,7 @@ trait Compiler extends AlphaEq with Source with Core with Backend {
 
   /** Standard pipeline prefix. Brings a tree into a form convenient for transformation. */
   lazy val preProcess: Seq[u.Tree => u.Tree] = Seq(
+    Source.removeImplicits(API.implicitTypes),
     fixSymbolTypes,
     stubTypeTrees,
     unQualifyStatics,

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/Source.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/Source.scala
@@ -182,8 +182,6 @@ trait Source extends Common
       PatternMatching.destruct
     } andThen {
       Foreach2Loop.transform
-    } andThen {
-      removeImplicits(API.implicitTypes)
     }
 
     /** Removes implicit lists consisting of the following symbols. */

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
@@ -103,6 +103,8 @@ object SparkDataset {
   import org.apache.spark.sql.Encoder
   import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
+  import Meta.Implicits._
+
   implicit def encoderForType[T: Meta]: Encoder[T] =
     ExpressionEncoder[T]
 

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
@@ -27,6 +27,8 @@ import scala.language.{higherKinds, implicitConversions}
 class SparkRDD[A: Meta] private[api](@transient private val rep: RDD[A])(implicit spark: SparkSession)
   extends DataBag[A] {
 
+  import Meta.Implicits._
+
   import SparkRDD.{encoderForType, wrap}
 
   @transient override val m = implicitly[Meta[A]]
@@ -94,6 +96,8 @@ object SparkRDD {
 
   import org.apache.spark.sql.Encoder
   import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+
+  import Meta.Implicits._
 
   implicit def encoderForType[T: Meta]: Encoder[T] =
     ExpressionEncoder[T]


### PR DESCRIPTION
So far, for every resolution of `Meta`, the compiler created the following code:
```
(`package`.this.Meta.apply(
    `package`.ctagFor(
        `package`.this.Meta.apply(
            Predef.this.implicitly,
            `package`.ttagFor(
                `package`.this.Meta.apply(
                    Predef.this.implicitly,
                    Predef.this.implicitly
                )
            )
        )
    ),
    `package`.ttagFor(
        `package`.this.Meta.apply(
            `package`.ctagFor(
                `package`.this.Meta.apply(
                    Predef.this.implicitly,
                    Predef.this.implicitly
                )
            ),
            Predef.this.implicitly
        )
    )
))
```

Now it looks like this, as it should be:
```
`package`.this.Meta.apply(Predef.this.implicitly, Predef.this.implicitly)
```

This makes compilation faster. For example, `BaseCodegenTest` compiles almost twice as fast.

Additionally, I moved `removeImplicits` to the very beginning of the pipeline to get rid of the very large trees that get generated from `implicitly` earlier.