### PR TITLE
[GUI] Prototype GraphTools and Graph Webapp /w Cytoscape

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -232,6 +232,7 @@ This project includes:
   Spark Project Unsafe under Apache 2.0 License
   spire under BSD-style
   spire-macros under BSD-style
+  spray-json under Apache 2
   StAX API under The Apache Software License, Version 2.0
   stream-lib under Apache License, Version 2.0
   test-interface under BSD

--- a/emma-gui/public/cytoscape-template.html
+++ b/emma-gui/public/cytoscape-template.html
@@ -1,0 +1,143 @@
+<!--
+
+    Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test-Cytoscape</title>
+
+    <script src="http://code.jquery.com/jquery-2.0.3.min.js"></script>
+    <script src="http://js.cytoscape.org/js/cytoscape.min.js"></script>
+
+    <script src="https://cdn.rawgit.com/cpettitt/dagre/v0.7.4/dist/dagre.min.js"></script>
+    <script src="https://cdn.rawgit.com/cytoscape/cytoscape.js-dagre/1.1.2/cytoscape-dagre.js"></script>
+
+    <style>
+        body {
+            font-family: helvetica;
+            font-size: 14px;
+        }
+        #cy {
+            width: 100%;
+            height: 100%;
+            position: absolute;
+            left: 0;
+            top: 0;
+            z-index: 0;
+        }
+        h1 {
+            opacity: 0.5;
+            font-size: 1em;
+        }
+        #graphselection {
+            position: absolute;
+            left: 10px; top: 10px;
+            z-index: 1;
+            font-size: 14px;
+        }
+    </style>
+
+    <script type="application/javascript">
+        $(function() {
+          const cy = cytoscape({
+                container: $("#cy"),
+
+                layout: {
+                    // name: 'breadthfirst'
+                    name: 'dagre'
+                },
+                style: [
+                    {
+                        selector: 'node',
+                        style: {
+                            'shape': 'rectangle',
+                            'background-color': '#983351', // primary medium
+                            'label': 'data(label)',
+                            'text-halign': 'center',
+                            'text-valign': 'center',
+                            'color': '#fad0e2', // primary very light
+                            'width': 'label',
+                            'height': 'label',
+                            'padding-top': '10',
+                            'padding-right': '10',
+                            'padding-bottom': '10',
+                            'padding-left': '10'
+                        }
+                    },
+                    {
+                        selector: ':parent',
+                        style: {
+                            'background-opacity': 0.333,
+                            'text-halign': "center",
+                            'text-valign': 'top',
+                            'color': '#333'
+                        }
+                    },
+                    {
+                        selector: ':parent node',
+                        style: {
+                            'background-color': '#226666' // Secondary (2) medium
+                        }
+                    },
+                    {
+                        selector: 'edge',
+                        style: {
+                            'width': 3,
+                            'curve-style': 'bezier',
+                            'line-color': '#de839e', // primary medium
+                            'target-arrow-color': '#983351', // primary medium
+                            'target-arrow-shape': 'triangle',
+                            'target-arrow-fill': "filled",
+                            'label': 'data(label)'
+                        }
+                    }
+                ],
+                elements: new Promise((resolve, reject) => {
+                    $.getJSON("/graph/graph-json/", (data) => {
+                        const selectionList = $("#graphselection");
+                        data.map((c, i, a) => Object.keys(c)[0])
+                            .forEach((c, i, a) => {
+                                selectionList.append(
+                                    $('<option />', {
+                                        value: c,
+                                        text: c,
+                                        selected: i === 0
+                                    })
+                                );
+                            });
+                        selectionList.change(function() { // this is bound by jQ m(
+                            const value = $(this).val();
+                            const e = data.find((e) => Object.keys(e)[0] === value);
+                            cy.elements().remove();
+                            cy.add(e[value]);
+                            cy.layout({ name: "dagre"});
+                        });
+                        const first = data[0]
+                        resolve(first[Object.keys(first)[0]]);
+                    });
+                })
+            });
+        });
+    </script>
+</head>
+<body>
+<p><form><select id="graphselection"></select></form></p>
+<div id="cy" />
+</body>
+</html>
+

--- a/emma-gui/src/main/scala/org/emmalanguage/server/GraphServlet.scala
+++ b/emma-gui/src/main/scala/org/emmalanguage/server/GraphServlet.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package server
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+import javax.servlet.http._
+import org.apache.commons.io.FilenameUtils
+
+import java.nio.file.Path
+
+class GraphServlet(path: Path) extends HttpServlet {
+  protected override def doGet(req: HttpServletRequest, resp: HttpServletResponse): Unit = {
+    import HttpServletResponse.SC_OK
+    req.getRequestURI.split('/').last match {
+      case "graph-json" => {
+        val directory = new File(path.toFile.toString)
+        val contents = directory
+          .listFiles()
+          .filter(file => file.isFile && FilenameUtils.getExtension(file.getName) == "json")
+            .map(f => Files.readAllBytes(Paths.get(f.getAbsolutePath)))
+            .map(bytes => new String(bytes)).mkString(",")
+        resp.setStatus(SC_OK)
+        resp.setHeader("Content-Type", "application/json")
+        resp.getWriter.println(s"[$contents]")
+      }
+      case _ => {
+        resp.setStatus(SC_OK)
+        req.getRequestDispatcher("/cytoscape-template.html").forward(req, resp)
+      }
+    }
+  }
+}

