### PR TITLE
[EXAMPLES] Workaround for implicit Meta parameters

### DIFF
--- a/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/EnumerateTriangles.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/EnumerateTriangles.scala
@@ -24,7 +24,7 @@ import scala.Ordering.Implicits._
 @emma.lib
 object EnumerateTriangles {
 
-  def apply[V: Ordering : Meta](edges: DataBag[Edge[V]]): DataBag[Triangle[V]] = {
+  def apply[V: Ordering: Meta.Tag](edges: DataBag[Edge[V]]): DataBag[Triangle[V]] = {
     // generate all triangles (x - v - w) such that x < v < w
     val triangles = for {
       Edge(x, u) <- edges

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/TransitiveClosure.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/TransitiveClosure.scala
@@ -22,7 +22,7 @@ import model._
 @emma.lib
 object TransitiveClosure {
 
-  def apply[V: Meta](edges: DataBag[Edge[V]]): DataBag[Edge[V]] = {
+  def apply[V: Meta.Tag](edges: DataBag[Edge[V]]): DataBag[Edge[V]] = {
     var paths = edges.distinct
     var count = paths.size
     var added = 0L

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/model.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/graphs/model.scala
@@ -16,43 +16,11 @@
 package org.emmalanguage
 package examples.graphs
 
-import api.Meta
 import api.emma
-
-import scala.reflect.ClassTag
-import scala.reflect.runtime.universe._
 
 /** Graph model objects. */
 object model {
-
   case class Edge[V](src: V, dst: V)
-
   case class LEdge[V, L](@emma.pk src: V, @emma.pk dst: V, label: L)
-
   case class Triangle[V](x: V, y: V, z: V)
-
-  //@formatter:off
-  implicit def edgeMeta[V: Meta]: Meta[Edge[V]] = new Meta[Edge[V]] {
-    implicit def ctagV = implicitly[Meta[V]].ctag
-    implicit def ttagV = implicitly[Meta[V]].ttag
-    override def ctag = implicitly[ClassTag[Edge[V]]]
-    override def ttag = implicitly[TypeTag[Edge[V]]]
-  }
-
-  implicit def ledgeMeta[V: Meta, L: Meta]: Meta[LEdge[V, L]] = new Meta[LEdge[V, L]] {
-    implicit def ctagV = implicitly[Meta[V]].ctag
-    implicit def ttagV = implicitly[Meta[V]].ttag
-    implicit def ctagL = implicitly[Meta[L]].ctag
-    implicit def ttagL = implicitly[Meta[L]].ttag
-    override def ctag = implicitly[ClassTag[LEdge[V, L]]]
-    override def ttag = implicitly[TypeTag[LEdge[V, L]]]
-  }
-
-  implicit def triadMeta[V: Meta]: Meta[Triangle[V]] = new Meta[Triangle[V]] {
-    implicit val ctagV = implicitly[Meta[V]].ctag
-    implicit val ttagV = implicitly[Meta[V]].ttag
-    override def ctag = implicitly[ClassTag[Triangle[V]]]
-    override def ttag = implicitly[TypeTag[Triangle[V]]]
-  }
-  //@formatter:on
 }

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/imdb/GraphPreprocessing.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/imdb/GraphPreprocessing.scala
@@ -26,7 +26,7 @@ object GraphPreprocessing {
 
   type Proj[L] = DataBag[Collaboration] => L
 
-  def apply[L: Meta](input: String, csv: CSV)(proj: Proj[L]): DataBag[LEdge[Person, L]] = {
+  def apply[L: Meta.Tag](input: String, csv: CSV)(proj: Proj[L]): DataBag[LEdge[Person, L]] = {
 
     // FIXME: CSVMacro does not work with Option[T] types
     val people : DataBag[Person] = ??? // DataBag.readCSV[Person](s"$input/people.csv", csv)

--- a/emma-examples/src/main/scala/org/emmalanguage/examples/ml/model.scala
+++ b/emma-examples/src/main/scala/org/emmalanguage/examples/ml/model.scala
@@ -20,29 +20,8 @@ import api._
 
 import breeze.linalg.Vector
 
-import scala.reflect.ClassTag
-import scala.reflect.runtime.universe._
-
 /** Machine learning model objects. */
 object model {
-
   case class Point[ID: Meta](@emma.pk id: ID, vector: Vector[Double])
-
   case class LVector[L: Meta](label: L, vector: Vector[Double])
-
-  //@formatter:off
-  implicit def pointMeta[ID: Meta]: Meta[Point[ID]] = new Meta[Point[ID]] {
-    implicit def ctagID = implicitly[Meta[ID]].ctag
-    implicit def ttagID = implicitly[Meta[ID]].ttag
-    override def ctag = implicitly[ClassTag[Point[ID]]]
-    override def ttag = implicitly[TypeTag[Point[ID]]]
-  }
-
-  implicit def edgeMeta[L: Meta]: Meta[LVector[L]] = new Meta[LVector[L]] {
-    implicit def ctagL = implicitly[Meta[L]].ctag
-    implicit def ttagL = implicitly[Meta[L]].ttag
-    override def ctag = implicitly[ClassTag[LVector[L]]]
-    override def ttag = implicitly[TypeTag[LVector[L]]]
-  }
-  //@formatter:on
 }

--- a/emma-language/src/main/scala/org/emmalanguage/api/package.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/package.scala
@@ -16,7 +16,7 @@
 package org.emmalanguage
 
 import scala.reflect.ClassTag
-import scala.reflect.runtime.universe._
+import scala.reflect.runtime.universe.TypeTag
 
 /** Package object for the Emma API. Contains default methods and definitions. */
 package object api {
@@ -32,22 +32,16 @@ package object api {
   }
 
   object Meta {
-    implicit def apply[T : ClassTag : TypeTag]: Meta[T] = new Meta[T] {
-      override def ctag = implicitly[ClassTag[T]]
-      override def ttag = implicitly[TypeTag[T]]
-    }
+    type Tag[T] = TypeTag[T]
 
-    implicit def bag[T : ClassTag : TypeTag]: Meta[DataBag[T]] = new Meta[DataBag[T]] {
-      override def ctag = implicitly[ClassTag[DataBag[T]]]
-      override def ttag = implicitly[TypeTag[DataBag[T]]]
+    implicit def apply[T: Tag]: Meta[T] = new Meta[T] {
+      lazy val ctag = ClassTag[T](ttag.mirror.runtimeClass(ttag.tpe))
+      def ttag = implicitly[TypeTag[T]]
     }
 
     object Projections {
-      implicit def ttagFor[T: Meta]: scala.reflect.runtime.universe.TypeTag[T] =
-        implicitly[Meta[T]].ttag
-
-      implicit def ctagFor[T: Meta]: ClassTag[T] =
-        implicitly[Meta[T]].ctag
+      implicit def ttagFor[T](implicit meta: Meta[T]): TypeTag[T]  = meta.ttag
+      implicit def ctagFor[T](implicit meta: Meta[T]): ClassTag[T] = meta.ctag
     }
   }
   //@formatter:on


### PR DESCRIPTION
Given a `Meta.Tag[T] = runtime.universe.TypeTag[T]`, we can derive a `Meta[T]`.