### PR TITLE
[IR] Handle equiJoin and cross

### DIFF
--- a/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
@@ -197,4 +197,23 @@ object FlinkDataSet {
 
   implicit def wrap[A: Meta](rep: DataSet[A]): FlinkDataSet[A] =
     new FlinkDataSet(rep)
+
+  // ---------------------------------------------------------------------------
+  // ComprehensionCombinators
+  // (these should correspond to `compiler.ir.ComprehensionCombinators`)
+  // ---------------------------------------------------------------------------
+
+  def cross[A : Meta, B : Meta]
+    (xs: DataBag[A], ys: DataBag[B])
+    (implicit flink: FlinkEnv): DataBag[(A,B)] = (xs, ys) match {
+    case (xs: FlinkDataSet[A], ys: FlinkDataSet[B]) => xs.rep.cross(ys.rep)
+  }
+
+  def equiJoin[A : Meta, B : Meta, K : Meta]
+    (keyx: A => K, keyy: B => K)
+    (xs: DataBag[A], ys: DataBag[B])
+    (implicit flink: FlinkEnv): DataBag[(A,B)] = (xs, ys) match {
+    case (xs: FlinkDataSet[A], ys: FlinkDataSet[B]) =>
+      xs.rep.join(ys.rep).where(keyx).equalTo(keyy)
+  }
 }

--- a/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
@@ -28,7 +28,7 @@ import scala.util.hashing.MurmurHash3
 /** A `DataBag` implementation backed by a Flink `DataSet`. */
 class FlinkDataSet[A: Meta] private[api](@transient private val rep: DataSet[A]) extends DataBag[A] {
 
-  import Meta.Implicits._
+  import Meta.Projections._
 
   import FlinkDataSet.{typeInfoForType, wrap}
 
@@ -163,7 +163,7 @@ object FlinkDataSet {
     ).asInstanceOf[TypeInformation[T]]
   }
 
-  import Meta.Implicits._
+  import Meta.Projections._
 
   // ---------------------------------------------------------------------------
   // Constructors

--- a/emma-flink/src/test/scala/org/emmalanguage/compiler/flink/dataset/CodegenSpec.scala
+++ b/emma-flink/src/test/scala/org/emmalanguage/compiler/flink/dataset/CodegenSpec.scala
@@ -16,9 +16,9 @@
 package org.emmalanguage
 package compiler.flink.dataset
 
-import compiler.BaseCodegenTest
+import compiler.BaseCodegenSpec
 