--- a/emma-gui/src/main/scala/org/emmalanguage/server/HttpServer.scala
+++ b/emma-gui/src/main/scala/org/emmalanguage/server/HttpServer.scala
@@ -26,6 +26,7 @@ import org.eclipse.jetty.webapp.WebAppContext
 
 import java.io.{File, PrintStream}
 import java.net.{URL, URLClassLoader}
+import java.nio.file.Path
 import java.nio.file.Paths
 
 object HttpServer {
@@ -40,8 +41,16 @@ object HttpServer {
   private[server] var LOGGER: Logger = Logger.getRootLogger
   private var server: Server = null
 
+  private[this] var graphPath: Option[Path] = None
+
   @throws(classOf[Exception])
   def main(args: Array[String]): Unit = {
+    if(args.size != 1) {
+      // FIXME make better error message
+      println("Missing 1st argument (graph path)")
+      System.exit(1)
+    }
+    graphPath = Some(Paths.get(args(0)))
     System.setOut(createLoggingProxy(System.out))
     System.setErr(createLoggingProxy(System.err))
     HttpServer.start()
@@ -82,6 +91,8 @@ object HttpServer {
     context.addServlet(new ServletHolder(new CodeServlet), "/code/*")
     context.addServlet(new ServletHolder(new PlanServlet), "/plan/*")
     context.addServlet(new ServletHolder(new LogEventServlet), "/log/*")
+    context.addServlet(new ServletHolder(new GraphServlet(graphPath.get)), "/graph/*")
+
     this.server.setHandler(context)
 
     try {

--- a/emma-language/pom.xml
+++ b/emma-language/pom.xml
@@ -121,6 +121,12 @@
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.tools.version}</artifactId>
         </dependency>
+
+        <!-- JSON-Rendering -->
+        <dependency>
+            <groupId>io.spray</groupId>
+            <artifactId>spray-json_${scala.tools.version}</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
@@ -22,6 +22,7 @@ import lang.cf.ControlFlow
 import lang.core.Core
 import lang.libsupport.LibSupport
 import lang.source.Source
+import tools.GraphTools
 
 import scala.reflect.api.Universe
 
@@ -36,7 +37,8 @@ trait Compiler extends AlphaEq
   with Source
   with Core
   with Backend
-  with ControlFlow {
+  with ControlFlow
+  with GraphTools {
 
   /** The underlying universe object. */
   override val universe: Universe

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/tools/GraphTools.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/tools/GraphTools.scala
@@ -1,0 +1,146 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler.tools
+
+import org.emmalanguage.compiler.Common
+import org.emmalanguage.compiler.lang.cf.ControlFlow
+import org.emmalanguage.compiler.lang.core.Core
+
+import resource._
+
+import java.io.FileWriter
+import java.nio.file.Path
+
+trait GraphTools extends Common
+  with ControlFlow
+  { this: Core =>
+
+  import UniverseImplicits._
+
+  object CytoscapeGraphJsonProtocol extends spray.json.DefaultJsonProtocol {
+    import spray.json._
+
+    case class NodeData(id: String, label: String, parent: Option[String])
+    case class EdgeData(id: String, source: String, target: String, label: String)
+
+    sealed trait Element
+    case class NodeElement(data: NodeData,
+                           group: String = "nodes",
+                           style: Option[Map[String, String]] = None
+                          ) extends Element
+
+    case class EdgeElement(data: EdgeData,
+                           group: String = "edges",
+                           style: Option[Map[String, String]] = None
+                          ) extends Element
+
+    implicit val nodeDataFormat = jsonFormat3(NodeData)
+    implicit val edgeDataFormat = jsonFormat4(EdgeData)
+    implicit val nodeElementFormat = jsonFormat3(NodeElement)
+    implicit val edgeElementFormat = jsonFormat3(EdgeElement)
+
+    implicit object ElementJsonFormat extends RootJsonFormat[Element] {
+      def write(c: Element) = c match {
+        case n: NodeElement => n.toJson
+        case e: EdgeElement => e.toJson
+      }
+
+      def read(value: JsValue) = {
+        value.asJsObject.getFields("group") match {
+          case Seq(JsString(group)) if group == "nodes" => value.convertTo[NodeElement]
+          case Seq(JsString(group)) if group == "edges" => value.convertTo[EdgeElement]
+          case x => throw new IllegalArgumentException(s"Unable to convert to `${classOf[Element].getSimpleName}`: $x")
+        }
+      }
+    }
+  }
+
+  object GraphTools {
+    import Core.{Lang => core}
+    import CytoscapeGraphJsonProtocol._
+    import spray.json._
+    val cs = new Comprehension.Syntax(API.bagSymbol)
+    def mkGraph(tree: u.Tree): Iterable[Element] = {
+      val graph = ControlFlow.cfg(API.bagSymbol)(tree)
+      val mkLabel = label(graph) _
+      val nestFlipped = for {
+        (parent, children) <- graph.nest
+        child <- children
+      } yield child -> parent
+
+      val nodes = for {
+        n <- graph.uses.keys
+      } yield NodeElement(
+        data = NodeData(
+          id = n.name.toString,
+          label = mkLabel(n),
+          parent = nestFlipped.get(n).map(_.name.toString)
+        )
+      )
+
+      val edges = for {
+        (from, tos) <- graph.flow
+        to <- tos
+      } yield {
+        val source = from.name.toString
+        val target = to.name.toString
+        val label = to.name.toString
+        EdgeElement(
+          data = EdgeData(
+            id = s"${source}_to_${target}",
+            source = source,
+            target = target,
+            label = label
+          )
+        )
+      }
+      nodes ++ edges
+    }
+
+    private[emmalanguage] def mkJsonGraph(id: String, tree: u.Tree): JsValue = JsObject(id -> mkGraph(tree).toJson)
+    private[emmalanguage] def writeJsonGraph(basePath: Path, id: String, tree: u.Tree): u.Tree = {
+      basePath.toFile.mkdirs() // make parent
+      val targetPath: Path = basePath.resolve(s"$id.json")
+      for(pw <- managed(new FileWriter(targetPath.toAbsolutePath.toString))) {
+        pw.write(mkJsonGraph(id, tree).toString())
+      }
+      tree
+    }
+
+    /**
+      * Renders a tree in Cytoscape graph json format.
+      *
+      * The method returns the identical tree while writing the graph as an effect.
+      *
+      * @param basePath the base path of the file
+      * @param name the filename
+      * @return a function returning the identity of the tree
+      */
+    def renderGraph(basePath: Path)(name: String): u.Tree => u.Tree = writeJsonGraph(basePath, name, _)
+
+    private[emmalanguage] def label(graph: CFG.Graph[u.TermSymbol])(sym: u.TermSymbol): String = {
+      graph.defs.get(sym).map(_.rhs) match {
+        case Some(core.Atomic(x)) => u.showCode(x)
+        case Some(core.DefCall(_, sym, _, _)) => sym.name.decodedName.toString
+        case Some(core.Lambda(_, _, _)) => "Lambda"
+        case Some(cs.Comprehension(_, _)) => "For-Comprehension"
+        case Some(_) => s"[Unknown Symbol: ${sym.name.decodedName}]"
+        case None => s"Closure (${sym.name.decodedName})"
+      }
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -370,6 +370,13 @@
                 <artifactId>scala-arm_${scala.tools.version}</artifactId>
                 <version>${scala-arm.version}</version>
             </dependency>
+
+            <!-- JSON-Rendering -->
+            <dependency>
+                <groupId>io.spray</groupId>
+                <artifactId>spray-json_${scala.tools.version}</artifactId>
+                <version>1.3.2</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
# Graph-GUI Prototype

Creates visual graphs using `ControlFlow.cfg` and  http://js.cytoscape.org/ and renders them in a browser for analysis. Very early stage, but maybe useful nevertheless.

- `emma-language`
    + `compiler.tools.GraphTools.renderGraph` -- `Tree => Tree` to be inserted into compiler pipelines (example see below). (Currently) Renders the data dependency graph as an effect to a `JSON` file to be consumed by `GraphServlet`
- `emma-gui`
    + `HttpServer` -- Receives the location of JSON-Graphs as the first program argument (e.g. `/tmp/emma/graphs/`)
    + `GraphServlet` -- exposes `/graph/`, renders a HTML website that  renders the graphs using.

## Usage (for now): 

(assuming `compiler.GraphTools` is in scope)

### Render Graphs from a Pipeline

```scala
  /*private */ val renderToTemp = GraphTools.renderGraph(java.nio.file.Paths.get("/tmp/emma/graphs")) _

  /*override*/ val liftPipeline: u.Expr[Any] => u.Tree =
    compiler.pipeline(typeCheck = true)(
      LibSupport.expand,
      Core.lnf,
      renderToTemp("transitiveclosure-post-lnf"),
      Comprehension.resugar(API.bagSymbol),
      renderToTemp("transitiveclosure-post-resugar"),
      Core.inlineLetExprs,
      Comprehension.normalize(API.bagSymbol),
      Core.uninlineLetExprs,
      renderToTemp("transitiveclosure-final")
    ).compose(_.tree)
```

### Web-Server

Start `HttpServer` with command line argument `/tmp/emma/graph`. Graphs will be served at `http://localhost:8080/graph` (by default).

TODO: Proper integration, proper endpoint, proper consumer