### PR TITLE
[EXAMPLES] Migrate some examples to the new compiler pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,9 +183,9 @@ Add the *Emma* dependency
 ```xml
 <!-- Basic Emma API (required) -->
 <dependency>
-    <groupId>eu.stratosphere</groupId>
+    <groupId>org.emmalanguage</groupId>
     <artifactId>emma-language</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <scope>compile</scope>
 </dependency>
 ```
@@ -195,9 +195,9 @@ Optionally add either the *Flink* or *Spark* backend.
 ```xml
 <!-- Emma backend for Flink (optional) -->
 <dependency>
-    <groupId>eu.stratosphere</groupId>
+    <groupId>org.emmalanguage</groupId>
     <artifactId>emma-flink</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -205,9 +205,9 @@ Optionally add either the *Flink* or *Spark* backend.
 ```xml
 <!-- Emma backend for Spark (optional) -->
 <dependency>
-    <groupId>eu.stratosphere</groupId>
+    <groupId>org.emmalanguage</groupId>
     <artifactId>emma-spark</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <scope>runtime</scope>
 </dependency>
 ```

--- a/emma-examples/pom.xml
+++ b/emma-examples/pom.xml
@@ -21,8 +21,8 @@
 
     <parent>
         <artifactId>emma</artifactId>
-        <groupId>eu.stratosphere</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>org.emmalanguage</groupId>
+        <version>0.2-SNAPSHOT</version>
     </parent>
 
 
@@ -55,20 +55,20 @@
 
         <!-- Emma -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-language</artifactId>
         </dependency>
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-spark</artifactId>
         </dependency>
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-flink</artifactId>
         </dependency>
         <!-- Emma (test jars) -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-language</artifactId>
             <type>test-jar</type>
         </dependency>

--- a/emma-examples/pom.xml
+++ b/emma-examples/pom.xml
@@ -73,6 +73,30 @@
             <type>test-jar</type>
         </dependency>
 
+        <!-- Flink -->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-scala_${scala.tools.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-java_${scala.tools.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-clients_${scala.tools.version}</artifactId>
+        </dependency>
+
+        <!-- Spark -->
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-core_${scala.tools.version}</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_${scala.tools.version}</artifactId>
+        </dependency>
+
         <!-- HDFS -->
         <dependency>
             <groupId>org.apache.hadoop</groupId>
@@ -116,6 +140,10 @@
             <groupId>net.sourceforge.argparse4j</groupId>
             <artifactId>argparse4j</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.github.scopt</groupId>
+            <artifactId>scopt_${scala.tools.version}</artifactId>
+        </dependency>
 
         <!-- Dynamic loading -->
         <dependency>
@@ -143,22 +171,9 @@
             </activation>
             <properties>
                 <execution.backend>flink</execution.backend>
+                <flink.scope>compile</flink.scope>
+                <hadoop.scope>compile</hadoop.scope>
             </properties>
-            <dependencies>
-                <!-- Flink -->
-                <dependency>
-                    <groupId>org.apache.flink</groupId>
-                    <artifactId>flink-scala_${scala.tools.version}</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.flink</groupId>
-                    <artifactId>flink-java_${scala.tools.version}</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>org.apache.flink</groupId>
-                    <artifactId>flink-clients_${scala.tools.version}</artifactId>
-                </dependency>
-            </dependencies>
         </profile>
 
         <!-- profile that activates Spark-related dependencies -->
@@ -172,20 +187,9 @@
             </activation>
             <properties>
                 <execution.backend>spark</execution.backend>
+                <spark.scope>compile</spark.scope>
+                <hadoop.scope>compile</hadoop.scope>
             </properties>
-            <dependencies>
-                <!-- Spark -->
-                <dependency>
-                    <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-core_${scala.tools.version}</artifactId>
-                </dependency>
-                <!-- Guava -->
-                <dependency>
-                    <groupId>com.google.guava</groupId>
-                    <artifactId>guava</artifactId>
-                    <version>18.0</version>
-                </dependency>
-            </dependencies>
         </profile>
     </profiles>
 

--- a/emma-examples/pom.xml
+++ b/emma-examples/pom.xml
@@ -127,10 +127,6 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scalacheck</groupId>
-            <artifactId>scalacheck_${scala.tools.version}</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.tools.version}</artifactId>
         </dependency>

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/EnumerateTriangles.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/EnumerateTriangles.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.graphs
+
+import api._
+import model._
+
+import scala.Ordering.Implicits._
+
+@emma.lib
+object EnumerateTriangles {
+
+  def apply[V: Ordering : Meta](edges: DataBag[Edge[V]]): DataBag[Triangle[V]] = {
+    // generate all triangles (x - v - w) such that x < v < w
+    val triangles = for {
+      Edge(x, u) <- edges
+      Edge(y, v) <- edges
+      Edge(z, w) <- edges
+      if x < u
+      if y < v
+      if z < w
+      if u == y
+      if x == z
+      if v == w
+    } yield Triangle(x, u, v)
+    // return
+    triangles
+  }
+}

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/TransitiveClosure.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/TransitiveClosure.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.graphs
+
+import api._
+import model._
+
+@emma.lib
+object TransitiveClosure {
+
+  def apply[V: Meta](edges: DataBag[Edge[V]]): DataBag[Edge[V]] = {
+    var paths = edges.distinct
+    var count = paths.size
+    var added = 0L
+
+    do {
+      val delta = for {
+        e1 <- paths
+        e2 <- paths
+        if e1.dst == e2.src
+      } yield Edge(e1.src, e2.dst)
+
+      paths = (paths union delta).distinct
+
+      added = paths.size - count
+      count = paths.size
+    } while (added > 0)
+
+    paths
+  }
+}

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/model.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/model.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.graphs
+
+import api.Meta
+import api.emma
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+/** Graph model objects. */
+object model {
+
+  case class Edge[V](src: V, dst: V)
+
+  case class LEdge[V, L](@emma.pk src: V, @emma.pk dst: V, label: L)
+
+  case class Triangle[V](x: V, y: V, z: V)
+
+  //@formatter:off
+  implicit def edgeMeta[V: Meta]: Meta[Edge[V]] = new Meta[Edge[V]] {
+    implicit def ctagV = implicitly[Meta[V]].ctag
+    implicit def ttagV = implicitly[Meta[V]].ttag
+    override def ctag = implicitly[ClassTag[Edge[V]]]
+    override def ttag = implicitly[TypeTag[Edge[V]]]
+  }
+
+  implicit def ledgeMeta[V: Meta, L: Meta]: Meta[LEdge[V, L]] = new Meta[LEdge[V, L]] {
+    implicit def ctagV = implicitly[Meta[V]].ctag
+    implicit def ttagV = implicitly[Meta[V]].ttag
+    implicit def ctagL = implicitly[Meta[L]].ctag
+    implicit def ttagL = implicitly[Meta[L]].ttag
+    override def ctag = implicitly[ClassTag[LEdge[V, L]]]
+    override def ttag = implicitly[TypeTag[LEdge[V, L]]]
+  }
+
+  implicit def triadMeta[V: Meta]: Meta[Triangle[V]] = new Meta[Triangle[V]] {
+    implicit val ctagV = implicitly[Meta[V]].ctag
+    implicit val ttagV = implicitly[Meta[V]].ttag
+    override def ctag = implicitly[ClassTag[Triangle[V]]]
+    override def ttag = implicitly[TypeTag[Triangle[V]]]
+  }
+  //@formatter:on
+}

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/imdb/DirectorsMuses.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/imdb/DirectorsMuses.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.imdb
+
+import api._
+import model._
+import io.csv.CSV
+
+@emma.lib
+object DirectorsMuses {
+
+  def apply(input: String, csv: CSV): String => Unit = {
+
+    // FIXME: CSVMacro does not work with Option[T] types
+    val people: DataBag[Person] = ??? // DataBag.readCSV[Person](s"$input/people.csv", csv)
+    val movies: DataBag[Movie] = ??? // DataBag.readCSV[Movie](s"$input/people.csv", csv)
+    val credits: DataBag[Credit] = ??? // DataBag.readCSV[Credit](s"$input/people.csv", csv)
+
+    val collaborations = for {
+      pd <- people
+      cd <- credits
+      mv <- movies
+      ca <- credits
+      pa <- people
+      if pd.id == cd.personID
+      if mv.id == cd.movieID
+      if mv.id == ca.movieID
+      if pa.id == ca.personID
+      if cd.creditType == CreditType.Director.toString
+      if ca.creditType == CreditType.Actor.toString
+    } yield Collaboration(pd, pa, mv)
+
+    val collaborationCounts = for {
+      Group((d, a), ms) <- collaborations.groupBy { case Collaboration(d, a, _) => (d, a) }
+    } yield CollaborationCount(d, a, ms.size)
+
+    val maxCounts = collaborationCounts
+      .groupBy(_.director)
+      .map { case Group(d, vals) => MaxCount(d, vals.map(_.count).max) }
+
+    val muses = for {
+      cc <- collaborationCounts
+      mc <- maxCounts
+      if cc.director == mc.director
+      if cc.count > 1
+      if cc.count >= mc.maxCount - 1
+    } yield cc
+
+    // result function
+    (name: String) => if (name.nonEmpty) {
+      val matches = for {
+        x <- muses; if x.director.name contains name
+      } yield x
+
+      for {
+        (d, ccs) <- matches.fetch().groupBy(_.director)
+      } println(
+        s"""
+           |Director ${d.name} has the following muses:
+           |${ccs.map(cc => s"- ${cc.actor.name} (collaborated in ${cc.count} movies").mkString("\n")}
+           """.stripMargin)
+    }
+  }
+
+  //----------------------------------------------------------------------------
+  // helper model
+  //----------------------------------------------------------------------------
+
+  //@formatter:off
+  case class Collaboration
+  (
+    director : Person,
+    actor    : Person,
+    movie    : Movie
+  )
+
+  case class CollaborationCount
+  (
+    director : Person,
+    actor    : Person,
+    count    : Long
+  )
+
+  case class MaxCount
+  (
+    director : Person,
+    maxCount : Long
+  )
+  //@formatter:on
+
+}

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/imdb/GraphPreprocessing.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/imdb/GraphPreprocessing.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.imdb
+
+import api._
+import examples.graphs.model._
+import io.csv.CSV
+import model._
+
+@emma.lib
+object GraphPreprocessing {
+
+  type Proj[L] = DataBag[Collaboration] => L
+
+  def apply[L: Meta](input: String, csv: CSV)(proj: Proj[L]): DataBag[LEdge[Person, L]] = {
+
+    // FIXME: CSVMacro does not work with Option[T] types
+    val people : DataBag[Person] = ??? // DataBag.readCSV[Person](s"$input/people.csv", csv)
+    val movies : DataBag[Movie]  = ??? // DataBag.readCSV[Movie](s"$input/people.csv", csv)
+    val credits: DataBag[Credit] = ??? // DataBag.readCSV[Credit](s"$input/people.csv", csv)
+
+    val collaborations = for {
+      pd <- people
+      cd <- credits
+      mv <- movies
+      ca <- credits
+      pa <- people
+      if pd.id == cd.personID
+      if mv.id == cd.movieID
+      if mv.id == ca.movieID
+      if pa.id == ca.personID
+      if cd.creditType == CreditType.Director.toString
+      if ca.creditType == CreditType.Actor.toString
+    } yield Collaboration(pd, cd, mv, ca, pa)
+
+    for {
+      Group((pd, pa), cs) <- collaborations.groupBy(c => (c.director, c.actor))
+    } yield {
+      LEdge(pd, pa, proj(cs))
+    }
+  }
+
+  //----------------------------------------------------------------------------
+  // helper model
+  //----------------------------------------------------------------------------
+
+  //@formatter:off
+  case class Collaboration
+  (
+    director       : Person,
+    creditDirector : Credit,
+    movie          : Movie,
+    creditActor    : Credit,
+    actor          : Person
+  )
+  //@formatter:on
+
+}

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/imdb/model.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/imdb/model.scala
@@ -1,0 +1,145 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.imdb
+
+object model {
+
+  //@formatter:off
+  case class Movie
+  (
+    id       : Long,
+    title    : Title,
+    year     : Option[Short]  = None,
+    yearFrom : Option[Short]  = None,
+    yearTo   : Option[Short]  = None
+  )
+
+  case class Title
+  (
+    title         : String,
+    version       : String,
+    titleType     : String,
+    episodeName   : Option[String] = None,
+    episodeNumber : Option[String] = None,
+    suspended     : Boolean        = false
+  ) {
+    private val parenTitleTypes = Set[String]("Series", "Episode")
+
+    override def toString: String = {
+      val modifiers = mkModifiers
+      val episodeNm = mkEpisodeName
+      val susString = if(suspended) Some("{{SUSPENDED}}") else None
+      Seq[Option[String]](Some(mkTitle), Some(s"($version)"), modifiers, episodeNm, susString)
+        .flatten
+        .mkString(" ")
+    }
+
+    private def mkTitle: String =
+      if(parenTitleTypes.contains(titleType)) s""""$title""""
+      else title
+
+    private def mkModifiers: Option[String] = titleType match {
+      case "TV"         => Some("(TV)")
+      case "Video"      => Some("(V)")
+      case "VideoGame"  => Some("(VG)")
+      case _            => None
+    }
+
+    private def mkEpisodeName: Option[String] =
+      List(episodeName, episodeNumber.map(n => s"($n)")).flatten match {
+        case Nil => None
+        case x => Some(s"""{${x.mkString(" ")}}""")
+      }
+  }
+
+  case class Person
+  (
+    id      : Long,
+    gender  : Option[String],
+    name    : String
+  )
+
+  case class Credit
+  (
+    personID        : Long,
+    movieID         : Long,
+    creditType      : String, // actor, director, cinematographer, editor, ...
+    creditedAs      : Option[String] = None,
+    characterName   : Option[String] = None,
+    billingPosition : Option[Int] = None
+  )
+
+  case class Rating
+  (
+    movieID: Long,
+    votesDistribution : String, // len 10, consisting of [.*1-9]
+    totalVotes        : Int,
+    rating            : String,
+    isNew             : Boolean = false
+  )
+
+  case class Technical
+  (
+    movieID: Long,
+    key     : String,
+    value   : String,
+    comment : Option[String]
+  )
+
+  case class Genre(movieID: Long, genre: String)
+
+  case class Country(movieID: Long, country: String)
+
+  case class Keyword(movieID: Long, keyword: String)
+
+  case class Location(movieID: Long, location: String, comment: Option[String])
+
+  case object TitleType extends Enumeration {
+    val MotionPicture = Value("MotionPicture")
+    val TV = Value("TV")
+    val Video = Value("Video")
+    val Series = Value("Series")
+    val Episode = Value("Episode")
+    val VideoGame = Value("VideoGame")
+  }
+
+  case object CreditType extends Enumeration {
+    val Actor = Value("actor")
+    val Composer = Value("composer")
+    val Cinematographer = Value("cinematographer")
+    val Director = Value("director")
+    val Editor = Value("editor")
+    val Producer = Value("producer")
+    val Writer = Value("writer")
+  }
+
+  case object TechnicalKey extends Enumeration {
+    val Cam = Value("Cam")
+    val Met = Value("Met")
+    val Ofm = Value("Ofm")
+    val Pfm = Value("Pfm")
+    val Rat = Value("Rat")
+    val Pcs = Value("Pcs")
+    val Lab = Value("Lab")
+  }
+
+  case object Gender extends Enumeration {
+    val Male = Value("m")
+    val Female = Value("f")
+  }
+  //@formatter:on
+}

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/ml/classification/NaiveBayes.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/ml/classification/NaiveBayes.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.ml.classification
+
+import api.Meta.Projections._
+import api._
+import examples.ml.model._
+
+import breeze.linalg._
+
+@emma.lib
+object NaiveBayes {
+
+  type ModelType = ModelType.Value
+  type Model[L] = (L, Double, Vector[Double])
+
+  def apply[L: Meta](
+    lambda: Double, modelType: ModelType // hyper-parameters
+  )(
+    data: DataBag[LVector[L]] // data-parameters
+  ): DataBag[Model[L]] = {
+    val dimensions = data.map(_.vector.length).distinct.fetch()
+    assert(dimensions.size == 1, "Multiple dimensions in input data. All vectors should have the same length.")
+    val N = dimensions.head
+
+    val aggregated = for (Group(label, values) <- data.groupBy(_.label)) yield {
+      val lCnt = values.size
+      val lSum = values.fold(Vector.zeros[Double](N))(_.vector, _ + _)
+      (label, lCnt, lSum)
+    }
+
+    val numPoints = data.size
+    val numLabels = aggregated.size
+    val priorDenom = math.log(numPoints + numLabels * lambda)
+
+    val model = for ((label, lCnt, lSum) <- aggregated) yield {
+      val prior = math.log(lCnt + lambda) - priorDenom
+
+      val evidenceDenom =
+        if (modelType == ModelType.Multinomial) math.log(sum(lSum) + lambda * N)
+        else /* bernoulli */ math.log(lCnt + 2.0 * lambda)
+
+      val evidence = for {
+        x <- lSum
+      } yield math.log(x + lambda) - evidenceDenom
+
+      (label, prior, evidence)
+    }
+
+    model
+  }
+
+  object ModelType extends Enumeration {
+    val Multinomial = Value("multinomial")
+    val Bernoulli = Value("bernoulli")
+  }
+
+}

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/ml/clustering/KMeans.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/ml/clustering/KMeans.scala
@@ -1,0 +1,104 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.ml.clustering
+
+import api._
+import api.Meta.Projections._
+import examples.ml.model._
+
+import breeze.linalg._
+
+@emma.lib
+object KMeans {
+
+  def apply[PID: Meta](
+    k: Int, epsilon: Double, iterations: Int // hyper-parameters
+  )(
+    points: DataBag[Point[PID]] // data-parameters
+  ): DataBag[Solution[PID]] = {
+
+    val dimensions = points.map(_.vector.length).distinct.fetch()
+    assert(dimensions.size == 1, "Multiple dimensions in input data. All vectors should have the same length.")
+    val N = dimensions.head
+
+    var bestSolution = DataBag.empty[Solution[PID]]
+    var minSqrDist = 0.0
+    val zeroVec = Vector.zeros[Double](N)
+
+    for (i <- 1 to iterations) {
+      // initialize forgy cluster means
+      var change = 0.0
+      var centroids = DataBag(points.sample(k))
+
+      // initialize solution
+      var solution = for (p <- points) yield {
+        val closest = centroids.min(comparing { (m1, m2) =>
+          val diff1 = p.vector - m1.vector
+          val diff2 = p.vector - m2.vector
+          (diff1 dot diff1) < (diff2 dot diff2)
+        })
+
+        val diff = p.vector - closest.vector
+        Solution(p, closest.id, diff dot diff)
+      }
+
+      do {
+        // update means
+        val newMeans = for (Group(clusterID, associatedPoints) <- solution.groupBy {
+          _.clusterID
+        }) yield {
+          val sum = associatedPoints.fold(zeroVec)(_.point.vector, _ + _)
+          val cnt = associatedPoints.size.toDouble
+          Point(clusterID, sum / cnt)
+        }
+
+        // compute change between the old and the new means
+        change = (for {
+          mean <- centroids
+          newMean <- newMeans
+          if mean.id == newMean.id
+        } yield sum((mean.vector - newMean.vector) :* (mean.vector - newMean.vector))).sum
+
+        // update solution: re-assign clusters
+        solution = for (s <- solution) yield {
+          val closest = centroids.min(comparing { (m1, m2) =>
+            val diff1 = s.point.vector - m1.vector
+            val diff2 = s.point.vector - m2.vector
+            (diff1.t * diff1) < (diff2.t * diff2)
+          })
+
+          val diff = s.point.vector - closest.vector
+          s.copy(clusterID = closest.id, sqrDist = diff dot diff)
+        }
+
+        // use new means for the next iteration
+        centroids = newMeans
+      } while (change > epsilon)
+
+      val sumSqrDist = solution.map(_.sqrDist).sum
+      if (i <= 1 || sumSqrDist < minSqrDist) {
+        minSqrDist = sumSqrDist
+        bestSolution = solution
+      }
+    }
+
+    bestSolution
+  }
+
+  case class Solution[PID](point: Point[PID], clusterID: PID, sqrDist: Double = 0)
+
+}

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/ml/model.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/ml/model.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.ml
+
+import api._
+
+import breeze.linalg.Vector
+
+import scala.reflect.ClassTag
+import scala.reflect.runtime.universe._
+
+/** Machine learning model objects. */
+object model {
+
+  case class Point[ID: Meta](@emma.pk id: ID, vector: Vector[Double])
+
+  case class LVector[L: Meta](label: L, vector: Vector[Double])
+
+  //@formatter:off
+  implicit def pointMeta[ID: Meta]: Meta[Point[ID]] = new Meta[Point[ID]] {
+    implicit def ctagID = implicitly[Meta[ID]].ctag
+    implicit def ttagID = implicitly[Meta[ID]].ttag
+    override def ctag = implicitly[ClassTag[Point[ID]]]
+    override def ttag = implicitly[TypeTag[Point[ID]]]
+  }
+
+  implicit def edgeMeta[L: Meta]: Meta[LVector[L]] = new Meta[LVector[L]] {
+    implicit def ctagL = implicitly[Meta[L]].ctag
+    implicit def ttagL = implicitly[Meta[L]].ttag
+    override def ctag = implicitly[ClassTag[LVector[L]]]
+    override def ttag = implicitly[TypeTag[LVector[L]]]
+  }
+  //@formatter:on
+}

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/text/WordCount.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/text/WordCount.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.text
+
+import api._
+
+@emma.lib
+object WordCount {
+
+  def apply(docs: DataBag[String]): DataBag[(String, Long)] = {
+    val words = for {
+      line <- docs
+      word <- DataBag[String](line.toLowerCase.split("\\W+"))
+    } yield word
+
+    // group the words by their identity and count the occurrence of each word
+    val counts = for {
+      group <- words.groupBy(identity)
+    } yield (group.key, group.values.size)
+
+    counts
+  }
+}

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/datamining/classification/NaiveBayesTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/datamining/classification/NaiveBayesTest.scala
@@ -43,7 +43,7 @@ class NaiveBayesTest extends FlatSpec with Matchers with BeforeAndAfter {
     deleteRecursive(new File(path))
   }
 
-  "NaiveBayes" should "create the correct model on Bernoulli house-votes-84 data set" in withRuntime() { rt =>
+  "NaiveBayes" should "create the correct model on Bernoulli house-votes-84 data set" ignore withRuntime() { rt =>
     val expectedModel = Source
       .fromFile(s"$path/model.txt")
       .getLines().map { line =>

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/datamining/clustering/KMeansTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/datamining/clustering/KMeansTest.scala
@@ -44,7 +44,7 @@ class KMeansTest extends FlatSpec with Matchers with BeforeAndAfter {
     deleteRecursive(new File(path))
   }
 
-  "KMeans" should "cluster points around the corners of a hypercube" in withRuntime() { rt =>
+  "KMeans" should "cluster points around the corners of a hypercube" ignore withRuntime() { rt =>
     val expected = clusters(Source
       .fromFile(s"$path/clusters.tsv")
       .getLines().map { line =>

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/TransitiveClosureTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/TransitiveClosureTest.scala
@@ -41,7 +41,7 @@ class TransitiveClosureTest extends FlatSpec with Matchers with BeforeAndAfter {
     deleteRecursive(new File(path))
   }
 
-  "TransitiveClosure" should "compute the transitive closure of a directed graph" in
+  "TransitiveClosure" should "compute the transitive closure of a directed graph" ignore
     withRuntime() { rt =>
       val graph = Source.fromFile(s"$path/edges.tsv").getLines.map { line =>
         val record = line.split('\t').map(_.toLong)

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/TriangleCountTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/graphs/TriangleCountTest.scala
@@ -40,7 +40,7 @@ class TriangleCountTest extends FlatSpec with Matchers with BeforeAndAfter {
     deleteRecursive(new File(path))
   }
 
-  "Triangle Count" should "find the correct number of triangles" in withRuntime() { rt =>
+  "Triangle Count" should "find the correct number of triangles" ignore withRuntime() { rt =>
     val ts = new TriangleCount(s"$path/edges.tsv", "", rt).algorithm run rt
     ts should be (3629)
   }

--- a/emma-examples/src/test/scala/eu/stratosphere/emma/examples/text/WordCountTest.scala
+++ b/emma-examples/src/test/scala/eu/stratosphere/emma/examples/text/WordCountTest.scala
@@ -46,7 +46,7 @@ class WordCountTest extends FlatSpec with Matchers with BeforeAndAfter {
     deleteRecursive(Paths.get(path).toFile)
   }
 
-  "WordCount" should "count words" in withRuntime() { rt =>
+  "WordCount" should "count words" ignore withRuntime() { rt =>
     new WordCount(s"$path/hamlet.txt", s"$path/output.txt", rt).run()
 
     val act = DataBag(fromPath(s"$path/output.txt"))

--- a/emma-examples/src/test/scala/org/emmalanguage/cli/SparkExamples.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/cli/SparkExamples.scala
@@ -1,0 +1,264 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package cli
+
+import api.Meta.Projections._
+import api._
+import examples.graphs._
+import examples.graphs.model._
+import examples.ml.classification._
+import examples.ml.clustering._
+import examples.ml.model._
+import examples.text._
+import io.csv.CSV
+
+import breeze.linalg.Vector
+import org.apache.spark.sql.SparkSession
+
+// TODO: migrate this to `emma-spark` once the dependency to `emma-examples` is inverted
+object SparkExamples {
+
+  // ---------------------------------------------------------------------------
+  // Config and helper type aliases
+  // ---------------------------------------------------------------------------
+
+  //@formatter:off
+  case class Config
+  (
+    // general parameters
+    master      : String               = "local[*]",
+    command     : Option[String]       = None,
+    // union of all parameters bound by a command option or argument
+    // (in alphabetic order)
+    csv         : CSV                  = CSV(),
+    epsilon     : Double               = 0,
+    iterations  : Int                  = 0,
+    input       : String               = System.getProperty("java.io.tmpdir"),
+    k           : Int                  = 0,
+    lambda      : Double               = 0,
+    nbModelType : NaiveBayes.ModelType = NaiveBayes.ModelType.Bernoulli,
+    output      : String               = System.getProperty("java.io.tmpdir")
+  )
+  //@formatter:on
+
+  // ---------------------------------------------------------------------------
+  // Parser & main method
+  // ---------------------------------------------------------------------------
+
+  val parser = new Parser {
+    head("emma-examples", "0.2-SNAPSHOT")
+
+    help("help")
+      .text("Show this help message")
+
+    opt[String]("master")
+      .action((x, c) => c.copy(master = x))
+      .text("Spark master address")
+
+    section("Graph Analytics")
+    cmd("transitive-closure")
+      .text("Compute the transitive closure of a directed graph")
+      .children(
+        arg[String]("input")
+          .text("edges path")
+          .action((x, c) => c.copy(input = x)),
+        arg[String]("output")
+          .text("closure path")
+          .action((x, c) => c.copy(output = x)))
+    note("")
+    cmd("triangle-count")
+      .text("Count the number of triangle cliques in a graph")
+      .children(
+        arg[String]("input")
+          .text("edges path")
+          .action((x, c) => c.copy(input = x)))
+
+    section("Machine Learning")
+    cmd("naive-bayes")
+      .text("Naive Bayes classification")
+      .children(
+        arg[Double]("lambda")
+          .text("termination threshold")
+          .action((x, c) => c.copy(lambda = x)),
+        arg[NaiveBayes.ModelType]("model-type")
+          .text("'beroulli' or 'multinomial'")
+          .action((x, c) => c.copy(nbModelType = x)),
+        arg[String]("input")
+          .text("training data path")
+          .action((x, c) => c.copy(input = x)),
+        arg[String]("output")
+          .text("resulting model path")
+          .action((x, c) => c.copy(output = x)))
+    note("")
+    cmd("k-means")
+      .text("K-Means Clustering")
+      .children(
+        arg[Int]("k")
+          .text("number of clusters")
+          .action((x, c) => c.copy(k = x)),
+        arg[Double]("epsilon")
+          .text("termination threshold")
+          .action((x, c) => c.copy(epsilon = x))
+          .validate(between("epsilon", 0, 1.0)),
+        arg[Int]("iterations")
+          .text("number of repeated iterations")
+          .action((x, c) => c.copy(iterations = x))
+          .validate(between("iterations", 0, 100)),
+        arg[String]("input")
+          .text("points path")
+          .action((x, c) => c.copy(input = x)),
+        arg[String]("output")
+          .text("solution path")
+          .action((x, c) => c.copy(output = x)))
+
+    section("Text Analytics")
+    cmd("word-count")
+      .text("Word Count Example")
+      .children(
+        arg[String]("input")
+          .text("documents path")
+          .action((x, c) => c.copy(input = x)),
+        arg[String]("output")
+          .text("word counts path")
+          .action((x, c) => c.copy(output = x)))
+  }
+
+  def main(args: Array[String]): Unit =
+    (for {
+      cfg <- parser.parse(args, Config())
+      cmd <- cfg.command
+      res <- cmd match {
+        // Graphs
+        case "transitive-closure" =>
+          Some(transitiveClosure(cfg)(sparkSession(cfg)))
+        case "triangle-count" =>
+          Some(triangleCount(cfg)(sparkSession(cfg)))
+        // Machine Learning
+        case "naive-bayes" =>
+          Some(naiveBayes(cfg)(sparkSession(cfg)))
+        case "k-means" =>
+          Some(kMeans(cfg)(sparkSession(cfg)))
+        // Text
+        case "word-count" =>
+          Some(wordCount(cfg)(sparkSession(cfg)))
+        case _ =>
+          None
+      }
+    } yield res) getOrElse parser.showUsage()
+
+  // ---------------------------------------------------------------------------
+  // Parallelized algorithms
+  // ---------------------------------------------------------------------------
+
+  // Graphs
+
+  def transitiveClosure(c: Config)(implicit spark: SparkSession): Unit =
+    emma.onSpark {
+      // read in set of edges to be used as input
+      val edges = DataBag.readCSV[Edge[Long]](c.input, c.csv)
+      // build the transitive closure
+      val paths = TransitiveClosure(edges)
+      // write the results into a file
+      paths.writeCSV(c.output, c.csv)
+    }
+
+  def triangleCount(c: Config)(implicit spark: SparkSession): Unit =
+    emma.onSpark {
+      // convert a bag of directed edges into an undirected set
+      val incoming = DataBag.readCSV[Edge[Long]](c.input, c.csv)
+      val outgoing = incoming.map(e => Edge(e.dst, e.src))
+      val edges = (incoming union outgoing).distinct
+      // compute all triangles
+      val triangles = EnumerateTriangles(edges)
+      // count the number of enumerated triangles
+      val triangleCount = triangles.size
+      // print the result to the console
+      println(s"The number of triangles in the graph is $triangleCount")
+    }
+
+  // Machine Learning
+
+  def naiveBayes(c: Config)(implicit spark: SparkSession): Unit =
+    emma.onSpark {
+      // read the training data
+      val data = for (line <- DataBag.readCSV[String](c.input, c.csv)) yield {
+        val record = line.split(",").map(_.toDouble)
+        LVector(record.head, Vector(record.slice(1, record.length)))
+      }
+      // run classification algorithm
+      val model = NaiveBayes(c.lambda, c.nbModelType)(data)
+      // write the result model into a file
+      model.writeCSV(c.output, c.csv)
+    }
+
+  def kMeans(c: Config)(implicit spark: SparkSession): Unit =
+    emma.onSpark {
+      // read the input
+      val points = for (line <- DataBag.readCSV[String](c.input, c.csv)) yield {
+        val record = line.split("\t")
+        Point(record.head.toLong, Vector(record.tail.map(_.toDouble)))
+      }
+      // do the clustering
+      val solution = KMeans(c.k, c.epsilon, c.iterations)(points)
+      // write the result model into a file
+      solution.writeCSV(c.output, c.csv)
+    }
+
+  // Text
+
+  def wordCount(c: Config)(implicit spark: SparkSession): Unit =
+    emma.onSpark {
+      // read the input files and split them into lowercased words
+      val docs = DataBag.readCSV[String](c.input, c.csv)
+      // parse and count the words
+      val counts = WordCount(docs)
+      // write the results into a file
+      counts.writeCSV(c.output, c.csv)
+    }
+
+  // ---------------------------------------------------------------------------
+  // Helper methods
+  // ---------------------------------------------------------------------------
+
+  private def sparkSession(c: Config): SparkSession = SparkSession.builder()
+    .master(c.master)
+    .appName(s"Emma example: c.command")
+    .getOrCreate()
+
+  class Parser extends scopt.OptionParser[Config]("emma-examples") {
+
+    import scopt._
+    import scala.Ordering.Implicits._
+
+    implicit val naiveBayesModelTypeRead: scopt.Read[NaiveBayes.ModelType] =
+      scopt.Read.reads(NaiveBayes.ModelType.withName)
+
+    override def usageExample: String =
+      "emma-examples command [options] <args>..."
+
+    override def cmd(name: String): OptionDef[Unit, Config] =
+      super.cmd(name).action((_, c) => c.copy(command = Some(name)))
+
+    def section(name: String): OptionDef[Unit, Config] =
+      note(s"\n## $name\n")
+
+    def between[T: Numeric](name: String, min: T, max: T) = (x: T) =>
+      if (x > min && x < max) success
+      else failure(s"Value <$name> must be > $min and < $max")
+  }
+
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/compiler/integration/BaseCompilerITCase.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/compiler/integration/BaseCompilerITCase.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler.integration
+
+import compiler.BaseCompilerSpec
+
+/** Base trait for full Emma examples. */
+trait BaseCompilerITCase extends BaseCompilerSpec {
+
+  import compiler._
+
+  // ---------------------------------------------------------------------------
+  // Transformation pipelines
+  // ---------------------------------------------------------------------------
+
+  val anfPipeline: u.Expr[Any] => u.Tree =
+    compiler.pipeline(typeCheck = true)(
+      Core.anf
+    ).compose(_.tree)
+
+  val liftPipeline: u.Expr[Any] => u.Tree =
+    compiler.pipeline(typeCheck = true)(
+      LibSupport.expand,
+      Core.lift
+    ).compose(_.tree)
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/compiler/integration/graphs/EnumerateTrianglesITCase.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/compiler/integration/graphs/EnumerateTrianglesITCase.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler.integration.graphs
+
+import api.Meta.Projections._
+import api._
+import compiler.integration.BaseCompilerITCase
+import compiler.ir.ComprehensionSyntax._
+import examples.graphs._
+import examples.graphs.model._
+import io.csv.CSV
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+import scala.Ordering.Implicits._
+
+/** A spec for comprehension normalization. */
+@RunWith(classOf[JUnitRunner])
+class EnumerateTrianglesITCase extends BaseCompilerITCase {
+
+  import compiler._
+
+  // ---------------------------------------------------------------------------
+  // Program closure
+  // ---------------------------------------------------------------------------
+
+  // input parameters
+  val input: String = null
+  val csv = CSV()
+
+  // ---------------------------------------------------------------------------
+  // Program representations
+  // ---------------------------------------------------------------------------
+
+  val sourceExpr = liftPipeline(u.reify {
+    // convert a list of directed edges
+    val incoming = DataBag.readCSV[Edge[Long]](input, csv)
+    val outgoing = incoming.map(e => Edge(e.dst, e.src))
+    val edges = (incoming union outgoing).distinct
+    // compute all triangles
+    val triangles = EnumerateTriangles[Long](edges)
+    // count the number of enumerated triangles
+    val triangleCount = triangles.size
+    // print the result to the console
+    println(s"The number of triangles in the graph is $triangleCount")
+  })
+
+  val coreExpr = anfPipeline(u.reify {
+    // convert a list of directed edges
+    val input = this.input
+    val csv = this.csv
+    val incoming = DataBag.readCSV[Edge[Long]](input, csv)
+    val outgoing = comprehension[Edge[Long], DataBag] {
+      val e = generator[Edge[Long], DataBag](incoming)
+      head(Edge(e.dst, e.src))
+    }
+    val edges$r1 = (incoming union outgoing).distinct
+    // compute all triangles
+    val edges$r2 = edges$r1;
+    val o: Ordering[Long] = scala.math.Ordering.Long
+    val triangles = comprehension[Triangle[Long], DataBag] {
+      val e1 = generator[Edge[Long], DataBag](edges$r2)
+      val e2 = generator[Edge[Long], DataBag](edges$r2)
+      val e3 = generator[Edge[Long], DataBag](edges$r2)
+      guard {
+        val x$1 = e1.src
+        val u$1 = e1.dst
+        val ops$1 = infixOrderingOps[Long](x$1)(o)
+        ops$1 < u$1
+      }
+      guard {
+        val y$1 = e2.src
+        val v$1 = e2.dst
+        val ops$1 = infixOrderingOps[Long](y$1)(o)
+        ops$1 < v$1
+      }
+      guard {
+        val z$1 = e3.src
+        val w$1 = e3.dst
+        val ops$1 = infixOrderingOps[Long](z$1)(o)
+        ops$1 < w$1
+      }
+      guard {
+        val u$2 = e1.dst
+        val y$2 = e2.src
+        u$2 == y$2
+      }
+      guard {
+        val x$2 = e1.src
+        val z$2 = e3.src
+        x$2 == z$2
+      }
+      guard {
+        val v$2 = e2.dst
+        val w$2 = e3.dst
+        v$2 == w$2
+      }
+      head {
+        val x$3 = e1.src
+        val u$3 = e1.dst
+        val v$3 = e2.dst
+        Triangle(x$3, u$3, v$3)
+      }
+    }
+    // count the number of enumerated triangles
+    val triangleCount = triangles.size
+    // print the result to the console
+    println(s"The number of triangles in the graph is $triangleCount")
+  })
+
+  // ---------------------------------------------------------------------------
+  // Specs
+  // ---------------------------------------------------------------------------
+
+  "lifting" in {
+    sourceExpr shouldBe alphaEqTo(coreExpr)
+  }
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/compiler/integration/text/WordCountITCase.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/compiler/integration/text/WordCountITCase.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler.integration.text
+
+import api.DataBag
+import api.Group
+import compiler.integration.BaseCompilerITCase
+import compiler.ir.ComprehensionSyntax._
+import examples.text.WordCount
+import io.csv.CSV
+
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+@RunWith(classOf[JUnitRunner])
+class WordCountITCase extends BaseCompilerITCase {
+
+  import compiler._
+
+  // ---------------------------------------------------------------------------
+  // Program closure
+  // ---------------------------------------------------------------------------
+
+  // input parameters
+  val input: String = null
+  val output: String = null
+  val csv = CSV()
+
+  // ---------------------------------------------------------------------------
+  // Program representations
+  // ---------------------------------------------------------------------------
+
+  val sourceExpr = liftPipeline(u.reify {
+    // read the input files and split them into lowercased words
+    val docs = DataBag.readCSV[String](input, csv)
+    // parse and count the words
+    val counts = WordCount(docs)
+    // write the results into a CSV file
+    counts.writeCSV(output, csv)
+  })
+
+  val coreExpr = anfPipeline(u.reify {
+    val input = this.input
+    val csv$r1 = this.csv
+    val docs = DataBag.readCSV[String](input, csv$r1)
+
+    // read the input files and split them into lowercased words
+    val words = comprehension[String, DataBag] {
+      val line = generator[String, DataBag] {
+        docs
+      }
+      val word = generator[String, DataBag] {
+        DataBag[String](line.toLowerCase.split("\\W+"))
+      }
+      head {
+        word
+      }
+    }
+
+    val anonfun$r3 = (x: String) => {
+      val x$r3 = Predef identity x
+      x$r3
+    }
+
+    val groupBy$r1 = words groupBy anonfun$r3
+
+    // group the words by their identity and count the occurrence of each word
+    val counts = comprehension[(String, Long), DataBag] {
+      val group = generator[Group[String, DataBag[String]], DataBag] {
+        groupBy$r1
+      }
+      head {
+        (group.key, group.values.size)
+      }
+    }
+
+    // write the results into a CSV file
+    val output$r1 = this.output
+    val csv$r2 = this.csv
+    val x$r1 = counts.writeCSV(output$r1, csv$r2)
+    x$r1
+  })
+
+  // ---------------------------------------------------------------------------
+  // Specs
+  // ---------------------------------------------------------------------------
+
+  "lifting" in {
+    sourceExpr shouldBe alphaEqTo(coreExpr)
+  }
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/graphs/BaseTransitiveClosureSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/graphs/BaseTransitiveClosureSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.graphs
+
+import examples.graphs.model.Edge
+import io.csv.CSV
+import test.util._
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import scala.io.Source
+
+import java.io.File
+
+trait BaseTransitiveClosureSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  val dir = "/graphs/trans-closure"
+  val path = tempPath(dir)
+
+  before {
+    new File(path).mkdirs()
+    materializeResource(s"$dir/edges.tsv")
+  }
+
+  after {
+    deleteRecursive(new File(path))
+  }
+
+  "TransitiveClosure" should "compute the transitive closure of a directed graph" in {
+    val graph = (for {
+      line <- Source.fromFile(s"$path/edges.tsv").getLines
+    } yield {
+      val record = line.split('\t').map(_.toLong)
+      Edge(record(0), record(1))
+    }).toSet
+
+    val closure = transitiveClosure(s"$path/edges.tsv", CSV())
+
+    graph subsetOf closure should be(true)
+  }
+
+  def transitiveClosure(input: String, csv: CSV): Set[Edge[Long]]
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/graphs/BaseTriangleCountSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/graphs/BaseTriangleCountSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.graphs
+
+import api._
+import io.csv.CSV
+import test.util._
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+
+trait BaseTriangleCountSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  val dir = "/graphs/triangle-cnt"
+  val path = tempPath(dir)
+
+  before {
+    new File(path).mkdirs()
+    materializeResource(s"$dir/edges.tsv")
+  }
+
+  after {
+    deleteRecursive(new File(path))
+  }
+
+  "Triangle Count" should "find the correct number of triangles" in {
+    val ts = triangleCount(s"$path/edges.tsv", CSV())
+    ts should be(3629)
+  }
+
+  def triangleCount(input: String, csv: CSV): Long
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/graphs/SparkTransitiveClosureSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/graphs/SparkTransitiveClosureSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.graphs
+
+import api._
+import examples.graphs.model.Edge
+import io.csv.CSV
+import eu.stratosphere.emma.testutil.ExampleTest
+
+import org.apache.spark.sql.SparkSession
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+// TODO: migrate this to `emma-spark` once the dependency to `emma-examples` is inverted
+@Category(Array(classOf[ExampleTest]))
+@RunWith(classOf[JUnitRunner])
+class SparkTransitiveClosureSpec extends BaseTransitiveClosureSpec {
+
+  override def transitiveClosure(input: String, csv: CSV): Set[Edge[Long]] =
+    emma.onSpark {
+      // read in set of edges
+      val edges = DataBag.readCSV[Edge[Long]](input, csv)
+      // build the transitive closure
+      val paths = TransitiveClosure(edges)
+      // return the closure as local set
+      paths.fetch().toSet
+    }
+
+  implicit lazy val sparkSession = SparkSession.builder()
+    .master("local[*]")
+    .appName(this.getClass.getSimpleName)
+    .getOrCreate()
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/graphs/SparkTriangleCountSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/graphs/SparkTriangleCountSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.graphs
+
+import api._
+import examples.graphs.model.Edge
+import io.csv.CSV
+import eu.stratosphere.emma.testutil.ExampleTest
+
+import org.apache.spark.sql.SparkSession
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+// TODO: migrate this to `emma-spark` once the dependency to `emma-examples` is inverted
+@Category(Array(classOf[ExampleTest]))
+@RunWith(classOf[JUnitRunner])
+class SparkTriangleCountSpec extends BaseTriangleCountSpec {
+
+  override def triangleCount(input: String, csv: CSV): Long =
+    emma.onSpark {
+      // read a bag of directed edges
+      // and convert it into an undirected bag without duplicates
+      val incoming = DataBag.readCSV[Edge[Long]](input, csv)
+      val outgoing = incoming.map(e => Edge(e.dst, e.src))
+      val edges = (incoming union outgoing).distinct
+      // compute all triangles
+      val triangles = EnumerateTriangles(edges)
+      // count and return the number of enumerated triangles
+      triangles.size
+    }
+
+  implicit lazy val sparkSession = SparkSession.builder()
+    .master("local[*]")
+    .appName(this.getClass.getSimpleName)
+    .getOrCreate()
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/ml/classification/BaseNaiveBayesSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/ml/classification/BaseNaiveBayesSpec.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.ml.classification
+
+import test.util._
+
+import breeze.linalg.Vector
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import scala.io.Source
+
+import java.io.File
+
+trait BaseNaiveBayesSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  type MType = NaiveBayes.ModelType
+  type Model = NaiveBayes.Model[Double]
+
+  val dir = "/classification/naivebayes"
+  val path = tempPath(dir)
+
+  before {
+    new File(path).mkdirs()
+    materializeResource(s"$dir/vote.csv")
+    materializeResource(s"$dir/model.txt")
+  }
+
+  after {
+    deleteRecursive(new File(path))
+  }
+
+  "NaiveBayes" should "create the correct model on Bernoulli house-votes-84 data set" in {
+    val expectedModel = for {
+      line <- Source.fromFile(s"$path/model.txt").getLines().toSet[String]
+    } yield {
+      val values = line.split(",").map(_.toDouble)
+      (values(0), values(1), Vector(values.slice(2, values.length)))
+    }
+
+    val solution = naiveBayes(s"$path/vote.csv", 1.0, NaiveBayes.ModelType.Bernoulli)
+
+    solution should contain theSameElementsAs expectedModel
+  }
+
+  def naiveBayes(input: String, lambda: Double, modelType: MType): Set[Model]
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/ml/classification/SparkNaiveBayesSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/ml/classification/SparkNaiveBayesSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.ml.classification
+
+import api.Meta.Projections._
+import api._
+import examples.ml.model._
+import io.csv.CSV
+import eu.stratosphere.emma.testutil.ExampleTest
+
+import breeze.linalg.Vector
+import org.apache.spark.sql.SparkSession
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+// TODO: migrate this to `emma-spark` once the dependency to `emma-examples` is inverted
+@Category(Array(classOf[ExampleTest]))
+@RunWith(classOf[JUnitRunner])
+class SparkNaiveBayesSpec extends BaseNaiveBayesSpec {
+
+  def naiveBayes(input: String, lambda: Double, modelType: MType): Set[Model] =
+    emma.onSpark {
+      // read the input
+      val data = for (line <- DataBag.readCSV[String](input, CSV())) yield {
+        val record = line.split(",").map(_.toDouble)
+        LVector(record.head, Vector(record.slice(1, record.length)))
+      }
+      // classification
+      val result = NaiveBayes(lambda, modelType)(data)
+      // fetch the result locally
+      result.fetch().toSet[Model]
+    }
+
+  implicit lazy val sparkSession = SparkSession.builder()
+    .master("local[*]")
+    .appName(this.getClass.getSimpleName)
+    .getOrCreate()
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/ml/clustering/BaseKMeansSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/ml/clustering/BaseKMeansSpec.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.ml.clustering
+
+import KMeans.Solution
+import test.util._
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import scala.io.Source
+
+import java.io.File
+
+trait BaseKMeansSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  val dir = "/clustering/kmeans"
+  val path = tempPath(dir)
+  val epsilon = 1e-3
+  val iterations = 5
+  val delimiter = "\t"
+  val overlap = .75
+
+  before {
+    new File(path).mkdirs()
+    materializeResource(s"$dir/points.tsv")
+    materializeResource(s"$dir/clusters.tsv")
+  }
+
+  after {
+    deleteRecursive(new File(path))
+  }
+
+  "KMeans" should "cluster points around the corners of a hypercube" in {
+    val exp =
+      clusters(for {
+        line <- Source.fromFile(s"$path/clusters.tsv").getLines().toSet[String]
+      } yield {
+        val Seq(point, cluster) = line.split(delimiter).map(_.toLong).toSeq
+        point -> cluster
+      })
+
+    val act =
+      clusters(for {
+        s <- kMeans(exp.size, epsilon, iterations, s"$path/points.tsv")
+      } yield (s.point.id, s.clusterID))
+
+    val correctClusters =
+      (for {
+        act <- act
+        exp <- exp
+        if (act & exp).size / exp.size.toDouble >= overlap
+      } yield ()).size
+
+    correctClusters / exp.size.toDouble shouldBe 1
+  }
+
+  def clusters(associations: Set[(Long, Long)]): Iterable[Set[Long]] =
+    for ((_, values) <- associations.groupBy { case (p, c) => c })
+      yield values.map { case (p, c) => p }
+
+  def kMeans(size: Int, epsilon: Double, iterations: Int, input: String): Set[Solution[Long]]
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/ml/clustering/SparkKMeansSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/ml/clustering/SparkKMeansSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.ml.clustering
+
+import KMeans.Solution
+import api.Meta.Projections._
+import api._
+import examples.ml.model._
+import io.csv.CSV
+import eu.stratosphere.emma.testutil.ExampleTest
+
+import breeze.linalg.Vector
+import org.apache.spark.sql.SparkSession
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+// TODO: migrate this to `emma-spark` once the dependency to `emma-examples` is inverted
+@Category(Array(classOf[ExampleTest]))
+@RunWith(classOf[JUnitRunner])
+class SparkKMeansSpec extends BaseKMeansSpec {
+
+  override def kMeans(k: Int, epsilon: Double, iterations: Int, input: String): Set[Solution[Long]] =
+    emma.onSpark {
+      // read the input
+      val points = for (line <- DataBag.readCSV[String](input, CSV())) yield {
+        val record = line.split("\t")
+        Point(record.head.toLong, Vector(record.tail.map(_.toDouble)))
+      }
+      // do the clustering
+      val result = KMeans(k, epsilon, iterations)(points)
+      // return the solution as a local set
+      result.fetch().toSet[Solution[Long]]
+    }
+
+  implicit lazy val sparkSession = SparkSession.builder()
+    .master("local[*]")
+    .appName(this.getClass.getSimpleName)
+    .getOrCreate()
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/text/BaseWordCountSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/text/BaseWordCountSpec.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.text
+
+import api._
+import io.csv.CSV
+import test.util._
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import java.nio.file.Paths
+
+trait BaseWordCountSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  val dir = "/text/"
+  val path = tempPath(dir)
+  val text = "To be or not to Be"
+
+  before {
+    new File(path).mkdirs()
+    Files.write(Paths.get(s"$path/hamlet.txt"), text.getBytes(StandardCharsets.UTF_8))
+  }
+
+  after {
+    deleteRecursive(Paths.get(path).toFile)
+  }
+
+  "WordCount" should "count words" in {
+    wordCount(s"$path/hamlet.txt", s"$path/output.txt", CSV())
+
+    val act = DataBag(fromPath(s"$path/output.txt"))
+    val exp = DataBag(text.toLowerCase.split("\\W+").groupBy(x => x).toSeq.map(x => s"${x._1}\t${x._2.length}"))
+
+    compareBags(act.fetch(), exp.fetch())
+  }
+
+  def wordCount(input: String, output: String, csv: CSV): Unit
+}

--- a/emma-examples/src/test/scala/org/emmalanguage/examples/text/SparkWordCountSpec.scala
+++ b/emma-examples/src/test/scala/org/emmalanguage/examples/text/SparkWordCountSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.text
+
+import api._
+import io.csv.CSV
+import eu.stratosphere.emma.testutil.ExampleTest
+
+import org.apache.spark.sql.SparkSession
+import org.junit.experimental.categories.Category
+import org.junit.runner.RunWith
+import org.scalatest.junit.JUnitRunner
+
+// TODO: migrate this to `emma-spark` once the dependency to `emma-examples` is inverted
+@Category(Array(classOf[ExampleTest]))
+@RunWith(classOf[JUnitRunner])
+class SparkWordCountSpec extends BaseWordCountSpec {
+
+  override def wordCount(input: String, output: String, csv: CSV): Unit =
+    emma.onSpark {
+      // read the input
+      val docs = DataBag.readCSV[String](input, csv)
+      // parse and count the words
+      val counts = WordCount(docs)
+      // write the results into a file
+      counts.writeCSV(output, csv)
+    }
+
+  implicit lazy val sparkSession = SparkSession.builder()
+    .master("local[*]")
+    .appName(this.getClass.getSimpleName)
+    .getOrCreate()
+}

--- a/emma-flink/pom.xml
+++ b/emma-flink/pom.xml
@@ -21,8 +21,8 @@
 
     <parent>
         <artifactId>emma</artifactId>
-        <groupId>eu.stratosphere</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>org.emmalanguage</groupId>
+        <version>0.2-SNAPSHOT</version>
     </parent>
 
 
@@ -46,12 +46,12 @@
 
         <!-- Emma -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-language</artifactId>
         </dependency>
         <!-- Emma (test jars) -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-language</artifactId>
             <type>test-jar</type>
         </dependency>

--- a/emma-flink/pom.xml
+++ b/emma-flink/pom.xml
@@ -86,10 +86,6 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scalacheck</groupId>
-            <artifactId>scalacheck_${scala.tools.version}</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.tools.version}</artifactId>
         </dependency>

--- a/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
@@ -105,7 +105,9 @@ class FlinkDataSet[A: Meta] private[api](@transient private val rep: DataSet[A])
     rep.getExecutionEnvironment.execute()
   }
 
-  override lazy val fetch: Seq[A] =
+  def fetch(): Seq[A] = collect
+
+  private lazy val collect: Seq[A] =
     rep.collect()
 
   // -----------------------------------------------------

--- a/emma-gui/pom.xml
+++ b/emma-gui/pom.xml
@@ -21,8 +21,8 @@
 
     <parent>
         <artifactId>emma</artifactId>
-        <groupId>eu.stratosphere</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>org.emmalanguage</groupId>
+        <version>0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>emma-gui</artifactId>
@@ -35,11 +35,11 @@
     <dependencies>
         <!-- Emma -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-examples</artifactId>
         </dependency>
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-flink</artifactId>
         </dependency>
 

--- a/emma-language/pom.xml
+++ b/emma-language/pom.xml
@@ -21,8 +21,8 @@
 
     <parent>
         <artifactId>emma</artifactId>
-        <groupId>eu.stratosphere</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>org.emmalanguage</groupId>
+        <version>0.2-SNAPSHOT</version>
     </parent>
 
 

--- a/emma-language/pom.xml
+++ b/emma-language/pom.xml
@@ -118,10 +118,6 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scalacheck</groupId>
-            <artifactId>scalacheck_${scala.tools.version}</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.tools.version}</artifactId>
         </dependency>

--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/ConvertersMacros.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/ConvertersMacros.scala
@@ -52,7 +52,7 @@ class ConvertersMacros(val c: blackbox.Context) extends MacroAST {
     if (T <:< api.Type[Product]) {
       val method = T.decl(api.TermName.init).alternatives.head.asMethod
       val params = method.typeSignatureIn(T).paramLists.head
-      val args = for (p <- params) yield fromCSV(api.Type.of(p), value)
+      val args = for (p <- params) yield fromCSV(p.info, value)
       q"new $T(..$args)"
     } else {
       if (T =:= unit || T =:= Java.void) api.Term.unit

--- a/emma-language/src/main/scala/org/emmalanguage/api/ScalaSeq.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/ScalaSeq.scala
@@ -81,7 +81,7 @@ class ScalaSeq[A] private[api](private[api] val rep: Seq[A]) extends DataBag[A] 
   override def writeCSV(path: String, format: CSV)(implicit converter: CSVConverter[A]): Unit =
     CSVScalaSupport(format).write(path)(rep)
 
-  override val fetch: Seq[A] =
+  override def fetch(): Seq[A] =
     rep
 
 }

--- a/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
@@ -293,6 +293,10 @@ trait CommonAST {
     def pkg(sym: Symbol): Boolean =
       sym.isPackage
 
+    /** Is `sym` a by-name parameter? */
+    def byName(sym: Symbol): Boolean =
+      sym.isTerm && sym.asTerm.isByNameParam
+
     /** Is `tpe` legal for a term (i.e. not of a higher kind or method)? */
     def result(tpe: Type): Boolean =
       !is.poly(tpe) && !is.method(tpe)

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Loops.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Loops.scala
@@ -80,8 +80,7 @@ trait Loops { this: AST =>
         assert(is.defined(cond), s"$this condition is not defined: $cond")
         assert(is.defined(body), s"$this body is not defined: $body")
         assert(has.tpe(cond), s"$this condition has no type:\n${Tree.showTypes(cond)}")
-        lazy val Cond = Type.of(cond)
-        assert(Cond =:= Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
+        assert(cond.tpe <:< Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
 
         val nme = TermName.fresh("while")
         val lbl = LabelSym(u.NoSymbol, nme)
@@ -110,8 +109,7 @@ trait Loops { this: AST =>
         assert(is.defined(cond), s"$this condition is not defined: $cond")
         assert(is.defined(body), s"$this body is not defined: $body")
         assert(has.tpe(cond), s"$this condition has no type:\n${Tree.showTypes(cond)}")
-        lazy val Cond = Type.of(cond)
-        assert(Cond =:= Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
+        assert(cond.tpe <:< Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
 
         val nme = TermName.fresh("doWhile")
         val lbl = LabelSym(u.NoSymbol, nme)

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
@@ -25,8 +25,9 @@ trait Symbols { this: AST =>
   trait SymbolAPI { this: API =>
 
     import universe._
-    import u.definitions._
-    import u.internal._
+    import definitions._
+    import internal._
+    import reificationSupport._
     import u.Flag.IMPLICIT
 
     object Sym extends Node {
@@ -50,11 +51,11 @@ trait Symbols { this: AST =>
 
       /** Creates a copy of `sym`, optionally changing some of its attributes. */
       def copy(sym: u.Symbol)(
-          name:  u.Name     = sym.name,
-          owner: u.Symbol   = sym.owner,
-          tpe:   u.Type     = sym.info,
-          pos:   u.Position = sym.pos,
-          flags: u.FlagSet  = get.flags(sym)): u.Symbol = {
+        name:  u.Name     = sym.name,
+        owner: u.Symbol   = sym.owner,
+        tpe:   u.Type     = sym.info,
+        pos:   u.Position = sym.pos,
+        flags: u.FlagSet  = get.flags(sym)): u.Symbol = {
 
         // Optimize when there are no changes.
         if (name == sym.name && owner == sym.owner && tpe == sym.info &&
@@ -77,8 +78,7 @@ trait Symbols { this: AST =>
           else newTermSymbol(owner, termName, pos, flags)
         }
 
-        set.tpe(dup, Type.fix(tpe))
-        dup
+        setInfo(dup, tpe.dealias.widen)
       }
 
       /** A map of all tuple symbols by number of elements. */

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Trees.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Trees.scala
@@ -20,7 +20,6 @@ import cats.std.all._
 import shapeless._
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 trait Trees { this: AST =>
 
@@ -37,9 +36,9 @@ trait Trees { this: AST =>
 
       /** Creates a shallow copy of `tree`, preserving its type and setting new attributes. */
       def copy[T <: Tree](tree: T)(
-          pos: u.Position = tree.pos,
-          sym: u.Symbol   = tree.symbol,
-          tpe: u.Type     = tree.tpe): T = {
+        pos: u.Position = tree.pos,
+        sym: u.Symbol   = tree.symbol,
+        tpe: u.Type     = tree.tpe): T = {
 
         // Optimize when there are no changes.
         if (pos == tree.pos && sym == tree.symbol && tpe == tree.tpe) return tree
@@ -323,7 +322,7 @@ trait Trees { this: AST =>
         assert(has.tpe(target), s"$this target `$target` has no type")
         assert(is.encoded(target), s"$this target `$target` is not encoded")
 
-        val tpe = Type.of(target) match {
+        val tpe = target.info match {
           case u.NullaryMethodType(result) => result
           case other => other
         }
@@ -350,7 +349,7 @@ trait Trees { this: AST =>
 
         val mod = member.isPackageClass || member.isModuleClass
         val sym = if (mod) member.asClass.module else member
-        val tpe = Type.of(sym, in = target.tpe) match {
+        val tpe = sym.infoIn(target.tpe) match {
           case u.NullaryMethodType(result) => result
           case other => other
         }

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Variables.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Variables.scala
@@ -121,8 +121,8 @@ trait Variables { this: AST =>
         assert(is.term(rhs), s"$this RHS is not a term:\n${Tree.show(rhs)}")
         assert(has.tpe(lhs), s"$this LHS `$lhs` has no type")
         assert(has.tpe(rhs), s"$this RHS has no type:\n${Tree.showTypes(rhs)}")
-        lazy val (lhT, rhT) = (Type.of(lhs), Type.of(rhs))
-        assert(rhT weak_<:< lhT, s"$this LH type `$lhT` is not a supertype of RH type `$rhT`")
+        assert(rhs.tpe <:< lhs.info,
+          s"$this LH type `${lhs.info}` is not a supertype of RH type `${rhs.tpe}`")
 
         val mut = u.Assign(VarRef(lhs), rhs)
         set(mut, tpe = u.NoType)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
@@ -76,7 +76,8 @@ private[backend] trait Order extends Common {
      */
     lazy val disambiguate: u.Tree => (u.Tree, Set[u.TermSymbol]) = tree => {
 
-      def isFun(sym: u.TermSymbol) = api.Sym.funs(api.Type.of(sym).typeSymbol)
+      def isFun(sym: u.TermSymbol) =
+        api.Sym.funs(sym.info.dealias.widen.typeSymbol)
 
       // The Set of symbols of ValDefs of functions
       val funs = tree.collect {

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/cf/CFG.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/cf/CFG.scala
@@ -128,8 +128,7 @@ private[compiler] trait CFG extends Common {
             val values = defs.collect {
               case value @ (api.ValSym(_), _) => value
               case (_, core.ParDef(lhs, _, flags)) if choices.contains(lhs) =>
-                val tpe = api.Type.of(lhs)
-                val rhs = core.DefCall(module)(phi, tpe)(choices(lhs))
+                val rhs = core.DefCall(module)(phi, lhs.info)(choices(lhs))
                 lhs -> core.ParDef(lhs, rhs, flags)
             }
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
@@ -19,24 +19,28 @@ package compiler.lang.comprehension
 import compiler.Common
 import compiler.lang.core.Core
 
+import shapeless._
+
 import scala.annotation.tailrec
+import scala.collection.breakOut
 
 private[comprehension] trait Combination extends Common {
   self: Core with Comprehension =>
 
-  import Comprehension.{splitAt,Combinators}
-  import Core.{Lang => core}
-  import UniverseImplicits._
-
   private[comprehension] object Combination {
 
-    private val cs = new Comprehension.Syntax(API.bagSymbol)
+    import Comprehension._
+    import UniverseImplicits._
+    import Core.{Lang => core}
 
-    //@formatter:off
-    private val tuple2   = api.Type[(Nothing, Nothing)]
-    private val tuple2_1 = tuple2.member(api.TermName("_1")).asTerm
-    private val tuple2_2 = tuple2.member(api.TermName("_2")).asTerm
-    //@formatter:on
+    private type Rule = (u.Symbol, u.Tree) => Option[u.Tree]
+    private val cs = new Comprehension.Syntax(API.bagSymbol)
+    private val tuple2 = core.Ref(api.Sym.tuple(2).companion.asModule)
+    private val tuple2App = tuple2.tpe.member(api.TermName.app).asMethod
+    private val Seq(_1, _2) = {
+      val tuple2 = api.Type[(Nothing, Nothing)]
+      for (i <- 1 to 2) yield tuple2.member(api.TermName(s"_$i")).asTerm
+    }
 
     // TODO: Split conjunctive filter predicates.
 
@@ -52,10 +56,11 @@ private[comprehension] trait Combination extends Common {
      *
      * - An ANF tree with no mock-comprehensions.
      */
-    lazy val transform: u.Tree => u.Tree = root =>
-      api.TopDown.transform {
-        case comp@cs.Comprehension(_,_) => combine(comp)
-      }(root).tree
+    val transform: u.Tree => u.Tree =
+      api.TopDown.withOwner.transformWith {
+        case Attr.inh(comp @ cs.Comprehension(_, _), owner :: _) =>
+          combine(owner, comp)
+      }.andThen(_.tree)
 
     /**
      * Performs the combination for one comprehension. That is, the root of the given tree
@@ -65,54 +70,13 @@ private[comprehension] trait Combination extends Common {
      * of the rules would be interleaved across the outer and the nested comprehensions, which
      * would mess up the order of rule applications for a single comprehension.
      */
-    lazy val combine: u.Tree => u.Tree = root0 => {
-
-      var root = root0
-
-      //@formatter:off
-      // states for the state machine
-      sealed trait RewriteState
-      object Start     extends RewriteState
-      object Filter    extends RewriteState
-      object FlatMap   extends RewriteState
-      object FlatMap2  extends RewriteState
-      object Join      extends RewriteState
-      object Cross     extends RewriteState
-      object Residuals extends RewriteState
-      object End       extends RewriteState
-
-      def applyOnce(rule: u.Tree =?> u.Tree): Boolean = {
-        if (rule.isDefinedAt(root)) {
-          val prevRoot = root
-          root = rule(root)
-          root != prevRoot
-        } else {
-          false
-        }
+    @tailrec def combine(owner: u.Symbol, tree: u.Tree): u.Tree =
+      rules.foldLeft(Option.empty[u.Tree]) {
+        (done, rule) => done orElse rule(owner, tree)
+      } match {
+        case Some(result) => combine(owner, result)
+        case None => tree
       }
-
-      @tailrec
-      def applyExhaustively(rule: u.Tree =?> u.Tree): Unit = {
-        if (applyOnce(rule)) applyExhaustively(rule)
-      }
-
-      // state machine for the rewrite process
-      @tailrec
-      def process(state: RewriteState): u.Tree = state match {
-        case Start     => process(Filter)
-        case Filter    => applyExhaustively(MatchFilter); process(FlatMap)
-        case FlatMap   => if (applyOnce(MatchFlatMap))    process(Filter) else process(FlatMap2)
-        case FlatMap2  => if (applyOnce(MatchFlatMap2))   process(Filter) else process(Join)
-        case Join      => if (applyOnce(MatchEquiJoin))   process(Filter) else process(Cross)
-        case Cross     => if (applyOnce(MatchCross))      process(Filter) else process(Residuals)
-        case Residuals => applyOnce(MatchResidual);       process(End)
-        case End       => root
-      }
-      //@formatter:on
-
-      // run the state machine
-      process(Start)
-    }
 
     /**
      * Creates a filter combinator.
@@ -151,8 +115,8 @@ private[comprehension] trait Combination extends Common {
      *         $pVals
      *         $pExpr
      *       }
-     *       val $ir = $xExpr withFilter $p
-     *       $ir
+     *       val $filtered = $xExpr withFilter $p
+     *       $filtered
      *     }
      *     $qs2
      *     $qs3
@@ -160,44 +124,26 @@ private[comprehension] trait Combination extends Common {
      *   }
      * }}}
      */
-    val MatchFilter: u.Tree =?> u.Tree = Function.unlift((tree: u.Tree) => tree match {
-      case cs.Comprehension(qs, hd) =>
-
-        val allGenVars = (for {
-          cs.Generator(x, _) <- qs
-        } yield x).toSet
-
-        (for {
-          grd@cs.Guard(grdBlk@core.Let(pVals, Seq(), pExpr)) <- qs.view // (Seq() is to disallow control flow)
-          (qs12, qs3) = splitAt(grd)(qs)
-          gen@cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs12
-          (qs1, qs2) = splitAt[u.Tree](gen)(qs12)
-          if {
-            val refdGens = api.Tree.refs(grd) intersect allGenVars
-            refdGens.isEmpty || (refdGens.size == 1 && refdGens.head == x)
-          }
-        } yield {
-
-          val pArg = api.TermSym.free(api.TermName.fresh("pArg"), Core.bagElemTpe(xExpr))
-          val pBdy = replaceRefs(x, pArg)(grdBlk)
-          val (pRef, pVal) = valDefAndRef("p", core.Lambda(pArg)(pBdy))
-          val (irRef, irVal) = valDefAndRef("ir", cs.WithFilter(xExpr)(pRef))
-
-          //@formatter:off
-          cs.Comprehension(
-            qs1 ++
-            Seq(cs.Generator(x, core.Let(
-              xVals :+ pVal :+ irVal: _*
-            )()(irRef))) ++
-            qs2 ++ qs3,
-            hd
-          )
-          //@formatter:on
-
-        }).headOption
+    val MatchFilter: Rule = {
+      case (owner, cs.Comprehension(qs, hd)) => (for {
+        guard @ cs.Guard(pred) <- qs.view
+        (qs12, qs3) = splitAt(guard)(qs)
+        // (Seq() is to disallow control flow)
+        xGen @ cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs12.view
+        (qs1, qs2) = splitAt[u.Tree](xGen)(qs12)
+        refd = api.Tree.refs(guard) intersect gens(qs12)
+        if refd.isEmpty || (refd.size == 1 && refd.head == x)
+      } yield {
+        val (pRef, pVal) = valRefAndDef(owner, "p", core.Lambda(x)(pred))
+        val (fRef, fVal) = valRefAndDef(owner, "filtered", cs.WithFilter(xExpr)(pRef))
+        val vals = Seq.concat(xVals, Seq(pVal, fVal))
+        val gen = cs.Generator(x, core.Let(vals: _*)()(fRef))
+        val combined = Seq.concat(qs1, Seq(gen), qs2, qs3)
+        cs.Comprehension(combined, hd)
+      }).headOption
 
       case _ => None
-    })
+    }
 
 
     /**
@@ -213,14 +159,14 @@ private[comprehension] trait Combination extends Common {
      *       $xExpr
      *     }
      *     $qs2
-     *     val $y = generator yBlk
+     *     val $y = generator yBody
      *     $qs3
      *     $hd
      *   }
      * }}}
      *
      * ==Guard==
-     * - The generator of `y` must refer to exactly one generator variable and this variable should be `x`.
+     * - The generator of `y` must refer to exactly one generator variable - `x`.
      * - The remaining qualifiers, as well as the head should not refer to `x`.
      * - The matched generators should not have control flow.
      *
@@ -232,52 +178,35 @@ private[comprehension] trait Combination extends Common {
      *     $qs2
      *     val $y = generator {
      *       $xVals
-     *       val $f = $fArg => yBlk[fArg/x]
-     *       val $ir = $xExpr flatMap $f
-     *       $ir
+     *       val $f = $x => yBody
+     *       val $fmapped = $xExpr flatMap $f
+     *       $fmapped
      *     }
      *     $qs3
      *     $hd
      *   }
      * }}}
      */
-    val MatchFlatMap: u.Tree =?> u.Tree = Function.unlift((tree: u.Tree) => tree match {
-      case cs.Comprehension(qs, hd) =>
+    val MatchFlatMap: Rule = {
+      case (owner, cs.Comprehension(qs, hd)) => (for {
+        // (Seq() is to disallow control flow)
+        xGen @ cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs.view
+        (qs1, qs23) = splitAt[u.Tree](xGen)(qs)
+        yGen @ cs.Generator(y, yRhs) <- qs23.view
+        (qs2, qs3) = splitAt[u.Tree](yGen)(qs23)
+        if (api.Tree.refs(yGen) intersect gens(qs)) == Set(x)
+        if Seq.concat(qs2, qs3, Seq(hd)).forall(!api.Tree.refs(_).contains(x))
+      } yield {
+        val (fRef, fVal) = valRefAndDef(owner, "f", core.Lambda(x)(yRhs))
+        val (fmRef, fmVal) = valRefAndDef(owner, "fmapped", cs.FlatMap(xExpr)(fRef))
+        val vals = Seq.concat(xVals, Seq(fVal, fmVal))
+        val gen = cs.Generator(y, core.Let(vals: _*)()(fmRef))
+        val combined = Seq.concat(qs1, qs2, Seq(gen), qs3)
+        cs.Comprehension(combined, hd)
+      }).headOption
 
-        val allGenVars = (for {
-          cs.Generator(x, _) <- qs
-        } yield x).toSet
-
-        (for {
-          xGen@cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs.view // (Seq() is to disallow control flow)
-          (qs1, qs23) = splitAt[u.Tree](xGen)(qs)
-          yGen@cs.Generator(y, yBlk@core.Let(_, Seq(), _)) <- qs23
-          (qs2, qs3) = splitAt[u.Tree](yGen)(qs23)
-          if (api.Tree.refs(yGen) intersect allGenVars) == Set(x)
-          if (qs2 ++ qs3 :+ hd).forall(!api.Tree.refs(_).contains(x))
-        } yield {
-
-          val fArg = api.TermSym.free(api.TermName.fresh("fArg"), Core.bagElemTpe(xExpr))
-          val fBdy = replaceRefs(x, fArg)(yBlk)
-          val (fRef, fVal) = valDefAndRef("f", core.Lambda(fArg)(fBdy))
-          val (irRef, irVal) = valDefAndRef("ir", cs.FlatMap(xExpr)(fRef))
-
-          //@formatter:off
-          cs.Comprehension(
-            qs1 ++ qs2 ++
-            Seq(cs.Generator(y, core.Let(
-              xVals :+ fVal :+ irVal: _*
-            )()(irRef))) ++
-            qs3,
-            hd
-          )
-          //@formatter:on
-
-        }).headOption
-
-      case _ =>
-        None
-    })
+      case _ => None
+    }
 
     /**
      * Creates a flatMap combinator. The difference between this and the other flatMap rule, is that
@@ -303,7 +232,7 @@ private[comprehension] trait Combination extends Common {
      * }}}
      *
      * ==Guard==
-     * - The generator of `y` must refer to exactly one generator variable and this variable should be `x`.
+     * - The generator of `y` must refer to exactly one generator variable - `x`.
      * - The matched generators should not have control flow.
      *
      * ==Rewrite==
@@ -312,17 +241,17 @@ private[comprehension] trait Combination extends Common {
      *     $qs1
      *     val $xy = generator {
      *       $xVals
-     *       val $f = $fArg => {
-     *         $yVals[fArg/x]
-     *         val $g = $gArg => {
-     *           val $ir2 = ($fArg, $gArg)
-     *           $ir2
+     *       val $f = $x => {
+     *         $yVals
+     *         val $g = $y1 => {
+     *           val $ir = ($x, $y1)
+     *           $ir
      *         }
-     *         val $xy0 = $yExpr[fArg/x] map $g
-     *         $xy0
+     *         val $mapped = $yExpr map $g
+     *         $mapped
      *       }
-     *       val $ir = $xExpr flatMap $f
-     *       $ir
+     *       val $fmapped = $xExpr flatMap $f
+     *       $fmapped
      *     }
      *     $qs2[xy._1/x][xy._2/y]  // Note: Introduce ValDefs for xy._1 and xy._2 to maintain ANF
      *     $qs3[xy._1/x][xy._2/y]
@@ -330,70 +259,40 @@ private[comprehension] trait Combination extends Common {
      *   }
      * }}}
      */
-    val MatchFlatMap2: u.Tree =?> u.Tree = Function.unlift((tree: u.Tree) => tree match {
-      case cs.Comprehension(qs, hd) =>
+    val MatchFlatMap2: Rule = {
+      case (owner, cs.Comprehension(qs, hd)) => (for {
+        // (Seq() is to disallow control flow)
+        xGen @ cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs.view
+        (qs1, qs23) = splitAt[u.Tree](xGen)(qs)
+        yGen @ cs.Generator(y, core.Let(yVals, Seq(), yExpr)) <- qs23.view
+        (qs2, qs3) = splitAt[u.Tree](yGen)(qs23)
+        if (api.Tree.refs(yGen) intersect gens(qs)) == Set(x)
+      } yield {
+        val y1 = api.TermSym.free(api.TermName.fresh(y), Core.bagElemTpe(yExpr))
+        val irArgs = Seq(core.Ref(x), core.Ref(y1))
+        val irRhs = core.DefCall(Some(tuple2))(tuple2App, x.info, y1.info)(irArgs)
+        val (irRef, irVal) = valRefAndDef(owner, "ir", irRhs)
+        val gBody = core.Let(irVal)()(irRef)
+        val (gRef, gVal) = valRefAndDef(owner, "g", core.Lambda(y1)(gBody))
+        val (mRef, mVal) = valRefAndDef(owner, "mapped", cs.Map(yExpr)(gRef))
+        val fBody = core.Let(yVals ++ Seq(gVal, mVal): _*)()(mRef)
+        val (fRef, fVal) = valRefAndDef(owner, "f", core.Lambda(x)(fBody))
+        val (fmRef, fmVal) = valRefAndDef(owner, "fmapped", cs.FlatMap(xExpr)(fRef))
+        val xyTpe = Core.bagElemTpe(fmRef)
+        assert(xyTpe.typeConstructor =:= api.Sym.tuple(2).toTypeConstructor)
+        val xy = api.ValSym(owner, api.TermName.fresh("xy"), xyTpe)
+        val xyRef = core.Ref(xy)
+        val xy1 = core.ValDef(x, core.DefCall(Some(xyRef))(_1)())
+        val xy2 = core.ValDef(y, core.DefCall(Some(xyRef))(_2)())
+        val bind = capture(cs, Seq(xy1, xy2)) _
+        val vals = Seq.concat(xVals, Seq(fVal, fmVal))
+        val gen = cs.Generator(xy, core.Let(vals: _*)()(fmRef))
+        val combined = Seq.concat(qs1, Seq(gen), qs2.view map bind, qs3.view map bind)
+        cs.Comprehension(combined, bind(hd))
+      }).headOption
 
-        val allGenVars = (for {
-          cs.Generator(x, _) <- qs
-        } yield x).toSet
-
-        (for {
-          xGen@cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs.view // (Seq() is to disallow control flow)
-          (qs1, qs23) = splitAt[u.Tree](xGen)(qs)
-          yGen@cs.Generator(y, yBlk@core.Let(yVals, Seq(), yExpr)) <- qs23
-          (qs2, qs3) = splitAt[u.Tree](yGen)(qs23)
-          if (api.Tree.refs(yGen) intersect allGenVars) == Set(x)
-        } yield {
-
-          val fArg = api.TermSym.free(api.TermName.fresh("fArg"), Core.bagElemTpe(xExpr))
-          val fArgRef = core.Ref(fArg)
-          val xTofArg = (tree: u.Tree) => replaceRefs(x, fArg)(tree)
-          val yValsRepl = yVals map { case core.ValDef(lhs, rhs, fs) => core.ValDef(lhs, xTofArg(rhs), fs) }
-          val yExprRepl = xTofArg(yExpr)
-          val gArg = api.TermSym.free(api.TermName.fresh("gArg"), Core.bagElemTpe(yExpr))
-          val gArgRef = core.Ref(gArg)
-          val (ir2Ref, ir2Val) = valDefAndRef("ir2", core.Inst(tuple2, fArgRef.tpe, gArgRef.tpe)(
-            Seq(fArgRef, gArgRef)))
-          val gBdy = core.Let(ir2Val)()(ir2Ref)
-          val (gRef, gVal) = valDefAndRef("g", core.Lambda(gArg)(gBdy))
-          val (xy0Ref, xy0Val) = valDefAndRef("xy0", cs.Map(yExprRepl)(gRef))
-          val fBdy = core.Let(yValsRepl :+ gVal :+ xy0Val: _*)()(xy0Ref)
-          val (fRef, fVal) = valDefAndRef("f", core.Lambda(fArg)(fBdy))
-          val (irRef, irVal) = valDefAndRef("ir", cs.FlatMap(xExpr)(fRef))
-
-          //@formatter:off
-          val xyTpe = Core.bagElemTpe(irRef)
-          assert(xyTpe.typeConstructor == api.Sym.tuple(2).toTypeConstructor)
-          val xySym = api.TermSym.free(api.TermName.fresh("xy"), xyTpe)
-          val xyRef = core.Ref(xySym)
-          val xy_1  = core.DefCall(Some(xyRef))(tuple2_1)()
-          val xy_2  = core.DefCall(Some(xyRef))(tuple2_2)()
-
-          val replaceXYandANF =
-            api.Tree.replace(core.Ref(x), xy_1) andThen
-            api.Tree.replace(core.Ref(y), xy_2) andThen
-            Core.anf
-
-          val qsReplFunc = this.qsReplFunc(replaceXYandANF)
-          val qs2Repl = qs2 map qsReplFunc
-          val qs3Repl = qs3 map qsReplFunc
-          val hdRepl = cs.Head(Comprehension.asLet(replaceXYandANF(cs.Head.unapply(hd).get)))
-
-          cs.Comprehension(
-            qs1 ++
-            Seq(cs.Generator(xySym, core.Let(
-              xVals :+ fVal :+ irVal: _*
-            )()(irRef))) ++
-            qs2Repl ++ qs3Repl,
-            hdRepl
-          )
-          //@formatter:on
-
-        }).headOption
-
-      case _ =>
-        None
-    })
+      case _ => None
+    }
 
     /**
      * Creates a cross combinator.
@@ -417,70 +316,50 @@ private[comprehension] trait Combination extends Common {
      * }}}
      *
      * ==Guard==
-     * - The matched generators should not be correlated, i.e. the generator of `y` should not refer to `x`.
+     * - The matched generators should not be correlated, i.e. the gen of `y` should not refer `x`.
      * - The matched generators should not have control flow.
      *
      * ==Rewrite==
-     * {{{ [[ hd[c.x/x][c.y/y] | qs1, c ← ⨯ xs ys, qs3[c.x/x][c.y/y] ]] }}}
+     * {{{ [[ hd[xy._1/x][xy._2/y] | qs1, xy ← ⨯ xs ys, qs3[xy._1/x][xy._2/y] ]] }}}
      * {{{
      *   comprehension {
      *     $qs1
-     *     val $c = generator {
+     *     val $xy = generator {
      *       $xVals
      *       $yVals
-     *       val ir = cross($xExpr, $yExpr)
-     *       ir
+     *       val $crossed = cross($xExpr, $yExpr)
+     *       $crossed
      *     }
-     *     $qs3[c.x/x][c.y/y]  // Note: Introduce ValDefs for c.x and c.y to maintain ANF
-     *     $hd[c.x/x][c.y/y]
+     *     $qs3[xy._1/x][xy._2/y]  // Note: Introduce ValDefs for xy._1 and xy._2 to maintain ANF
+     *     $hd[xy._1/x][xy._2/y]
      *   }
      * }}}
      */
-    val MatchCross: u.Tree =?> u.Tree = Function.unlift((tree: u.Tree) => tree match {
-      case cs.Comprehension(qs, hd) =>
+    val MatchCross: Rule = {
+      case (owner, cs.Comprehension(qs, hd)) => (for {
+        // (Seq() is to disallow control flow)
+        xGen @ cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs.view
+        (qs1, qs23) = splitAt[u.Tree](xGen)(qs)
+        yGen @ cs.Generator(y, core.Let(yVals, Seq(), yExpr)) <- qs23.view
+        (qs2, qs3) = splitAt[u.Tree](yGen)(qs23)
+        if qs2.isEmpty && !api.Tree.refs(yGen).contains(x)
+      } yield {
+        val (cRef, cVal) = valRefAndDef(owner, "crossed", Combinators.Cross(xExpr, yExpr))
+        val xyTpe = Core.bagElemTpe(cRef)
+        assert(xyTpe.typeConstructor =:= api.Sym.tuple(2).toTypeConstructor)
+        val xy = api.ValSym(owner, api.TermName.fresh("xy"), xyTpe)
+        val xyRef = core.Ref(xy)
+        val xy1 = core.ValDef(x, core.DefCall(Some(xyRef))(_1)())
+        val xy2 = core.ValDef(y, core.DefCall(Some(xyRef))(_2)())
+        val bind = capture(cs, Seq(xy1, xy2)) _
+        val vals = Seq.concat(xVals, yVals, Seq(cVal))
+        val gen = cs.Generator(xy, core.Let(vals: _*)()(cRef))
+        val combined = Seq.concat(qs1, Seq(gen), qs3.view map bind)
+        cs.Comprehension(combined, bind(hd))
+      }).headOption
 
-        (for {
-          xGen@cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs.view // (Seq() is to disallow control flow)
-          (qs1, qs23) = splitAt[u.Tree](xGen)(qs)
-          yGen@cs.Generator(y, core.Let(yVals, Seq(), yExpr)) <- qs23
-          (qs2, qs3) = splitAt[u.Tree](yGen)(qs23)
-          if qs2.isEmpty
-          if !api.Tree.refs(yGen).contains(x)
-        } yield {
-
-          val (irRef, irVal) = valDefAndRef("ir", Combinators.Cross(xExpr, yExpr))
-
-          //@formatter:off
-          val cTpe = Core.bagElemTpe(irRef)
-          assert(cTpe.typeConstructor == api.Sym.tuple(2).toTypeConstructor)
-          val cSym = api.TermSym.free(api.TermName.fresh("c"), cTpe)
-          val cRef = core.Ref(cSym)
-          val cx   = core.DefCall(Some(cRef))(tuple2_1)()
-          val cy   = core.DefCall(Some(cRef))(tuple2_2)()
-
-          val replaceXYandANF =
-            api.Tree.replace(core.Ref(x), cx) andThen
-            api.Tree.replace(core.Ref(y), cy) andThen
-            Core.anf
-
-          val qs3Repl = qs3 map qsReplFunc(replaceXYandANF)
-          val hdRepl = cs.Head(Comprehension.asLet(replaceXYandANF(cs.Head.unapply(hd).get)))
-
-          cs.Comprehension(
-            qs1 ++
-            Seq(cs.Generator(cSym, core.Let(
-              xVals ++ yVals :+ irVal: _*
-            )()(irRef))) ++
-            qs3Repl,
-            hdRepl
-          )
-          //@formatter:on
-
-        }).headOption
-
-      case _ =>
-        None
-    })
+      case _ => None
+    }
 
     /**
      * Creates a join combinator.
@@ -500,9 +379,9 @@ private[comprehension] trait Combination extends Common {
      *     }
      *     $qs3
      *     guard {
-     *       $joinCondVals0
-     *       val jcr = $kxExpr == $kyExpr  // Or `$kyExpr == $kxExpr`
-     *       jcr
+     *       $joinVals
+     *       val $cond = $kxExpr == $kyExpr  // Or `$kyExpr == $kxExpr`
+     *       $cond
      *     }
      *     $qs4
      *     $hd
@@ -510,118 +389,88 @@ private[comprehension] trait Combination extends Common {
      * }}}
      *
      * ==Guard==
-     * - The matched generators should not be correlated, i.e. the generator of `y` should not refer to `x`.
+     * - The matched generators should not be correlated, i.e. the gen of `y` should not refer `x`.
      * - The matched guard should refer to x and y, but not to other generator variables.
      * - $kxExpr's dependencies in $joinCondVals0 should not contain y, and vice versa for $kyExpr
      * - The matched generators and guard should not have control flow.
      *
      * ==Rewrite==
-     * {{{ [[ hd[j.x/x][j.y/y] | qs1, j ← ⋈ k₁ k₂ xs ys, qs3[j.x/x][j.y/y], qs4[j.x/x][j.y/y] ]] }}}
+     * {{{ [[ hd[xy._1/x][xy._2/y] | qs1, xy ← ⋈ k₁ k₂ xs ys, qs3[xy._1/x][xy._2/y],
+     *        qs4[xy._1/x][xy._2/y] ]] }}}
      * {{{
      *   comprehension {
      *     $qs1
-     *     val $j = generator {
+     *     val $xy = generator {
      *       $xVals
      *       $yVals
      *       val $kx = x => {
-     *         $joinCondVals0  // But only those vals that are needed for kxExpr
+     *         $joinVals  // But only those vals that are needed for kxExpr
      *         $kxExpr
      *       }
      *       val $ky = y => {
-     *         $joinCondVals0  // But only those vals that are needed for kyExpr
+     *         $joinVals  // But only those vals that are needed for kyExpr
      *         $kyExpr
      *       }
-     *       val $ir = join $kx $ky $xExpr $yExpr
-     *       $ir
+     *       val $joined = join $kx $ky $xExpr $yExpr
+     *       $joined
      *     }
-     *     $qs3[j.x/x][j.y/y]  // Note: Introduce ValDefs for j.x and j.y to maintain ANF
-     *     $qs4[j.x/x][j.y/y]
-     *     $hd[j.x/x][j.y/y]
+     *     $qs3[xy._1/x][xy._2/y]  // Note: Introduce ValDefs for j.x and j.y to maintain ANF
+     *     $qs4[xy._1/x][xy._2/y]
+     *     $hd[xy._1/x][xy._2/y]
      *   }
      * }}}
      */
-    val MatchEquiJoin: u.Tree =?> u.Tree = Function.unlift((tree: u.Tree) => tree match {
-      case cs.Comprehension(qs, hd) =>
+    val MatchEquiJoin: Rule = {
+      case (owner, cs.Comprehension(qs, hd)) => (for {
+        // (Seq() is to disallow control flow)
+        xGen @ cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs.view
+        (qs1, qs234) = splitAt[u.Tree](xGen)(qs)
+        yGen @ cs.Generator(y, core.Let(yVals, Seq(), yExpr)) <- qs234.view
+        (qs2, qs34) = splitAt[u.Tree](yGen)(qs234)
+        if qs2.isEmpty && !api.Tree.refs(yGen).contains(x)
+        grd @ cs.Guard(core.Let(grdVals, Seq(), core.Ref(cond))) <- qs34.view
+        if (api.Tree.refs(grd) intersect gens(qs)) == Set(x, y)
+        condVal @ core.ValDef(`cond`, core.DefCall(Some(eqLhs), eq, _, Seq(eqRhs)), _) <- grdVals
+        if eq.name.toString == "$eq$eq"
+        joinVals = grdVals.filter(_ != condVal)
+        (kxExpr, kyExpr) <- Seq((eqLhs, eqRhs), (eqRhs, eqLhs))
+        kxBody = Core.dce(core.Let(joinVals: _*)()(kxExpr))
+        if !api.Tree.refs(kxBody).contains(y)
+        kyBody = Core.dce(core.Let(joinVals: _*)()(kyExpr))
+        if !api.Tree.refs(kyBody).contains(x)
+        (qs3, qs4) = splitAt[u.Tree](grd)(qs34)
+      } yield {
+        // It can happen that the key functions have differing return types (e.g. Long and Int).
+        // In this case, we add casts before the return expr of the key functions to the weakLub.
+        def maybeCast(tree: u.Tree) = if (kxExpr.tpe =:= kyExpr.tpe) tree else tree match {
+          case core.Let(valDefs, _, expr) =>
+            val asInstanceOf = expr.tpe.member(api.TermName("asInstanceOf")).asTerm
+            val kLub = api.Type.weakLub(kxExpr.tpe, kyExpr.tpe)
+            val cast = core.DefCall(Some(expr))(asInstanceOf, kLub)()
+            val (castRef, castVal) = valRefAndDef(owner, "cast", cast)
+            core.Let(valDefs :+ castVal: _*)()(castRef)
+          case other => other
+        }
 
-        val allGenVars = (for {
-          cs.Generator(x, _) <- qs
-        } yield x).toSet
+        val (kxRef, kxVal) = valRefAndDef(owner, "kx", core.Lambda(x)(maybeCast(kxBody)))
+        val (kyRef, kyVal) = valRefAndDef(owner, "ky", core.Lambda(y)(maybeCast(kyBody)))
+        val join = Combinators.EquiJoin(kxRef, kyRef)(xExpr, yExpr)
+        val (jRef, jVal) = valRefAndDef(owner, "joined", join)
+        val xyTpe = Core.bagElemTpe(jRef)
+        assert(xyTpe.typeConstructor =:= api.Sym.tuple(2).toTypeConstructor)
+        val xy = api.ValSym(owner, api.TermName.fresh("xy"), xyTpe)
+        val xyRef = core.Ref(xy)
+        val xy1 = core.ValDef(x, core.DefCall(Some(xyRef))(_1)())
+        val xy2 = core.ValDef(y, core.DefCall(Some(xyRef))(_2)())
+        val bind = capture(cs, Seq(xy1, xy2)) _
+        val vals = Seq.concat(xVals, yVals, Seq(kxVal, kyVal, jVal))
+        val gen = cs.Generator(xy, core.Let(vals: _*)()(jRef))
+        val combined = Seq.concat(qs1, Seq(gen), qs3.view map bind, qs4.view map bind)
+        cs.Comprehension(combined, bind(hd))
+      }).headOption
 
-        (for {
-          xGen@cs.Generator(x, core.Let(xVals, Seq(), xExpr)) <- qs.view // (Seq() is to disallow control flow)
-          (qs1, qs234) = splitAt[u.Tree](xGen)(qs)
-          yGen@cs.Generator(y, core.Let(yVals, Seq(), yExpr)) <- qs234
-          (qs2, qs34) = splitAt[u.Tree](yGen)(qs234)
-          if qs2.isEmpty
-          if !api.Tree.refs(yGen).contains(x)
-          grd@cs.Guard(grdBlk@core.Let(joinCondVals, Seq(), joinCondExpr@core.Ref(jcr))) <- qs34
-          if (api.Tree.refs(grd) intersect allGenVars) == Set(x, y)
-          jcrVal@core.ValDef(`jcr`, core.DefCall(Some(eqeqLhs), method, _, Seq(eqeqRhs)), _) <- joinCondVals
-          if method.name.toString == "$eq$eq"
-          joinCondVals0 = joinCondVals.filter(_ != jcrVal)
-          (kxExpr, kyExpr) <- Seq((eqeqLhs, eqeqRhs), (eqeqRhs, eqeqLhs))
-          kxBdy0 = Core.dce(core.Let(joinCondVals0: _*)()(kxExpr))
-          if !api.Tree.refs(kxBdy0).contains(y)
-          kyBdy0 = Core.dce(core.Let(joinCondVals0: _*)()(kyExpr))
-          if !api.Tree.refs(kyBdy0).contains(x)
-          (qs3, qs4) = splitAt[u.Tree](grd)(qs34)
-        } yield {
-
-          // It can happen that the key functions have differing return types (e.g. Long and Int).
-          // In this case, we add casts before the return expression of the key functions to the weakLub.
-          val maybeAddCast = (t: u.Tree) => if (kxExpr.tpe == kyExpr.tpe) t
-          else t match {
-            case core.Let(valDefs, _, expr) =>
-              val asInstanceOf = expr.tpe.member(api.TermName("asInstanceOf")).asTerm
-              val kLub = api.Type.weakLub(kxExpr.tpe, kyExpr.tpe)
-              val (castRef, castVal) = valDefAndRef("cast", core.DefCall(Some(expr))(asInstanceOf, kLub)())
-              core.Let(valDefs :+ castVal: _*)()(castRef)
-          }
-
-          val kxArg = api.TermSym.free(api.TermName.fresh("kxArg"), Core.bagElemTpe(xExpr))
-          val kxBdy = replaceRefs(x, kxArg)(maybeAddCast(kxBdy0))
-          val (kxRef, kxVal) = valDefAndRef("kx", core.Lambda(kxArg)(kxBdy))
-
-          val kyArg = api.TermSym.free(api.TermName.fresh("kyArg"), Core.bagElemTpe(yExpr))
-          val kyBdy = api.TopDown.transform { case core.Ref(`y`) => core.Ref(kyArg) }(
-            api.Tree.refreshAll(maybeAddCast(kyBdy0))).tree
-          val (kyRef, kyVal) = valDefAndRef("ky", core.Lambda(kyArg)(kyBdy))
-
-          val (irRef, irVal) = valDefAndRef("ir", Combinators.EquiJoin(kxRef, kyRef)(xExpr, yExpr))
-
-          //@formatter:off
-          val jTpe = Core.bagElemTpe(irRef)
-          assert(jTpe.typeConstructor == api.Sym.tuple(2).toTypeConstructor)
-          val jSym = api.TermSym.free(api.TermName.fresh("j"), jTpe)
-          val jRef = core.Ref(jSym)
-          val jx   = core.DefCall(Some(jRef))(tuple2_1)()
-          val jy   = core.DefCall(Some(jRef))(tuple2_2)()
-
-          val replaceXYandANF =
-            api.Tree.replace(core.Ref(x), jx) andThen
-            api.Tree.replace(core.Ref(y), jy) andThen
-            Core.anf
-
-          val qsReplFunc = this.qsReplFunc(replaceXYandANF)
-          val qs3Repl = qs3 map qsReplFunc
-          val qs4Repl = qs4 map qsReplFunc
-          val hdRepl  = cs.Head(Comprehension.asLet(replaceXYandANF(cs.Head.unapply(hd).get)))
-
-          cs.Comprehension(
-            qs1 ++
-            Seq(cs.Generator(jSym, core.Let(
-              xVals ++ yVals :+ kxVal :+ kyVal :+ irVal: _*
-            )()(irRef))) ++
-            qs3Repl ++ qs4Repl,
-            hdRepl
-          )
-          //@formatter:on
-
-        }).headOption
-
-      case _ =>
-        None
-    })
+      case _ => None
+    }
 
     /**
      * Eliminates the residual comprehension.
@@ -646,37 +495,29 @@ private[comprehension] trait Combination extends Common {
      * {{{
      *   $xVals
      *   val $f = $fArg => $hd[fArg/x]
-     *   val $ir = $xExpr map $f
-     *   $ir
+     *   val $mapped = $xExpr map $f
+     *   $mapped
      * }}}
      */
-    val MatchResidual: u.Tree =?> u.Tree = Function.unlift((tree: u.Tree) => tree match {
-      case cs.Comprehension(Seq(cs.Generator(x, core.Let(xVals, Seq(), xExpr))), cs.Head(hd)) =>
-
-        val fArg = api.TermSym.free(api.TermName.fresh("fArg"), Core.bagElemTpe(xExpr))
-        val (fRef, fVal) = valDefAndRef("f", core.Lambda(fArg)(replaceRefs(x, fArg)(hd)))
-        val (irRef, irVal) = valDefAndRef("ir", cs.Map(xExpr)(fRef))
-
-        Some(core.Let(xVals :+ fVal :+ irVal :_*)()(irRef))
-
-      case _ =>
-        None
-    })
-
-    private def replaceRefs(find: u.TermSymbol, repl: u.TermSymbol)(t: u.Tree): u.Tree = {
-      api.Tree.replace(core.Ref(find), core.Ref(repl))(t)
+    val MatchResidual: Rule = {
+      case (own, cs.Comprehension(Seq(cs.Generator(x, core.Let(vs, Seq(), expr))), cs.Head(hd))) =>
+        val (fRef, fVal) = valRefAndDef(own, "f", core.Lambda(x)(hd))
+        val (mRef, mVal) = valRefAndDef(own, "mapped", cs.Map(expr)(fRef))
+        Some(core.Let(vs ++ Seq(fVal, mVal): _*)()(mRef))
+      case _ => None
     }
 
-    private def qsReplFunc(f: u.Tree => u.Tree): u.Tree =?> u.Tree = {
-      case cs.Generator(sym, blk) => cs.Generator(sym, Comprehension.asLet(f(blk)))
-      case cs.Guard(blk) => cs.Guard(Comprehension.asLet(f(blk)))
-    }
+    private val rules = Seq(
+      MatchFilter, MatchFlatMap, MatchFlatMap2,
+      MatchEquiJoin, MatchCross, MatchResidual)
 
     /** Creates a ValDef, and returns its Ident on the left hand side. */
-    private def valDefAndRef(name: String, rhs: u.Tree): (u.Ident, u.ValDef) = {
-      val sym = api.TermSym.free(api.TermName.fresh(name), rhs.tpe)
-      (core.Ref(sym), api.ValDef(sym, rhs))
+    private def valRefAndDef(own: u.Symbol, name: String, rhs: u.Tree): (u.Ident, u.ValDef) = {
+      val lhs = api.ValSym(own, api.TermName.fresh(name), rhs.tpe)
+      (core.Ref(lhs), core.ValDef(lhs, rhs))
     }
-  }
 
+    private def gens(qs: Seq[u.Tree]): Set[u.TermSymbol] =
+      qs.collect { case cs.Generator(x, _) => x } (breakOut)
+  }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
@@ -229,8 +229,7 @@ trait Comprehension extends Common
 
         def apply(kx: u.Tree, ky: u.Tree)(xs: u.Tree, ys: u.Tree): u.Tree = {
           val keyTpe = api.Type.arg(2, kx.tpe)
-          // See comment before maybeAddCast in Combination
-          assert(keyTpe == api.Type.arg(2, ky.tpe))
+          assert(keyTpe =:= api.Type.arg(2, ky.tpe))
 
           core.DefCall(module)(symbol,
             Core.bagElemTpe(xs), Core.bagElemTpe(ys), keyTpe)(
@@ -276,17 +275,41 @@ trait Comprehension extends Common
     // General helpers
     // -------------------------------------------------------------------------
 
+    /** Wraps `tree` in a Let block if necessary. */
     private[comprehension] def asLet(tree: u.Tree): u.Block = tree match {
       case let @ core.Let(_, _, _) => let
-      case other => core.Let()()(other)
+      case _ => core.Let()()(tree)
     }
 
-    /* Splits a `Seq[A]` into a prefix and suffix. */
-    private[comprehension] def splitAt[A](e: A): Seq[A] => (Seq[A], Seq[A]) = {
-      (_: Seq[A]).span(_ != e)
-    } andThen {
-      case (pre, Seq(_, suf@_*)) => (pre, suf)
+    /** Splits a `Seq[A]` into a prefix and suffix, excluding `pivot`. */
+    private[comprehension] def splitAt[A](pivot: A)(xs: Seq[A]): (Seq[A], Seq[A]) =
+      xs.span(_ != pivot) match {
+        case (prefix, Seq(_, suffix @ _*)) => (prefix, suffix)
+        case (prefix, _) => (prefix, Seq.empty)
+      }
+
+    /** Prepends and binds free variables in `tree` to `vals`. */
+    private[comprehension] def capture(
+      cs: Comprehension.Syntax,
+      vals: Seq[u.ValDef],
+      prune: Boolean = true
+    )(tree: u.Tree): u.Tree = {
+      val prefix = if (!prune) vals
+        else vals.filter(api.Tree.refs(tree).compose(_.symbol.asTerm))
+
+      def prepend(let: u.Tree): u.Block = let match {
+        case core.Let(suffix, defs, expr) =>
+          core.Let(prefix ++ suffix: _*)(defs: _*)(expr)
+        case expr =>
+          core.Let(prefix: _*)()(expr)
+      }
+
+      tree match {
+        case cs.Generator(x, gen) => cs.Generator(x, prepend(gen))
+        case cs.Guard(pred) => cs.Guard(prepend(pred))
+        case cs.Head(expr) => cs.Head(prepend(expr))
+        case _ => prepend(tree)
+      }
     }
   }
-
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
@@ -74,7 +74,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(f: u.Tree): u.Type =
-          api.Type.arg(2, api.Type.of(f))
+          api.Type.arg(2, f.tpe)
       }
 
       object FlatMap extends MonadOp {
@@ -94,7 +94,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(f: u.Tree): u.Type =
-          api.Type.arg(1, api.Type.arg(2, api.Type.of(f)))
+          api.Type.arg(1, api.Type.arg(2, f.tpe))
       }
 
       object WithFilter extends MonadOp {
@@ -131,7 +131,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(expr: u.Tree): u.Type =
-          api.Type of expr
+          expr.tpe
       }
 
       /** Con- and destructs a generator from/to a tree. */
@@ -150,7 +150,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(expr: u.Tree): u.Type =
-          api.Type.arg(1, api.Type.of(expr))
+          api.Type.arg(1, expr.tpe)
       }
 
       /** Con- and destructs a guard from/to a tree. */
@@ -180,7 +180,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(expr: u.Tree): u.Type =
-          api.Type.of(expr)
+          expr.tpe
       }
 
       /** Con- and destructs a flatten from/to a tree. */
@@ -197,7 +197,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(expr: u.Tree): u.Type =
-          api.Type.arg(1, api.Type.arg(1, api.Type.of(expr)))
+          api.Type.arg(1, api.Type.arg(1, expr.tpe))
       }
 
     }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Normalize.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Normalize.scala
@@ -218,11 +218,10 @@ private[comprehension] trait Normalize extends Common {
       val symbol = ComprehensionSyntax.comprehension
 
       def unapply(tree: u.Tree): Option[(Seq[u.Tree], u.Tree)] = tree match {
-        case Comprehension(qs,hd) => Some(qs, hd)
-        case t if api.Type.of(t).typeConstructor == Monad => {
-          val x = api.TermSym.free(api.TermName.fresh("x"), api.Type.arg(1, api.Type.of(t)))
+        case Comprehension(qs, hd) => Some(qs, hd)
+        case t if api.Type.constructor(t.tpe) =:= Monad =>
+          val x = api.TermSym.free(api.TermName.fresh("x"), api.Type.arg(1, t.tpe))
           Some(Seq(Generator(x, core.Let()()(t))), Head(core.Let()()(api.TermRef(x))))
-        }
         case _ => None
       }
     }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/ANF.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/ANF.scala
@@ -78,7 +78,7 @@ private[core] trait ANF extends Common {
         // Simplify expression
         case Attr.inh(src.TypeAscr(target, tpe), owner :: _) =>
           val (stats, expr) = decompose(target, unline = false)
-          if (tpe =:= api.Type.of(expr)) {
+          if (expr.tpe =:= tpe) {
             src.Block(stats: _*)(expr)
           } else {
             val nme = api.TermName.fresh(nameOf(expr))

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
@@ -370,10 +370,10 @@ trait Core extends Common
      * Gets the type argument of the DataBag type that is the type of the given expression.
      */
     def bagElemTpe(xs: u.Tree): u.Type = {
-      assert(api.Type.of(xs).typeConstructor == API.DataBag,
+      assert(api.Type.constructor(xs.tpe) =:= API.DataBag,
         s"`bagElemTpe` was called with a tree that has a non-bag type. " +
           s"The tree:\n-----\n$xs\n-----\nIts type: `${xs.tpe}`")
-      api.Type.arg(1, api.Type.of(xs))
+      api.Type.arg(1, xs.tpe)
     }
   }
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Trampoline.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Trampoline.scala
@@ -58,7 +58,7 @@ private[core] trait Trampoline extends Common {
             val (own, nme, pos) = (method.owner, method.name, method.pos)
             val flg = get.flags(method)
             val pss = paramss.map(_.map(_.symbol.asTerm))
-            val Res = api.Type.kind1[TailRec](api.Type.of(method).finalResultType)
+            val Res = api.Type.kind1[TailRec](method.info.finalResultType)
             method -> api.DefSym(own, nme, flg, pos)(tparams: _*)(pss: _*)(Res)
           }).toMap
       }.transformWith {
@@ -91,14 +91,13 @@ private[core] trait Trampoline extends Common {
 
         // Wrap a tail call.
         case core.DefCall(None, cont, targs, argss@_*) if local.contains(cont) =>
-          val Res = api.Type.of(cont).finalResultType
+          val Res = cont.info.finalResultType
           core.DefCall(TailCalls)(tailcall, Res)(Seq(
             core.DefCall(None)(local(cont), targs: _*)(argss: _*)))
 
         // Wrap a return value.
         case _ =>
-          val Res = api.Type.of(expr)
-          core.DefCall(TailCalls)(done, Res)(Seq(expr))
+          core.DefCall(TailCalls)(done, expr.tpe)(Seq(expr))
       }
   }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/io/csv/CSVConverterMacro.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/csv/CSVConverterMacro.scala
@@ -62,7 +62,7 @@ class CSVConverterMacro(val c: blackbox.Context) extends MacroAST {
       }
       val method = alternatives.head.asMethod
       val params = method.typeSignatureIn(T).paramLists.head
-      val args = for (p <- params) yield fromCSV(api.Type.of(p), value)
+      val args = for (p <- params) yield fromCSV(p.info, value)
       q"new $T(..$args)"
     } else {
       if (T =:= unit || T =:= Java.void) api.Term.unit

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
@@ -22,6 +22,8 @@ import compiler.ir.ComprehensionSyntax._
 import compiler.ir.ComprehensionCombinators._
 import test.schema.Marketing._
 
+import shapeless._
+
 import org.junit.runner.RunWith
 import org.scalatest.junit.JUnitRunner
 
@@ -48,12 +50,18 @@ class CombinationSpec extends BaseCompilerSpec {
       Core.flatten
     ).compose(_.tree)
 
-  def applyOnce(rule: u.Tree =?> u.Tree): u.Expr[Any] => u.Tree =
+  def applyOnce(rule: (u.Symbol, u.Tree) => Option[u.Tree]): u.Expr[Any] => u.Tree = {
+    val transform = api.TopDown.withOwner.transformWith {
+      case Attr.inh(tree, owner :: _) => rule(owner, tree).getOrElse(tree)
+    }.andThen(_.tree)
+
     pipeline(typeCheck = true)(
       Core.lnf,
-      tree => time(api.TopDown.transform(rule)(tree).tree, "match rule"),
-      Core.flatten
+      tree => time(transform(tree), "match rule"),
+      Core.flatten,
+      Core.dce
     ).compose(_.tree)
+  }
 
   // ---------------------------------------------------------------------------
   // Spec tests
@@ -183,21 +191,21 @@ class CombinationSpec extends BaseCompilerSpec {
       val exp = u.reify {
         comprehension[(User, Long), DataBag] {
           val xy = generator[(User, Long), DataBag] {
-            val f = (fFuncArg: User) => {
-              val ir1 = fFuncArg.id
+            val f = (fArg: User) => {
+              val ir1 = fArg.id
               val ir2 = Seq(ir1, ir1)
               val ir3 = DataBag(ir2)
-              val gFunc = (gFuncArg: Long) => {
-                new Tuple2(fFuncArg, gFuncArg)
-              }
-              val ir5 = ir3 map gFunc
+              val g = (gArg: Long) => (fArg, gArg)
+              val ir5 = ir3 map g
               ir5
             }
             val ir4 = users$1 flatMap f
             ir4
           }
           guard {
-            xy._1.id != xy._2
+            val xy1 = xy._1
+            val xy2 = xy._2
+            xy1.id != xy2
           }
           val z = generator[User, DataBag] {
             DataBag(Seq(xy._1))
@@ -275,13 +283,16 @@ class CombinationSpec extends BaseCompilerSpec {
             cross(u, DataBag(Seq(1,2,3)) union DataBag(Seq(4,5,6)))
           }
           val z = generator[Long, DataBag] {
-            DataBag(Seq(c._1.id + c._1.id))
+            val c1 = c._1
+            DataBag(Seq(c1.id + c1.id))
           }
           guard {
             c._2 != 0
           }
           head {
-            (c._1.id + c._2 + z).toString
+            val c1 = c._1
+            val c2 = c._2
+            (c1.id + c2 + z).toString
           }
         }
       }
@@ -454,16 +465,18 @@ class CombinationSpec extends BaseCompilerSpec {
             DataBag(Seq(3L, 6L))
           }
           guard {
-            z != j._1 && z != j._2.id
+            val j1 = j._1
+            val j2 = j._2
+            z != j1 && z != j2.id
           }
           head[Short] {
             //(j._1 + j._2.name.first.length - z).asInstanceOf[Short]
-            val _2$14 = j._2
-            val name$6 = _2$14.name
+            val j1 = j._1
+            val j2 = j._2
+            val name$6 = j2.name
             val first$6 = name$6.first
             val length$6 = first$6.length
-            val _1$14 = j._1
-            val `+$18` = _1$14 + length$6
+            val `+$18` = j1 + length$6
             val `-$6` = `+$18` - z
             val asInstanceOf$8 = `-$6`.asInstanceOf[Short]
             asInstanceOf$8
@@ -528,8 +541,12 @@ class CombinationSpec extends BaseCompilerSpec {
             users$1 union users
           ),
           DataBag(Seq(1, 2, 3))
-        ) map {
-          c => (c._1._1, c._1._2, c._2)
+        ) map { c =>
+          val c1 = c._1
+          val c2 = c._2
+          val c11 = c1._1
+          val c12 = c1._2
+          (c11, c12, c2)
         }
       }
 
@@ -559,9 +576,11 @@ class CombinationSpec extends BaseCompilerSpec {
         cross(
           users,
           users
-        ).withFilter(
-          a => a._1.id != a._2.id
-        ) map {
+        ).withFilter { a =>
+          val a1 = a._1
+          val a2 = a._2
+          a1.id != a2.id
+        } map {
           c => (c._1, c._2)
         }
       }
@@ -689,22 +708,22 @@ class CombinationSpec extends BaseCompilerSpec {
           }
           val ir1 = plus$9 map f$30
           val g$8 = (gArg$8: Long) => {
-            val ir2$8 = new Tuple2(fArg$26, gArg$8)
+            val ir2$8 = (fArg$26, gArg$8)
             ir2$8
           }
           val xy0$8 = ir1 map g$8
           xy0$8
         }
         val ir$58 = apply$121 flatMap f$26
-        val f$28 = (fArg$28: (DataBag[User], Long)) => {
-          val _1$75 = fArg$28._1
+        val f$28 = (fArg: (DataBag[User], Long)) => {
+          val fArg1 = fArg._1
+          val fArg2 = fArg._2
           val p$11 = (pArg$11: User) => {
             val id$69 = pArg$11.id
-            val _2$55 = fArg$28._2
-            val `!=$32` = id$69 != _2$55
+            val `!=$32` = id$69 != fArg2
             `!=$32`
           }
-          val ir$64 = _1$75 withFilter p$11
+          val ir$64 = fArg1 withFilter p$11
           val f$32 = (fArg$32: User) => {
             fArg$32
           }

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DSCFSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DSCFSpec.scala
@@ -38,6 +38,153 @@ class DSCFSpec extends BaseCompilerSpec {
       Core.anf
     ).compose(_.tree)
 
+  "While Loop" - {
+    "with trivial body" in {
+
+      val act = dscfPipeline(u.reify {
+        var i = 0
+        while (i < 100) {
+          i += 1
+        }
+        println(i)
+      })
+
+      val exp = anfPipeline(u.reify {
+        val i$1 = 0
+        def while$1(i$2: Int): Unit = {
+          val x$1 = i$2 < 100
+          def body$1(i$3: Int): Unit = {
+            val i$2 = i$3 + 1
+            while$1(i$2)
+          }
+          def suffix$1(i$4: Int): Unit = {
+            println(i$4)
+          }
+          if (x$1) body$1(i$2)
+          else suffix$1(i$2)
+        }
+        while$1(i$1)
+      })
+
+      act shouldBe alphaEqTo(exp)
+    }
+
+    "with non-trivial body" in {
+
+      val act = dscfPipeline(u.reify {
+        var i = 0
+        while (i < 100) {
+          if (i % 2 == 0) i += 2
+          else i *= 2
+        }
+        println(i)
+      })
+
+      val exp = anfPipeline(u.reify {
+        val i$1 = 0
+        def while$1(i$2: Int): Unit = {
+          val x$1 = i$2 < 100
+          def body$1(i$2: Int): Unit = {
+            val x$2 = i$2 % 2
+            val x$3 = x$2 == 0
+            def then$1(): Unit = {
+              val i$3 = i$2 + 2
+              suffix$2(i$3)
+            }
+            def else$1(): Unit = {
+              val i$4 = i$2 * 2
+              suffix$2(i$4)
+            }
+            def suffix$2(i$5: Int): Unit = {
+              while$1(i$5)
+            }
+            if (x$3) then$1()
+            else else$1()
+          }
+          def suffix$1(i$6: Int): Unit = {
+            println(i$6)
+          }
+          if (x$1) body$1(i$2)
+          else suffix$1(i$2)
+        }
+        while$1(i$1)
+      })
+
+      act shouldBe alphaEqTo(exp)
+    }
+  }
+
+  "Do-While Loop" - {
+
+    "with trivial body" in {
+
+      val act = dscfPipeline(u.reify {
+        var i = 0
+        do {
+          i += 1
+        } while (i < 100)
+        println(i)
+      })
+
+      val exp = anfPipeline(u.reify {
+        val i$1 = 0
+        def doWhile$1(i$2: Int): Unit = {
+          val i$3 = i$2 + 1
+          val x$1 = i$3 < 100
+          def suffix$1(): Unit = {
+            println(i$3)
+          }
+          if (x$1) doWhile$1(i$3)
+          else suffix$1()
+        }
+        doWhile$1(i$1)
+      })
+
+      act shouldBe alphaEqTo(exp)
+    }
+
+    "with non-trivial body" in {
+
+      val act = dscfPipeline(u.reify {
+        var i = 0
+        do {
+          if (i % 2 == 0) i += 2
+          else i *= 2
+        } while (i < 100)
+        println(i)
+      })
+
+      val exp = anfPipeline(u.reify {
+        val i$1 = 0
+        def doWhile$1(i$2: Int): Unit = {
+          val x$2 = i$2 % 2
+          val x$3 = x$2 == 0
+          def then$1(): Unit = {
+            val i$3 = i$2 + 2
+            suffix$2(i$3)
+          }
+          def else$1(): Unit = {
+            val i$4 = i$2 * 2
+            suffix$2(i$4)
+          }
+          def suffix$2(i$5: Int): Unit = {
+            val x$1 = i$5 < 100
+            def suffix$1(): Unit = {
+              println(i$5)
+            }
+            if (x$1) doWhile$1(i$5)
+            else suffix$1()
+          }
+          if (x$3) then$1()
+          else else$1()
+        }
+        doWhile$1(i$1)
+      })
+
+      act shouldBe alphaEqTo(exp)
+    }
+  }
+
   "Talor Series expansion for sin(x) around x = 0" in {
 
     val act = dscfPipeline(u.reify {
@@ -106,7 +253,7 @@ class DSCFSpec extends BaseCompilerSpec {
       sin(Math.PI / 2)
     })
 
-    act shouldBe alphaEqTo (exp)
+    act shouldBe alphaEqTo(exp)
   }
 
   "Google Code Jam 2015 A1 - Haircut (verified)" in {
@@ -200,7 +347,7 @@ class DSCFSpec extends BaseCompilerSpec {
       if (less$1) suffix$1(0L) else else$1()
     })
 
-    act shouldBe alphaEqTo (exp)
+    act shouldBe alphaEqTo(exp)
   }
 
   "Google Code Jam 2016 Qual - Counting sheep (verified)" in {
@@ -272,7 +419,7 @@ class DSCFSpec extends BaseCompilerSpec {
       if (eq$1) then$1() else else$1()
     })
 
-    act shouldBe alphaEqTo (exp)
+    act shouldBe alphaEqTo(exp)
   }
 
   "Google Code Jam 2016 Qual - Fractiles (verified)" in {
@@ -338,6 +485,6 @@ class DSCFSpec extends BaseCompilerSpec {
       while$1(check$1, infoGain$1, tile$1)
     })
 
-    act shouldBe alphaEqTo (exp)
+    act shouldBe alphaEqTo(exp)
   }
 }

--- a/emma-language/src/test/scala/org/emmalanguage/test/util.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/test/util.scala
@@ -55,6 +55,18 @@ object util {
   def fromPath(path: String): List[String] = fromPath(new java.io.File(path))
 
   /**
+   * Compares the contents of two bags.
+   *
+   * @param exp The bag containing the expected contents.
+   * @param act The bag containing the actual contents.
+   * @tparam T The type of the bag's elements.
+   */
+  def compareBags[T](exp: Seq[T], act: Seq[T]) = {
+    assert((exp diff act) == Seq.empty[String], s"Unexpected elements in result: $exp")
+    assert((act diff exp) == Seq.empty[String], s"Unseen elements in result: $act")
+  }
+
+  /**
    * Reads The contents from file (or folder containing a list of files) as a string.
    *
    * @param path The path of the file (or folder containing a list of files) to be read.

--- a/emma-quickstart/pom.xml
+++ b/emma-quickstart/pom.xml
@@ -21,8 +21,8 @@
 
     <parent>
         <artifactId>emma</artifactId>
-        <groupId>eu.stratosphere</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>org.emmalanguage</groupId>
+        <version>0.2-SNAPSHOT</version>
     </parent>
 
 

--- a/emma-quickstart/src/main/resources/archetype-resources/pom.xml
+++ b/emma-quickstart/src/main/resources/archetype-resources/pom.xml
@@ -78,13 +78,13 @@
 
         <!-- Emma -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-language</artifactId>
             <version>${emma.version}</version>
         </dependency>
         <!-- Emma (test jars) -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-language</artifactId>
             <version>${emma.version}</version>
             <type>test-jar</type>
@@ -172,7 +172,7 @@
             <dependencies>
                 <!-- Emma -->
                 <dependency>
-                    <groupId>eu.stratosphere</groupId>
+                    <groupId>org.emmalanguage</groupId>
                     <artifactId>emma-flink</artifactId>
                     <version>${emma.version}</version>
                 </dependency>
@@ -205,7 +205,7 @@
             <dependencies>
                 <!-- Emma -->
                 <dependency>
-                    <groupId>eu.stratosphere</groupId>
+                    <groupId>org.emmalanguage</groupId>
                     <artifactId>emma-spark</artifactId>
                     <version>${emma.version}</version>
                 </dependency>

--- a/emma-spark/pom.xml
+++ b/emma-spark/pom.xml
@@ -23,8 +23,8 @@
 
     <parent>
         <artifactId>emma</artifactId>
-        <groupId>eu.stratosphere</groupId>
-        <version>1.0-SNAPSHOT</version>
+        <groupId>org.emmalanguage</groupId>
+        <version>0.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>emma-spark</artifactId>
@@ -47,12 +47,12 @@
 
         <!-- Emma -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-language</artifactId>
         </dependency>
         <!-- Emma (test jars) -->
         <dependency>
-            <groupId>eu.stratosphere</groupId>
+            <groupId>org.emmalanguage</groupId>
             <artifactId>emma-language</artifactId>
             <type>test-jar</type>
         </dependency>

--- a/emma-spark/pom.xml
+++ b/emma-spark/pom.xml
@@ -73,10 +73,6 @@
             <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.scalacheck</groupId>
-            <artifactId>scalacheck_${scala.tools.version}</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.tools.version}</artifactId>
         </dependency>

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
@@ -93,7 +93,9 @@ class SparkDataset[A: Meta] private[api](@transient private[api] val rep: Datase
       .mode("overwrite")
       .csv(path)
 
-  override lazy val fetch: Seq[A] =
+  def fetch(): Seq[A] = collect
+
+  private lazy val collect: Seq[A] =
     rep.collect()
 
   // -----------------------------------------------------

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
@@ -68,11 +68,10 @@ class SparkDataset[A: Meta] private[api](@transient private[api] val rep: Datase
   // Set operations
   // -----------------------------------------------------
 
-  override def union(that: DataBag[A]): DataBag[A] = that match {
+  override def union(that: DataBag[A]): SparkDataset[A] = that match {
     case dbag: ScalaSeq[A] => this.rep union SparkDataset(dbag.rep).rep
-    case dbag: SparkRDD[A] => this.rep union dbag.rep.toDS()
     case dbag: SparkDataset[A] => this.rep union dbag.rep
-    case _ => that union this
+    case _ => throw new IllegalArgumentException(s"Unsupported rhs for `union` of type: ${that.getClass}")
   }
 
   override def distinct: SparkDataset[A] =

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
@@ -93,7 +93,9 @@ class SparkRDD[A: Meta] private[api](@transient private[api] val rep: RDD[A])(im
       .csv(path)
   }
 
-  override lazy val fetch: Seq[A] =
+  def fetch(): Seq[A] = collect
+
+  private lazy val collect: Seq[A] =
     rep.collect()
 
   // -----------------------------------------------------

--- a/emma-spark/src/main/scala/org/emmalanguage/api/emma/onSpark.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/emma/onSpark.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package api.emma
+
+import compiler.SparkMacro
+
+import scala.language.experimental.macros
+
+object onSpark {
+
+  final def apply[T](e: T): T = macro SparkMacro.parallelizeImpl[T]
+}

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+class SparkMacro(val c: blackbox.Context) extends MacroCompiler {
+
+  def parallelizeImpl[T](e: c.Expr[T]): c.Expr[T] = {
+    val res = parallelizePipeline(e)
+    //c.warning(e.tree.pos, Core.prettyPrint(res))
+    c.Expr[T](unTypeCheck(res))
+  }
+
+  private lazy val parallelizePipeline: c.Expr[Any] => u.Tree =
+    pipeline(typeCheck = false)(
+      LibSupport.expand,
+      Core.lift,
+      Comprehension.combine,
+      Backend.translateToDataflows(SparkAPI.rddModuleSymbol),
+      Core.inlineLetExprs,
+      Core.trampoline
+    ).compose(_.tree)
+
+  private object SparkAPI {
+    lazy val rddModuleSymbol = universe.rootMirror.staticModule(s"$rootPkg.api.SparkRDD")
+    lazy val sessionSymbol = universe.rootMirror.staticClass(s"org.apache.spark.sql.SparkSession")
+    lazy val sessionType = sessionSymbol.info
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -134,14 +134,18 @@
         <scalatest.version>2.2.6</scalatest.version>
 
         <!-- Other dependencies -->
-        <argparse4j.version>0.4.4</argparse4j.version>
-        <reflections.version>0.9.9</reflections.version>
-        <scala.graph-core.version>1.9.0</scala.graph-core.version>
+        <argparse4j.version>0.4.4</argparse4j.version><!-- TODO: remove -->
+        <scopt.version>3.5.0</scopt.version>
+        <reflections.version>0.9.9</reflections.version><!-- TODO: remove -->
+        <scala.graph-core.version>1.9.0</scala.graph-core.version><!-- TODO: remove -->
         <scala-arm.version>1.4</scala-arm.version>
 
         <!-- Test configuration -->
         <excludedSurefireGroups>eu.stratosphere.emma.testutil.ExampleTest</excludedSurefireGroups>
         <compile-spec-pipelines>false</compile-spec-pipelines>
+        <spark.scope>provided</spark.scope>
+        <flink.scope>provided</flink.scope>
+        <hadoop.scope>provided</hadoop.scope>
 
         <!-- Deployment configuration -->
         <nexus.skipStaging>true</nexus.skipStaging>
@@ -235,13 +239,13 @@
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-common</artifactId>
                 <version>${hadoop.version}</version>
-                <scope>provided</scope>
+                <scope>${hadoop.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.hadoop</groupId>
                 <artifactId>hadoop-hdfs</artifactId>
                 <version>${hadoop.version}</version>
-                <scope>provided</scope>
+                <scope>${hadoop.scope}</scope>
             </dependency>
 
             <!-- Flink -->
@@ -249,19 +253,19 @@
                 <groupId>org.apache.flink</groupId>
                 <artifactId>flink-scala_${scala.tools.version}</artifactId>
                 <version>${flink.version}</version>
-                <scope>provided</scope>
+                <scope>${flink.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.flink</groupId>
                 <artifactId>flink-java_${scala.tools.version}</artifactId>
                 <version>${flink.version}</version>
-                <scope>provided</scope>
+                <scope>${flink.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.flink</groupId>
                 <artifactId>flink-clients_${scala.tools.version}</artifactId>
                 <version>${flink.version}</version>
-                <scope>provided</scope>
+                <scope>${flink.scope}</scope>
             </dependency>
 
             <!-- Spark -->
@@ -269,13 +273,19 @@
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-core_${scala.tools.version}</artifactId>
                 <version>${spark.version}</version>
-                <scope>provided</scope>
+                <scope>${spark.scope}</scope>
             </dependency>
             <dependency>
                 <groupId>org.apache.spark</groupId>
                 <artifactId>spark-sql_${scala.tools.version}</artifactId>
                 <version>${spark.version}</version>
-                <scope>provided</scope>
+                <scope>${spark.scope}</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.spark</groupId>
+                <artifactId>spark-sql_${scala.tools.version}</artifactId>
+                <version>${spark.version}</version>
+                <scope>${spark.scope}</scope>
             </dependency>
 
             <!-- CSV -->
@@ -339,6 +349,12 @@
                 <groupId>net.sourceforge.argparse4j</groupId>
                 <artifactId>argparse4j</artifactId>
                 <version>${argparse4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.github.scopt</groupId>
+                <artifactId>scopt_${scala.tools.version}</artifactId>
+                <version>${scopt.version}</version>
+                <scope>compile</scope>
             </dependency>
 
             <!-- Dynamic loading -->

--- a/pom.xml
+++ b/pom.xml
@@ -21,15 +21,17 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>eu.stratosphere</groupId>
+    <groupId>org.emmalanguage</groupId>
     <artifactId>emma</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>emma</name>
     <description>
-        Emma is a Scala DSL for scalable data analysis.
-        Our goal is to improve developer productivity by hiding parallelism aspects behind a high-level, declarative API.
+        Emma is a macro-based, deeply embedded Scala DSL for scalable data analysis.
+        Emma aims is to improve developer productivity by maximizing the reuse of native Scala features in the DSL and
+        hiding parallelism aspects of supported backend engines (e.g. Flink, Spark) behind a high-level, declarative
+        API.
     </description>
     <inceptionYear>2014</inceptionYear>
     <url>https://emma-language.org</url>
@@ -88,13 +90,18 @@
         <build-helper-maven-plugin.version>1.7</build-helper-maven-plugin.version>
         <maven-archetype-plugin.version>2.4</maven-archetype-plugin.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
-        <maven-eclipse-plugin.version>2.9</maven-eclipse-plugin.version>
+        <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
+        <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-install-plugin.version>2.5.2</maven-install-plugin.version>
-        <maven-jar-plugin.version>2.5</maven-jar-plugin.version>
+        <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
+        <maven-javadoc-plugin.version>2.10.3</maven-javadoc-plugin.version>
+        <maven-project-info-reports.version>2.9</maven-project-info-reports.version>
+        <maven-site-plugin.version>3.5.1</maven-site-plugin.version>
         <maven-shade-plugin.version>2.4.1</maven-shade-plugin.version>
         <maven-surefire-plugin.version>2.18.1</maven-surefire-plugin.version>
         <maven-source-plugin.version>2.4</maven-source-plugin.version>
-        <scala-maven-plugin.version>3.2.0</scala-maven-plugin.version>
+        <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
+        <nexus-staging-maven-plugin.version>1.6.7</nexus-staging-maven-plugin.version>
 
         <!-- Java -->
         <java.version>1.7</java.version>
@@ -135,6 +142,9 @@
         <!-- Test configuration -->
         <excludedSurefireGroups>eu.stratosphere.emma.testutil.ExampleTest</excludedSurefireGroups>
         <compile-spec-pipelines>false</compile-spec-pipelines>
+
+        <!-- Deployment configuration -->
+        <nexus.skipStaging>true</nexus.skipStaging>
     </properties>
 
     <!-- Sonatype distribution management -->
@@ -143,6 +153,10 @@
             <id>ossrh</id>
             <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
     </distributionManagement>
 
     <dependencyManagement>
@@ -166,38 +180,38 @@
 
             <!-- Emma -->
             <dependency>
-                <groupId>eu.stratosphere</groupId>
+                <groupId>org.emmalanguage</groupId>
                 <artifactId>emma-flink</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>eu.stratosphere</groupId>
+                <groupId>org.emmalanguage</groupId>
                 <artifactId>emma-language</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>eu.stratosphere</groupId>
+                <groupId>org.emmalanguage</groupId>
                 <artifactId>emma-examples</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>eu.stratosphere</groupId>
+                <groupId>org.emmalanguage</groupId>
                 <artifactId>emma-gui</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>eu.stratosphere</groupId>
+                <groupId>org.emmalanguage</groupId>
                 <artifactId>emma-quickstart</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>
-                <groupId>eu.stratosphere</groupId>
+                <groupId>org.emmalanguage</groupId>
                 <artifactId>emma-spark</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <!-- Emma (test jars) -->
             <dependency>
-                <groupId>eu.stratosphere</groupId>
+                <groupId>org.emmalanguage</groupId>
                 <artifactId>emma-language</artifactId>
                 <version>${project.version}</version>
                 <type>test-jar</type>
@@ -349,18 +363,6 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <profiles>
-        <!-- Profile that activates integration tests and compile-spec-pipelines -->
-        <profile>
-            <id>IT</id>
-            <properties>
-                <!-- Test configuration -->
-                <excludedSurefireGroups>java.io.Serializable</excludedSurefireGroups> <!-- never used -->
-                <compile-spec-pipelines>true</compile-spec-pipelines>
-            </properties>
-        </profile>
-    </profiles>
 
     <build>
         <plugins>
@@ -577,7 +579,9 @@
                 </executions>
                 <configuration>
                     <generateChildNotices>false</generateChildNotices>
-                    <noticeTemplate>https://gist.githubusercontent.com/aalexandrov/25a931c7d106415c8af7/raw/04e7a3d5534194929f1864d0535b8cc1c5f9cddb/NOTICE.template</noticeTemplate>
+                    <noticeTemplate>
+                        https://gist.githubusercontent.com/aalexandrov/25a931c7d106415c8af7/raw/04e7a3d5534194929f1864d0535b8cc1c5f9cddb/NOTICE.template
+                    </noticeTemplate>
                     <includeChildDependencies>true</includeChildDependencies>
                     <licenseMapping>
                         <param>https://source.jasig.org/licenses/license-mappings.xml</param>
@@ -586,10 +590,65 @@
                     <generateChildNotices>false</generateChildNotices>
                 </configuration>
             </plugin>
+
+            <!-- Maven Deploy (disabled) -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+
+            <!-- Deploy via Nexus Staging -->
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+            </plugin>
         </plugins>
 
         <pluginManagement>
             <plugins>
+                <!-- Maven Deploy (disabled) -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-deploy-plugin.version}</version>
+                    <configuration>
+                        <skip>true</skip>
+                    </configuration>
+                </plugin>
+
+                <!-- Maven Archetype -->
+                <plugin>
+                    <artifactId>maven-archetype-plugin</artifactId>
+                    <version>${maven-archetype-plugin.version}</version><!--$NO-MVN-MAN-VER$-->
+                </plugin>
+
+                <!-- Maven Install -->
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>${maven-install-plugin.version}</version>
+                </plugin>
+
+                <!-- Maven Site Plugin -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-site-plugin</artifactId>
+                    <version>${maven-site-plugin.version}</version>
+                </plugin>
+
+                <!-- Nexus Staging -->
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>${nexus-staging-maven-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration> 
+                        <serverId>ossrh</serverId>
+                        <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        <skipStaging>${nexus.skipStaging}</skipStaging>
+                    </configuration>
+                </plugin>
+
                 <!-- Shade Package (Create package with dependencies) -->
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -607,19 +666,6 @@
                             </configuration>
                         </execution>
                     </executions>
-                </plugin>
-
-                <plugin>
-                    <artifactId>maven-archetype-plugin</artifactId>
-                    <version>${maven-archetype-plugin.version}</version><!--$NO-MVN-MAN-VER$-->
-                </plugin>
-                <plugin>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>${maven-install-plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <artifactId>maven-deploy-plugin</artifactId>
-                    <version>${maven-deploy-plugin.version}</version>
                 </plugin>
 
                 <!-- Scala style check -->
@@ -649,6 +695,91 @@
             </plugins>
         </pluginManagement>
     </build>
+
+    <profiles>
+        <!-- Profile that activates integration tests and compile-spec-pipelines -->
+        <profile>
+            <id>IT</id>
+            <properties>
+                <!-- Test configuration -->
+                <excludedSurefireGroups>java.io.Serializable</excludedSurefireGroups> <!-- never used -->
+                <compile-spec-pipelines>true</compile-spec-pipelines>
+            </properties>
+        </profile>
+        <!-- profile for Sonatype releases -->
+        <profile>
+            <id>release</id>
+            <properties>
+                <!-- Deployment configuration -->
+                <nexus.skipStaging>false</nexus.skipStaging>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>${maven-source-plugin.version}</version><!--$NO-MVN-MAN-VER$-->
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <version>${scala-maven-plugin.version}</version>
+                        <configuration>
+                            <finalName>${project.build.finalName}-scaladoc</finalName>
+                            <displayCmd>true</displayCmd>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>doc-jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${maven-javadoc-plugin.version}</version><!--$NO-MVN-MAN-VER$-->
+                        <configuration>
+                            <quiet>true</quiet>
+                            <skip>false</skip>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>${maven-gpg-plugin.version}</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
     <modules>
         <module>emma-language</module>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
         <!-- Flink -->
         <flink.version>0.10.0</flink.version>
         <!-- Spark -->
-        <spark.version>2.0.0</spark.version>
+        <spark.version>2.0.1</spark.version>
 
         <!-- Logging -->
         <log4j.version>1.2.17</log4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,6 @@
 
         <!-- Testing -->
         <junit.version>4.12</junit.version>
-        <scalacheck.version>1.12.5</scalacheck.version>
         <scalatest.version>2.2.6</scalatest.version>
 
         <!-- Other dependencies -->
@@ -329,12 +328,6 @@
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
                 <version>${junit.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.scalacheck</groupId>
-                <artifactId>scalacheck_${scala.tools.version}</artifactId>
-                <version>${scalacheck.version}</version>
                 <scope>test</scope>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR adds a first stab for a macro-based translation based on the new compiler pipeline.

The macro is called `emma.onSpark` and is defined by the pipeline:

```scala
private lazy val parallelizePipeline: c.Expr[Any] => u.Tree =
  pipeline(typeCheck = false)(
    LibSupport.expand,
    Core.lift,
    Comprehension.combine,
    Backend.translateToDataflows(SparkAPI.rddModuleSymbol),
    Core.inlineLetExprs,
    Core.trampoline
  ).compose(_.tree)
```

I migrated the following examples and their tests based on that:
    
- `EnumerateTriangles`,
- `TransitiveClosure`.
- `NaiveBayes`,
- `KMeans`,
- `WordCount`.

A similar Macro can be added for Flink as well.