-class CodegenTest extends BaseCodegenTest("FlinkDataSet") {
+class CodegenSpec extends BaseCodegenSpec {
 
   import compiler._
 

--- a/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
@@ -322,8 +322,8 @@ trait DataBag[A] extends Serializable {
   override def equals(o: Any): Boolean = o match {
     case that: DataBag[A] =>
       lazy val hashEq = this.## == that.##
-      lazy val thisVals = this.fetch().toSeq
-      lazy val thatVals = that.fetch().toSeq
+      lazy val thisVals = this.fetch()
+      lazy val thatVals = that.fetch()
       // Note that in the following line, checking diff in only one direction is enough because we also compare the
       // sizes. Also note that SeqLike.diff uses bag semantics.
       lazy val valsEq = thisVals.size == thatVals.size && (thisVals diff thatVals).isEmpty

--- a/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
@@ -21,7 +21,7 @@ import io.csv.{CSV, CSVConverter}
 /** An abstraction for homogeneous distributed collections. */
 trait DataBag[A] extends Serializable {
 
-  import Meta.Implicits._
+  import Meta.Projections._
 
   implicit def m: Meta[A]
 
@@ -113,7 +113,7 @@ trait DataBag[A] extends Serializable {
    * }}}
    *
    * @param that The second addend parameter.
-   * @return The set-theoretic union (with duplicates) between this DataBag and the given subtrahend.
+   * @return The set-theoretic union (with duplicates) between this DataBag and the given one.
    */
   def union(that: DataBag[A]): DataBag[A]
 
@@ -248,7 +248,7 @@ trait DataBag[A] extends Serializable {
    * Test if at least one element of the collection satisfies `p`.
    *
    * @param p predicate to test against the elements of the collection
-   * @return `false` if the collections is empty
+   * @return `true` if the collection contains an element that satisfies the predicate
    */
   def exists(p: A => Boolean): Boolean =
     fold(false)(p, _ || _)
@@ -257,13 +257,13 @@ trait DataBag[A] extends Serializable {
    * Test if all elements of the collection satisfy `p`.
    *
    * @param p predicate to test against the elements of the collection
-   * @return `true` if the collection is empty
+   * @return `true` if all the elements of the collection satisfy the predicate
    */
   def forall(p: A => Boolean): Boolean =
     fold(true)(p, _ && _)
 
   /**
-   * Find the some element in the collection that satisfies a given predicate.
+   * Finds some element in the collection that satisfies a given predicate.
    *
    * @param p the predicate to test against
    * @return [[Some]] element if one exists, [[None]] otherwise

--- a/emma-language/src/main/scala/org/emmalanguage/api/package.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/package.scala
@@ -42,7 +42,7 @@ package object api {
       override def ttag = implicitly[TypeTag[DataBag[T]]]
     }
 
-    object Implicits {
+    object Projections {
       implicit def ttagFor[T: Meta]: scala.reflect.runtime.universe.TypeTag[T] =
         implicitly[Meta[T]].ttag
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
@@ -101,7 +101,7 @@ private[backend] trait Order extends Common {
         }(Monoids.disj)
         // Am I inside a combinator call?
         .inherit {
-          case api.DefCall(_, method, _, _) if combinators contains method => true
+          case api.DefCall(_, method, _, _*) if combinators contains method => true
         }(Monoids.disj)
         // Funs given as arguments to combinators (combRefs)
         .accumulateWith[Vector[u.TermSymbol]] {
@@ -151,7 +151,7 @@ private[backend] trait Order extends Common {
       // because of the refresh. But this is not a problem, since isHighContext will be inherited to it anyway.
       val isHighContext: u.Tree =?> Boolean = {
         case core.ValDef(sym, _, _) if highFuns contains sym => true
-        case api.DefCall(_, method, _, _) if combinators contains method => true
+        case api.DefCall(_, method, _, _*) if combinators contains method => true
       }
 
       val disambiguatedTree = api.TopDown

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
@@ -41,7 +41,7 @@ private[backend] trait Order extends Common {
      * If a lambda is given as an argument to one of these methods,
      * then that lambda will be called from higher-order context.
      */
-    val combinators = API.ops ++ ComprehensionCombinators.methods
+    val combinators = API.ops ++ ComprehensionCombinators.ops
 
     /**
      * Disambiguates order in a tree and gives information on which parts of the code might be executed

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
@@ -131,11 +131,6 @@ private[backend] trait Order extends Common {
         reached
       }
 
-      // The Set of symbols of ValDefs of functions
-      val lambdas = tree.collect {
-        case core.ValDef(sym, api.Lambda(_,_,_), _) => sym
-      }.toSet
-
       val driverFuns = funReachability(topLevRefs)
       // highFuns0 will also contain the ambiguous ones, which we will soon eliminate
       val highFuns0 = funReachability(combRefs)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
@@ -36,7 +36,6 @@ private[comprehension] trait Combination extends Common {
     private val tuple2   = api.Type[(Nothing, Nothing)]
     private val tuple2_1 = tuple2.member(api.TermName("_1")).asTerm
     private val tuple2_2 = tuple2.member(api.TermName("_2")).asTerm
-    private val and      = api.Type[Boolean].member(api.TermName("&&")).asTerm
     //@formatter:on
 
     // TODO: Split conjunctive filter predicates.
@@ -81,8 +80,6 @@ private[comprehension] trait Combination extends Common {
       object Cross     extends RewriteState
       object Residuals extends RewriteState
       object End       extends RewriteState
-
-      val desugar = Comprehension.desugar(API.bagSymbol)
 
       def applyOnce(rule: u.Tree =?> u.Tree): Boolean = {
         if (rule.isDefinedAt(root)) {

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Normalize.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Normalize.scala
@@ -37,8 +37,8 @@ private[comprehension] trait Normalize extends Common {
      * Normalizes nested mock-comprehension syntax.
      *
      * @param monad The symbol of the monad syntax to be normalized.
-     * @param tree The tree to be resugared.
-     * @return The input tree with resugared comprehensions.
+     * @param tree The tree to be normalized.
+     * @return The normalized input tree.
      */
     def normalize(monad: u.Symbol)(tree: u.Tree): u.Tree = {
       // construct comprehension syntax helper for the given monad
@@ -100,7 +100,7 @@ private[comprehension] trait Normalize extends Common {
      * } // enclosing block
      * }}}
      *
-     * (2) A `flatten` expression occurring in the `rhs` opsition of some binding in the enclosing `let` block.
+     * (2) A `flatten` expression occurring in the `rhs` position of some binding in the enclosing `let` block.
      *
      * {{{
      * {

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DCE.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DCE.scala
@@ -51,7 +51,7 @@ private[core] trait DCE extends Common {
           val liveRefs = vals.foldRight(refs(expr) | refsInDefs) {
 
             // When we have a DefCall that is returning a unit, then treat this val as used
-            case (core.ValDef(lhs, rhs@api.DefCall(_, method, _, _), _), live)
+            case (core.ValDef(lhs, rhs@api.DefCall(_, method, _, _*), _), live)
               if method.returnType =:= api.Type[Unit] =>
               live | refs(rhs) + lhs
 

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCodegenSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCodegenSpec.scala
@@ -34,13 +34,13 @@ import java.io.File
 import java.nio.file.Paths
 
 @RunWith(classOf[JUnitRunner])
-abstract class BaseCodegenTest(rtName: String)
-  extends BaseCompilerSpec with Matchers with BeforeAndAfter {
+abstract class BaseCodegenSpec
+  extends BaseCompilerSpec with BeforeAndAfter {
 
-  import BaseCodegenTest._
+  import BaseCodegenSpec._
 
   import compiler._
-  
+
   val inputDir = tempPath("test/input")
   val outputDir = tempPath("test/output")
 
@@ -49,7 +49,7 @@ abstract class BaseCodegenTest(rtName: String)
   val codegenPipeline: u.Expr[Any] => u.Tree = compiler.pipeline(true)(
     checkValid,
     Core.lift,
-    Comprehension.desugar(API.bagSymbol),
+    Comprehension.combine,
     backendPipeline
   ).compose(_.tree)
 
@@ -586,7 +586,7 @@ abstract class BaseCodegenTest(rtName: String)
   }
 }
 
-object BaseCodegenTest {
+object BaseCodegenSpec {
   lazy val jabberwocky = fromPath(materializeResource("/lyrics/Jabberwocky.txt"))
 
   lazy val imdb = DataBag.readCSV[ImdbMovie]("file://" + materializeResource("/cinema/imdb.csv"), CSV()).fetch()

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCompilerSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCompilerSpec.scala
@@ -97,7 +97,7 @@ trait BaseCompilerSpec extends FreeSpec with Matchers with PropertyChecks with T
     }
     q"""
       class ${api.TypeName(UUID.randomUUID().toString)} {
-        def run(..$params) = {
+        def ${u.TermName(RuntimeCompiler.default.runMethod)}(..$params) = {
           $tree
         }
       }

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
@@ -494,7 +494,7 @@ class CombinationSpec extends BaseCompilerSpec {
       }
 
       applyOnce(MatchResidual)(inp) shouldBe alphaEqTo(liftPipeline(exp))
-      combine(inp) shouldBe alphaEqTo(liftPipeline(exp)) // TODO: @ggevay why test this here?
+      combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
   }
 
@@ -605,6 +605,7 @@ class CombinationSpec extends BaseCompilerSpec {
   }
 
   "combine nested" - {
+    
     "in head" in {
 
       val inp = u.reify {
@@ -640,9 +641,6 @@ class CombinationSpec extends BaseCompilerSpec {
 
       combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
-  }
-
-  "combine nested" - {
 
     "complicated" in {
 

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
@@ -142,7 +142,7 @@ object SparkDataset {
   import org.apache.spark.sql.Encoder
   import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
-  import Meta.Implicits._
+  import Meta.Projections._
 
   implicit def encoderForType[T: Meta]: Encoder[T] =
     ExpressionEncoder[T]

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
@@ -28,8 +28,8 @@ import scala.util.hashing.MurmurHash3
 class SparkRDD[A: Meta] private[api](@transient private[api] val rep: RDD[A])(implicit spark: SparkSession)
   extends DataBag[A] {
 
-  import Meta.Implicits._
   import spark.sqlContext.implicits._
+  import Meta.Projections._
 
   import SparkRDD.{encoderForType, wrap}
 
@@ -135,7 +135,7 @@ object SparkRDD {
   import org.apache.spark.sql.Encoder
   import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
-  import Meta.Implicits._
+  import Meta.Projections._
 
   implicit def encoderForType[T: Meta]: Encoder[T] =
     ExpressionEncoder[T]

--- a/emma-spark/src/test/scala/org/emmalanguage/compiler/spark/rdd/CodegenSpec.scala
+++ b/emma-spark/src/test/scala/org/emmalanguage/compiler/spark/rdd/CodegenSpec.scala
@@ -16,9 +16,9 @@
 package org.emmalanguage
 package compiler.spark.rdd
 
-import compiler.BaseCodegenTest
+import compiler.BaseCodegenSpec
 
-class CodegenTest extends BaseCodegenTest("SparkRDD") {
+class CodegenSpec extends BaseCodegenSpec {
 
   import compiler._
 


### PR DESCRIPTION
The main thing here is the first commit, which takes care of `equiJoin` and `cross`, and changes `BaseCodegenTest` to use comprehension combination instead of just desugaring.