### PR TITLE
[IR] Only widen types when necessary

### DIFF
--- a/emma-language/src/main/scala/eu/stratosphere/emma/macros/ConvertersMacros.scala
+++ b/emma-language/src/main/scala/eu/stratosphere/emma/macros/ConvertersMacros.scala
@@ -52,7 +52,7 @@ class ConvertersMacros(val c: blackbox.Context) extends MacroAST {
     if (T <:< api.Type[Product]) {
       val method = T.decl(api.TermName.init).alternatives.head.asMethod
       val params = method.typeSignatureIn(T).paramLists.head
-      val args = for (p <- params) yield fromCSV(api.Type.of(p), value)
+      val args = for (p <- params) yield fromCSV(p.info, value)
       q"new $T(..$args)"
     } else {
       if (T =:= unit || T =:= Java.void) api.Term.unit

--- a/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
@@ -293,6 +293,10 @@ trait CommonAST {
     def pkg(sym: Symbol): Boolean =
       sym.isPackage
 
+    /** Is `sym` a by-name parameter? */
+    def byName(sym: Symbol): Boolean =
+      sym.isTerm && sym.asTerm.isByNameParam
+
     /** Is `tpe` legal for a term (i.e. not of a higher kind or method)? */
     def result(tpe: Type): Boolean =
       !is.poly(tpe) && !is.method(tpe)

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Loops.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Loops.scala
@@ -80,8 +80,7 @@ trait Loops { this: AST =>
         assert(is.defined(cond), s"$this condition is not defined: $cond")
         assert(is.defined(body), s"$this body is not defined: $body")
         assert(has.tpe(cond), s"$this condition has no type:\n${Tree.showTypes(cond)}")
-        lazy val Cond = Type.of(cond)
-        assert(Cond =:= Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
+        assert(cond.tpe <:< Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
 
         val nme = TermName.fresh("while")
         val lbl = LabelSym(u.NoSymbol, nme)
@@ -110,8 +109,7 @@ trait Loops { this: AST =>
         assert(is.defined(cond), s"$this condition is not defined: $cond")
         assert(is.defined(body), s"$this body is not defined: $body")
         assert(has.tpe(cond), s"$this condition has no type:\n${Tree.showTypes(cond)}")
-        lazy val Cond = Type.of(cond)
-        assert(Cond =:= Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
+        assert(cond.tpe <:< Type.bool, s"$this condition is not boolean:\n${Tree.showTypes(cond)}")
 
         val nme = TermName.fresh("doWhile")
         val lbl = LabelSym(u.NoSymbol, nme)

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
@@ -25,8 +25,9 @@ trait Symbols { this: AST =>
   trait SymbolAPI { this: API =>
 
     import universe._
-    import u.definitions._
-    import u.internal._
+    import definitions._
+    import internal._
+    import reificationSupport._
     import u.Flag.IMPLICIT
 
     object Sym extends Node {
@@ -50,11 +51,11 @@ trait Symbols { this: AST =>
 
       /** Creates a copy of `sym`, optionally changing some of its attributes. */
       def copy(sym: u.Symbol)(
-          name:  u.Name     = sym.name,
-          owner: u.Symbol   = sym.owner,
-          tpe:   u.Type     = sym.info,
-          pos:   u.Position = sym.pos,
-          flags: u.FlagSet  = get.flags(sym)): u.Symbol = {
+        name:  u.Name     = sym.name,
+        owner: u.Symbol   = sym.owner,
+        tpe:   u.Type     = sym.info,
+        pos:   u.Position = sym.pos,
+        flags: u.FlagSet  = get.flags(sym)): u.Symbol = {
 
         // Optimize when there are no changes.
         if (name == sym.name && owner == sym.owner && tpe == sym.info &&
@@ -77,8 +78,7 @@ trait Symbols { this: AST =>
           else newTermSymbol(owner, termName, pos, flags)
         }
 
-        set.tpe(dup, Type.fix(tpe))
-        dup
+        setInfo(dup, tpe.dealias.widen)
       }
 
       /** A map of all tuple symbols by number of elements. */

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Trees.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Trees.scala
@@ -20,7 +20,6 @@ import cats.std.all._
 import shapeless._
 
 import scala.annotation.tailrec
-import scala.collection.mutable
 
 trait Trees { this: AST =>
 
@@ -37,9 +36,9 @@ trait Trees { this: AST =>
 
       /** Creates a shallow copy of `tree`, preserving its type and setting new attributes. */
       def copy[T <: Tree](tree: T)(
-          pos: u.Position = tree.pos,
-          sym: u.Symbol   = tree.symbol,
-          tpe: u.Type     = tree.tpe): T = {
+        pos: u.Position = tree.pos,
+        sym: u.Symbol   = tree.symbol,
+        tpe: u.Type     = tree.tpe): T = {
 
         // Optimize when there are no changes.
         if (pos == tree.pos && sym == tree.symbol && tpe == tree.tpe) return tree
@@ -323,7 +322,7 @@ trait Trees { this: AST =>
         assert(has.tpe(target), s"$this target `$target` has no type")
         assert(is.encoded(target), s"$this target `$target` is not encoded")
 
-        val tpe = Type.of(target) match {
+        val tpe = target.info match {
           case u.NullaryMethodType(result) => result
           case other => other
         }
@@ -350,7 +349,7 @@ trait Trees { this: AST =>
 
         val mod = member.isPackageClass || member.isModuleClass
         val sym = if (mod) member.asClass.module else member
-        val tpe = Type.of(sym, in = target.tpe) match {
+        val tpe = sym.infoIn(target.tpe) match {
           case u.NullaryMethodType(result) => result
           case other => other
         }

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Variables.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Variables.scala
@@ -121,8 +121,8 @@ trait Variables { this: AST =>
         assert(is.term(rhs), s"$this RHS is not a term:\n${Tree.show(rhs)}")
         assert(has.tpe(lhs), s"$this LHS `$lhs` has no type")
         assert(has.tpe(rhs), s"$this RHS has no type:\n${Tree.showTypes(rhs)}")
-        lazy val (lhT, rhT) = (Type.of(lhs), Type.of(rhs))
-        assert(rhT weak_<:< lhT, s"$this LH type `$lhT` is not a supertype of RH type `$rhT`")
+        assert(rhs.tpe <:< lhs.info,
+          s"$this LH type `${lhs.info}` is not a supertype of RH type `${rhs.tpe}`")
 
         val mut = u.Assign(VarRef(lhs), rhs)
         set(mut, tpe = u.NoType)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
@@ -76,7 +76,8 @@ private[backend] trait Order extends Common {
      */
     lazy val disambiguate: u.Tree => (u.Tree, Set[u.TermSymbol]) = tree => {
 
-      def isFun(sym: u.TermSymbol) = api.Sym.funs(api.Type.of(sym).typeSymbol)
+      def isFun(sym: u.TermSymbol) =
+        api.Sym.funs(sym.info.dealias.widen.typeSymbol)
 
       // The Set of symbols of ValDefs of functions
       val funs = tree.collect {

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/cf/CFG.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/cf/CFG.scala
@@ -128,8 +128,7 @@ private[compiler] trait CFG extends Common {
             val values = defs.collect {
               case value @ (api.ValSym(_), _) => value
               case (_, core.ParDef(lhs, _, flags)) if choices.contains(lhs) =>
-                val tpe = api.Type.of(lhs)
-                val rhs = core.DefCall(module)(phi, tpe)(choices(lhs))
+                val rhs = core.DefCall(module)(phi, lhs.info)(choices(lhs))
                 lhs -> core.ParDef(lhs, rhs, flags)
             }
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
@@ -74,7 +74,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(f: u.Tree): u.Type =
-          api.Type.arg(2, api.Type.of(f))
+          api.Type.arg(2, f.tpe)
       }
 
       object FlatMap extends MonadOp {
@@ -94,7 +94,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(f: u.Tree): u.Type =
-          api.Type.arg(1, api.Type.arg(2, api.Type.of(f)))
+          api.Type.arg(1, api.Type.arg(2, f.tpe))
       }
 
       object WithFilter extends MonadOp {
@@ -131,7 +131,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(expr: u.Tree): u.Type =
-          api.Type of expr
+          expr.tpe
       }
 
       /** Con- and destructs a generator from/to a tree. */
@@ -150,7 +150,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(expr: u.Tree): u.Type =
-          api.Type.arg(1, api.Type.of(expr))
+          api.Type.arg(1, expr.tpe)
       }
 
       /** Con- and destructs a guard from/to a tree. */
@@ -180,7 +180,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(expr: u.Tree): u.Type =
-          api.Type.of(expr)
+          expr.tpe
       }
 
       /** Con- and destructs a flatten from/to a tree. */
@@ -197,7 +197,7 @@ trait Comprehension extends Common
 
         @inline
         private def elemTpe(expr: u.Tree): u.Type =
-          api.Type.arg(1, api.Type.arg(1, api.Type.of(expr)))
+          api.Type.arg(1, api.Type.arg(1, expr.tpe))
       }
 
     }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Normalize.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Normalize.scala
@@ -218,11 +218,10 @@ private[comprehension] trait Normalize extends Common {
       val symbol = ComprehensionSyntax.comprehension
 
       def unapply(tree: u.Tree): Option[(Seq[u.Tree], u.Tree)] = tree match {
-        case Comprehension(qs,hd) => Some(qs, hd)
-        case t if api.Type.of(t).typeConstructor == Monad => {
-          val x = api.TermSym.free(api.TermName.fresh("x"), api.Type.arg(1, api.Type.of(t)))
+        case Comprehension(qs, hd) => Some(qs, hd)
+        case t if api.Type.constructor(t.tpe) =:= Monad =>
+          val x = api.TermSym.free(api.TermName.fresh("x"), api.Type.arg(1, t.tpe))
           Some(Seq(Generator(x, core.Let()()(t))), Head(core.Let()()(api.TermRef(x))))
-        }
         case _ => None
       }
     }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/ANF.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/ANF.scala
@@ -78,7 +78,7 @@ private[core] trait ANF extends Common {
         // Simplify expression
         case Attr.inh(src.TypeAscr(target, tpe), owner :: _) =>
           val (stats, expr) = decompose(target, unline = false)
-          if (tpe =:= api.Type.of(expr)) {
+          if (expr.tpe =:= tpe) {
             src.Block(stats: _*)(expr)
           } else {
             val nme = api.TermName.fresh(nameOf(expr))

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
@@ -370,10 +370,10 @@ trait Core extends Common
      * Gets the type argument of the DataBag type that is the type of the given expression.
      */
     def bagElemTpe(xs: u.Tree): u.Type = {
-      assert(api.Type.of(xs).typeConstructor == API.DataBag,
+      assert(api.Type.constructor(xs.tpe) =:= API.DataBag,
         s"`bagElemTpe` was called with a tree that has a non-bag type. " +
           s"The tree:\n-----\n$xs\n-----\nIts type: `${xs.tpe}`")
-      api.Type.arg(1, api.Type.of(xs))
+      api.Type.arg(1, xs.tpe)
     }
   }
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Trampoline.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Trampoline.scala
@@ -58,7 +58,7 @@ private[core] trait Trampoline extends Common {
             val (own, nme, pos) = (method.owner, method.name, method.pos)
             val flg = get.flags(method)
             val pss = paramss.map(_.map(_.symbol.asTerm))
-            val Res = api.Type.kind1[TailRec](api.Type.of(method).finalResultType)
+            val Res = api.Type.kind1[TailRec](method.info.finalResultType)
             method -> api.DefSym(own, nme, flg, pos)(tparams: _*)(pss: _*)(Res)
           }).toMap
       }.transformWith {
@@ -91,14 +91,13 @@ private[core] trait Trampoline extends Common {
 
         // Wrap a tail call.
         case core.DefCall(None, cont, targs, argss@_*) if local.contains(cont) =>
-          val Res = api.Type.of(cont).finalResultType
+          val Res = cont.info.finalResultType
           core.DefCall(TailCalls)(tailcall, Res)(Seq(
             core.DefCall(None)(local(cont), targs: _*)(argss: _*)))
 
         // Wrap a return value.
         case _ =>
-          val Res = api.Type.of(expr)
-          core.DefCall(TailCalls)(done, Res)(Seq(expr))
+          core.DefCall(TailCalls)(done, expr.tpe)(Seq(expr))
       }
   }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/io/csv/CSVConverterMacro.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/csv/CSVConverterMacro.scala
@@ -62,7 +62,7 @@ class CSVConverterMacro(val c: blackbox.Context) extends MacroAST {
       }
       val method = alternatives.head.asMethod
       val params = method.typeSignatureIn(T).paramLists.head
-      val args = for (p <- params) yield fromCSV(api.Type.of(p), value)
+      val args = for (p <- params) yield fromCSV(p.info, value)
       q"new $T(..$args)"
     } else {
       if (T =:= unit || T =:= Java.void) api.Term.unit


### PR DESCRIPTION
Also, removed `Type.of` and `Type.fix`.

This doesn't yet deal with path-dependent types, but it's a step in the right direction.