### PR TITLE
[API] Type class based Parquet support

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -39,7 +39,6 @@ This project includes:
   Apache Parquet Common under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
   Apache XBean :: ASM 5 shaded (repackaged) under null or null
@@ -54,7 +53,6 @@ This project includes:
   chill-avro under Apache 2
   chill-bijection under Apache 2
   chill-java under Apache 2
-  Codec under The Apache Software License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -215,7 +213,6 @@ This project includes:
   servlet-api under Commons Development and Distribution License, Version 1.0
   SLF4J API Module under MIT License
   SLF4J LOG4J-12 Binding under MIT License
-  Snappy for Java under The Apache Software License, Version 2.0
   snappy-java under The Apache Software License, Version 2.0
   Spark Project Catalyst under Apache 2.0 License
   Spark Project Core under Apache 2.0 License

--- a/emma-examples/emma-examples-flink/src/main/scala/org/emmalanguage/cli/FlinkExamplesRunner.scala
+++ b/emma-examples/emma-examples-flink/src/main/scala/org/emmalanguage/cli/FlinkExamplesRunner.scala
@@ -25,6 +25,7 @@ import examples.ml.clustering._
 import examples.ml.model._
 import examples.text._
 import io.csv._
+import util.Iso
 
 import breeze.linalg.{Vector => Vec}
 import org.apache.flink.api.scala.ExecutionEnvironment
@@ -161,7 +162,7 @@ object FlinkExamplesRunner {
   // ---------------------------------------------------------------------------
 
   implicit def breezeVectorCSVConverter[V: CSVColumn: ClassTag]: CSVConverter[Vec[V]] =
-    CSVConverter.iso[Array[V], Vec[V]](Vec.apply, _.toArray)
+    CSVConverter.iso[Array[V], Vec[V]](Iso.make(Vec.apply, _.toArray), implicitly)
 
   // Graphs
 

--- a/emma-examples/emma-examples-spark/src/main/scala/org/emmalanguage/cli/SparkExamplesRunner.scala
+++ b/emma-examples/emma-examples-spark/src/main/scala/org/emmalanguage/cli/SparkExamplesRunner.scala
@@ -25,6 +25,7 @@ import examples.ml.clustering._
 import examples.ml.model._
 import examples.text._
 import io.csv._
+import util.Iso
 
 import breeze.linalg.{Vector => Vec}
 import org.apache.spark.sql.SparkSession
@@ -165,8 +166,9 @@ object SparkExamplesRunner {
   // Parallelized algorithms
   // ---------------------------------------------------------------------------
 
-  implicit def breezeVectorCSVConverter[V: CSVColumn: ClassTag]: CSVConverter[Vec[V]] =
-    CSVConverter.iso[Array[V], Vec[V]](Vec.apply, _.toArray)
+  implicit def breezeVectorCSVConverter[V](implicit V: CSVColumn[V], ctag: ClassTag[V])
+    : CSVConverter[Vec[V]] = CSVConverter.iso[Array[V], Vec[V]](
+      Iso.make(Vec.apply, _.toArray), implicitly)
 
   // Graphs
 

--- a/emma-language/pom.xml
+++ b/emma-language/pom.xml
@@ -83,6 +83,24 @@
             <artifactId>hadoop-hdfs</artifactId>
         </dependency>
 
+        <!-- Parquet -->
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-encoding</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-column</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId>parquet-hadoop</artifactId>
+        </dependency>
+
         <!-- Serialization -->
         <dependency>
             <groupId>com.twitter</groupId>
@@ -114,6 +132,16 @@
             <artifactId>spray-json_${scala.tools.version}</artifactId>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- profile that activates provided dependencies -->
+        <profile>
+            <id>dev</id>
+            <properties>
+                <hadoop.scope>compile</hadoop.scope>
+            </properties>
+        </profile>
+    </profiles>
 
     <build>
         <plugins>

--- a/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
@@ -16,7 +16,8 @@
 package org.emmalanguage
 package api
 
-import io.csv.{CSV, CSVConverter}
+import io.csv._
+import io.parquet._
 
 /** An abstraction for homogeneous distributed collections. */
 trait DataBag[A] extends Serializable {
@@ -149,6 +150,15 @@ trait DataBag[A] extends Serializable {
    * @param path The location where the data will be written.
    */
   def writeText(path: String): Unit
+
+  /**
+   * Writes a DataBag into the specified `path` in a CSV format.
+   *
+   * @param path      The location where the data will be written.
+   * @param format    The CSV format configuration
+   * @param converter A converter to use for element serialization.
+   */
+  def writeParquet(path: String, format: Parquet)(implicit converter: ParquetConverter[A]): Unit
 
   /**
    * Converts the DataBag back into a scala Seq.
@@ -376,14 +386,26 @@ object DataBag {
    * @param format The CSV format configuration.
    * @tparam A the type of elements to read.
    */
-  def readCSV[A: Meta : CSVConverter](path: String, format: CSV): DataBag[A] = ScalaSeq.readCSV[A](path, format)
+  def readCSV[A: CSVConverter](path: String, format: CSV): DataBag[A] =
+    ScalaSeq.readCSV[A](path, format)
 
   /**
    * Reads a `DataBag[String]` elements from the specified `path`.
    *
    * @param path   The location where the data will be read from.
    */
-  def readText(path: String): DataBag[String] = ScalaSeq.readText(path)
+  def readText(path: String): DataBag[String] =
+    ScalaSeq.readText(path)
+
+  /**
+   * Reads a DataBag into the specified `path` using a Parquet format.
+   *
+   * @param path   The location where the data will be read from.
+   * @param format The Parquet format configuration.
+   * @tparam A the type of elements to read.
+   */
+  def readParquet[A: ParquetConverter](path: String, format: Parquet): DataBag[A] =
+    ScalaSeq.readParquet(path, format)
 
   // -----------------------------------------------------
   // Helper methods

--- a/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetConverter.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetConverter.scala
@@ -1,0 +1,336 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.parquet
+
+import util._
+
+import org.apache.parquet.io.api._
+import org.apache.parquet.schema._
+import Type.Repetition._
+
+import shapeless._
+import shapeless.labelled._
+import shapeless.ops.hlist._
+import shapeless.ops.nat._
+import shapeless.tag._
+
+import scala.collection.generic.CanBuild
+import scala.language.higherKinds
+
+/**
+ * Codec (provides encoding and decoding) type-class for the Parquet columnar format.
+ *
+ * Provided by default are codecs for Scala and Java primitives, collections and enumerations,
+ * [[Option]], tuples and case classes.
+ */
+trait ParquetConverter[A] {
+  def schema: Type
+  def reader(read: A => Unit): Converter
+  def writer(consumer: RecordConsumer): A => Unit
+}
+
+/** Factory methods and implicit instances of Parquet codecs. */
+object ParquetConverter extends IsoParquetConverters {
+
+  /** Summons an implicit codec for type `A` available in scope. */
+  def apply[A](implicit converter: ParquetConverter[A]): ParquetConverter[A] =
+    converter
+}
+
+trait IsoParquetConverters extends GenericParquetConverters {
+
+  private implicit val binaryIsoArrayByte: Binary <=> Array[Byte] =
+    Iso.make(_.getBytes, Binary.fromReusedByteArray)
+
+  private implicit val binaryIsoByte: Binary <=> Byte =
+    Iso.make(_.getBytesUnsafe.head, b => Binary.fromConstantByteArray(Array(b)))
+
+  private implicit val binaryIsoShort: Binary <=> Short =
+    Iso.make(bin => {
+      val bytes = bin.getBytesUnsafe
+      (bytes(0) + (bytes(1) << 8)).toShort
+    }, short => {
+      val bytes = Array(short.toByte, (short >> 8).toByte)
+      Binary.fromConstantByteArray(bytes)
+    })
+
+  private implicit val binaryIsoString: Binary <=> String =
+    Iso.make(_.toStringUsingUTF8, Binary.fromString)
+
+  private implicit val shortIsoChar: Short <=> Char =
+    Iso.make(_.toChar, _.toShort)
+
+  /**
+   * Derives a new Parquet codec for type `B` from an existing codec for type `A`,
+   * given an (implicit) isomorphism between `A` and `B`.
+   *
+   * Handles Java primitives and collections
+   * (the latter requires `import scala.collection.JavaConversions._`).
+   */
+  implicit def iso[A, B](implicit iso: A <=> B, underlying: ParquetConverter[A])
+  : ParquetConverter[B] = new ParquetConverter[B] {
+    def schema = underlying.schema
+    def reader(read: B => Unit) = underlying.reader(read.compose(iso.from))
+    def writer(consumer: RecordConsumer) = underlying.writer(consumer).compose(iso.to)
+  }
+
+  // Isomorphic converters
+  implicit val byteParquetConverter:      ParquetConverter[Byte]        = iso[Binary, Byte]
+  implicit val shortParquetConverter:     ParquetConverter[Short]       = iso[Binary, Short]
+  implicit val charParquetConverter:      ParquetConverter[Char]        = iso[Short, Char]
+  implicit val stringParquetConverter:    ParquetConverter[String]      = iso[Binary, String]
+  implicit val byteArrayParquetConverter: ParquetConverter[Array[Byte]] = iso[Binary, Array[Byte]]
+}
+
+trait GenericParquetConverters extends PrimitiveParquetConverters {
+
+  /** Creates an optional Parquet codec from an existing codec. */
+  implicit def optionParquetConverter[A](
+    implicit A: ParquetConverter[A]
+  ): ParquetConverter[Option[A]] = new ParquetConverter[Option[A]] {
+    val schema = new GroupType(REQUIRED, defaultField, copy(A.schema)(arity = OPTIONAL))
+
+    def reader(read: Option[A] => Unit) = new GroupConverter {
+      var optional = Option.empty[A]
+      val underlying = A.reader(v => optional = Some(v))
+      def getConverter(i: Int) = underlying
+      def start() = optional = None
+      def end() = read(optional)
+    }
+
+    def writer(consumer: RecordConsumer) = {
+      val write = A.writer(consumer)
+      optional => {
+        consumer.startGroup()
+        for (value <- optional) {
+          consumer.startField(defaultField, 0)
+          write(value)
+          consumer.endField(defaultField, 0)
+        }
+        consumer.endGroup()
+      }
+    }
+  }
+
+  /** Creates Parquet codec for a [[Traversable]] collection from an element codec. */
+  implicit def traversableParquetConverter[T[x] <: Traversable[x], A](
+    implicit TA: CanBuild[A, T[A]], A: ParquetConverter[A]
+  ): ParquetConverter[T[A]] = new ParquetConverter[T[A]] {
+    val schema = new GroupType(REQUIRED, defaultField, copy(A.schema)(arity = REPEATED))
+
+    def reader(read: T[A] => Unit) = new GroupConverter {
+      val builder = TA()
+      val element = A.reader(builder += _)
+      def getConverter(i: Int) = element
+      def start() = builder.clear()
+      def end() = read(builder.result())
+    }
+
+    def writer(consumer: RecordConsumer) = {
+      val write = A.writer(consumer)
+      values => {
+        consumer.startGroup()
+        consumer.startField(defaultField, 0)
+        values.foreach(write)
+        consumer.endField(defaultField, 0)
+        consumer.endGroup()
+      }
+    }
+  }
+
+  /**
+   * Creates a labelled Parquet codec for a generic field.
+   * @tparam K The singleton label symbol used as a field name in the schema.
+   * @tparam V The underlying type of the field with an existing codec.
+   * @tparam N The natural number type specifying the index of the field in a group.
+   */
+  implicit def fieldParquetConverter[K <: Symbol, V, N <: Nat](
+    implicit K: Witness.Aux[K], V: ParquetConverter[V], toInt: ToInt[N]
+  ): ParquetConverter[FieldType[K, V] @@ N] = new ParquetConverter[FieldType[K, V] @@ N] {
+    def key = K.value.name
+    val idx = toInt()
+    val schema = copy(V.schema)(name = key)
+
+    def reader(read: FieldType[K, V] @@ N => Unit) =
+      V.reader(read.compose(v => tag[N](field[K](v))))
+
+    def writer(consumer: RecordConsumer) = {
+      val write = V.writer(consumer)
+      value => {
+        consumer.startField(key, idx)
+        write(value)
+        consumer.endField(key, idx)
+      }
+    }
+  }
+
+  /** Induction base for deriving generic Parquet codecs (an empty group is not allowed). */
+  implicit def hConsParquetConverter[H](
+    implicit H: Lazy[ParquetConverter[H]]
+  ): ParquetConverter[H :: HNil] = new ParquetConverter[H :: HNil] {
+    def head = H.value
+    val schema = new GroupType(REQUIRED, defaultField, head.schema)
+
+    def reader(read: H :: HNil => Unit) = new GroupConverter {
+      val underlying = head.reader(read.compose(_ :: HNil))
+      def getConverter(i: Int) = underlying
+      def start() = ()
+      def end() = ()
+    }
+
+    def writer(consumer: RecordConsumer) =
+      head.writer(consumer).compose(_.head)
+  }
+
+  /** Induction step for deriving generic Parquet codecs. */
+  implicit def hListParquetConverter[A, B, T <: HList](
+    implicit H: Lazy[ParquetConverter[A]], T: Lazy[ParquetConverter[B :: T]]
+  ): ParquetConverter[A :: B :: T] = new ParquetConverter[A :: B :: T] {
+    def head = H.value
+    def tail = T.value
+
+    val schema = {
+      val underlying = tail.schema.asGroupType
+      val fields = new java.util.ArrayList[Type](underlying.getFieldCount + 1)
+      fields.add(head.schema)
+      fields.addAll(underlying.getFields)
+      new GroupType(REQUIRED, defaultField, fields)
+    }
+
+    def reader(read: A :: B :: T => Unit) = new GroupConverter {
+      var value: A = _
+      val hReader = head.reader(value = _)
+      val tReader = tail.reader(read.compose(value :: _)).asGroupConverter
+      def getConverter(i: Int) = if (i == 0) hReader else tReader.getConverter(i - 1)
+      def start() = ()
+      def end() = ()
+    }
+
+    def writer(consumer: RecordConsumer) = {
+      val writeH = head.writer(consumer)
+      val writeT = tail.writer(consumer)
+      value => {
+        writeH(value.head)
+        writeT(value.tail)
+      }
+    }
+  }
+
+  /** Polymorphic function for tagging generic fields. */
+  object tagWith extends Poly1 {
+    implicit def tagField[K, V, T] =
+      at[(FieldType[K, V], T)] { case (kv, _) => tag[T](kv) }
+  }
+
+  /** Polymorphic function for stripping tagged fields. */
+  object stripTag extends Poly1 {
+    implicit def stripField[K, V, T] =
+      at[FieldType[K, V] @@ T](identity[FieldType[K, V]])
+  }
+
+  /** Generic Parquet codec for case classes and tuples. */
+  implicit def genericParquetConverter[A, R <: HList, I <: HList, T <: HList](implicit
+    generic: LabelledGeneric.Aux[A, R],
+    indexed: ZipWithIndex.Aux[R, I],
+    tagged:  Mapper.Aux[tagWith.type, I, T],
+    strip:   Mapper.Aux[stripTag.type, T, R],
+    T: Lazy[ParquetConverter[T]]
+  ): ParquetConverter[A] = new ParquetConverter[A] {
+    def underlying = T.value
+    def schema = underlying.schema
+
+    def reader(read: A => Unit) = underlying
+      .reader(v => read(generic.from(strip(v))))
+
+    def writer(consumer: RecordConsumer) = {
+      val write = underlying.writer(consumer)
+      value => {
+        consumer.startGroup()
+        write(tagged(indexed(generic.to(value))))
+        consumer.endGroup()
+      }
+    }
+  }
+}
+
+trait PrimitiveParquetConverters {
+  import PrimitiveType.PrimitiveTypeName._
+
+  /** The default field name used for group wrappers. */
+  val defaultField = "value"
+
+  /** Copies a Parquet `schema`, changing its repetition or name. */
+  protected def copy(schema: Type)(
+    arity: Type.Repetition = schema.getRepetition,
+    name:  String          = schema.getName
+  ): Type = if (schema.isPrimitive) {
+    val prim = schema.asPrimitiveType
+    new PrimitiveType(arity, prim.getPrimitiveTypeName, name)
+  } else {
+    val group = schema.asGroupType
+    new GroupType(arity, name, group.getFields)
+  }
+
+  /** Codec for raw binary Parquet data. */
+  implicit val binaryParquetConverter: ParquetConverter[Binary] = new ParquetConverter[Binary] {
+    val schema = new PrimitiveType(REQUIRED, BINARY, defaultField)
+    def writer(consumer: RecordConsumer) = consumer.addBinary
+    def reader(read: Binary => Unit) = new PrimitiveConverter {
+      override def addBinary(value: Binary) = read(value)
+    }
+  }
+
+  implicit val booleanParquetConverter: ParquetConverter[Boolean] = new ParquetConverter[Boolean] {
+    val schema = new PrimitiveType(REQUIRED, BOOLEAN, defaultField)
+    def writer(consumer: RecordConsumer) = consumer.addBoolean
+    def reader(read: Boolean => Unit) = new PrimitiveConverter {
+      override def addBoolean(value: Boolean) = read(value)
+    }
+  }
+
+  implicit val intParquetConverter: ParquetConverter[Int] = new ParquetConverter[Int] {
+    val schema = new PrimitiveType(REQUIRED, INT32, defaultField)
+    def writer(consumer: RecordConsumer) = consumer.addInteger
+    def reader(read: Int => Unit) = new PrimitiveConverter {
+      override def addInt(value: Int) = read(value)
+    }
+  }
+
+  implicit val longParquetConverter: ParquetConverter[Long] = new ParquetConverter[Long] {
+    val schema = new PrimitiveType(REQUIRED, INT64, defaultField)
+    def writer(consumer: RecordConsumer) = consumer.addLong
+    def reader(read: Long => Unit) = new PrimitiveConverter {
+      override def addLong(value: Long) = read(value)
+    }
+  }
+
+  implicit val floatParquetConverter: ParquetConverter[Float] = new ParquetConverter[Float] {
+    val schema = new PrimitiveType(REQUIRED, FLOAT, defaultField)
+    def writer(consumer: RecordConsumer) = consumer.addFloat
+    def reader(read: Float => Unit) = new PrimitiveConverter {
+      override def addFloat(value: Float) = read(value)
+    }
+  }
+
+  implicit val doubleParquetConverter: ParquetConverter[Double] = new ParquetConverter[Double] {
+    val schema = new PrimitiveType(REQUIRED, DOUBLE, defaultField)
+    def writer(consumer: RecordConsumer) = consumer.addDouble
+    def reader(read: Double => Unit) = new PrimitiveConverter {
+      override def addDouble(value: Double) = read(value)
+    }
+  }
+}

--- a/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetReadSupport.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetReadSupport.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.parquet
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.ParquetReader
+import org.apache.parquet.hadoop.api._
+import org.apache.parquet.io.api._
+import org.apache.parquet.schema._
+
+import java.util
+
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+private[parquet] class ParquetReadSupport[A](implicit converter: ParquetConverter[A])
+  extends ReadSupport[A] {
+  import ReadSupport.ReadContext
+
+  var current: A = _
+  val schema = new MessageType("actor", converter.schema)
+
+  val reader = new GroupConverter {
+    val underlying = converter.reader(current = _)
+    def getConverter(i: Int) = underlying
+    def start() = ()
+    def end() = ()
+  }
+
+  override def init(context: InitContext): ReadSupport.ReadContext = {
+    val metadata = Map.empty[String, String].asJava
+    new ReadContext(schema, metadata)
+  }
+
+  def prepareForRead(
+    configuration: Configuration,
+    keyValueMetaData: util.Map[String, String],
+    fileSchema: MessageType,
+    readContext: ReadContext
+  ): RecordMaterializer[A] = new RecordMaterializer[A] {
+    def getRootConverter = reader
+    def getCurrentRecord = current
+  }
+}
+
+private[parquet] object ParquetReadSupport {
+  def builder[A: ParquetConverter](file: Path): ParquetReader.Builder[A] =
+    ParquetReader.builder(new ParquetReadSupport, file)
+}

--- a/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetScalaSupport.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetScalaSupport.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.parquet
+
+import io.ScalaSupport
+
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.ParquetFileWriter
+
+class ParquetScalaSupport[A: ParquetConverter](override val format: Parquet)
+  extends ScalaSupport[A, Parquet] {
+
+  private[emmalanguage] def read(path: String): TraversableOnce[A] = {
+    val builder = ParquetReadSupport
+      .builder(new Path(path)).withConf(format.config)
+
+    new Traversable[A] {
+      def foreach[U](f: A => U) = {
+        var exception: Throwable = null
+        val parquet = builder.build()
+        try Iterator.continually(parquet.read)
+          .takeWhile(_ != null).foreach(f)
+        catch { case ex: Throwable =>
+          exception = ex
+          throw ex
+        } finally if (parquet != null) {
+          if (exception != null) try {
+            parquet.close()
+          } catch { case ex: Throwable =>
+            exception.addSuppressed(ex)
+          } else parquet.close()
+        }
+      }
+    }
+  }
+
+  private[emmalanguage] def write(path: String)(xs: Traversable[A]): Unit = {
+    var exception: Throwable = null
+    val parquet = ParquetWriteSupport
+      .builder(new Path(path)).withConf(format.config)
+      .withWriteMode(ParquetFileWriter.Mode.OVERWRITE)
+      .build()
+
+    try xs.foreach(parquet.write)
+    catch { case ex: Throwable =>
+      exception = ex
+      throw ex
+    } finally if (parquet != null) {
+      if (exception != null) try {
+        parquet.close()
+      } catch { case ex: Throwable =>
+        exception.addSuppressed(ex)
+      } else parquet.close()
+    }
+  }
+}
+
+/** Companion object. */
+object ParquetScalaSupport {
+
+  def apply[A: ParquetConverter](format: Parquet): ParquetScalaSupport[A] =
+    new ParquetScalaSupport[A](format)
+}

--- a/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetWriteSupport.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetWriteSupport.scala
@@ -1,0 +1,65 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.parquet
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.ParquetWriter
+import org.apache.parquet.hadoop.api.WriteSupport
+import org.apache.parquet.io.api._
+import org.apache.parquet.schema._
+
+import scala.Function.const
+import scala.collection.JavaConverters.mapAsJavaMapConverter
+
+private[parquet] class ParquetWriteSupport[A](implicit converter: ParquetConverter[A])
+  extends WriteSupport[A] {
+  import WriteSupport.WriteContext
+
+  var consumer: RecordConsumer = _
+  var callback: A => Unit = const(())
+  val schema = new MessageType("actor", converter.schema)
+
+  def init(configuration: Configuration): WriteContext = {
+    val metadata = Map.empty[String, String].asJava
+    new WriteSupport.WriteContext(schema, metadata)
+  }
+
+  def prepareForWrite(recordConsumer: RecordConsumer): Unit = {
+    consumer = recordConsumer
+    callback = converter.writer(consumer)
+  }
+
+  def write(record: A): Unit = {
+    consumer.startMessage()
+    consumer.startField(ParquetConverter.defaultField, 0)
+    callback(record)
+    consumer.endField(ParquetConverter.defaultField, 0)
+    consumer.endMessage()
+  }
+}
+
+private[parquet] object ParquetWriteSupport {
+  def builder[A: ParquetConverter](file: Path): WriterBuilder[A] =
+    new WriterBuilder[A](new ParquetWriteSupport, file)
+
+  class WriterBuilder[A](support: WriteSupport[A], file: Path)
+    extends ParquetWriter.Builder[A, WriterBuilder[A]](file) {
+    def getWriteSupport(conf: Configuration) = support
+    def self() = this
+  }
+}

--- a/emma-language/src/main/scala/org/emmalanguage/util/Iso.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/util/Iso.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package util
+
+import api._
+
+import java.{lang => jl}
+import java.{math => jm}
+import java.{util => ju}
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+import scala.reflect.ClassTag
+
+/** Type class proving an isomorphism between types `A` and `B`. */
+trait Iso[A, B] {
+  def from(a: A): B
+  def to(b: B): A
+
+  /** Swaps the type arguments of this isomorphism. */
+  def swap: B <=> A = Iso.make(to, from)
+
+  /** Composes with `B <-> C` isomorphism to provide `A <-> C` isomorphism. */
+  def compose[C](implicit that: B <=> C): A <=> C =
+    Iso.make(a => that.from(from(a)), c => to(that.to(c)))
+}
+
+/** Factory methods and instances of isomorphism. */
+object Iso {
+
+  /** Summons an implicit isomorphism instance available in scope. */
+  def apply[A, B](implicit iso: A <=> B): A <=> B = iso
+
+  /**
+   * Creates a new isomorphism from pure view functions.
+   * Handles Java boxed primitives and collections
+   * (the latter requires `import scala.collection.JavaConversions._`).
+   */
+  implicit def make[A, B](implicit fromF: A => B, toF: B => A): A <=> B =
+    new Iso[A, B] {
+      def from(a: A) = fromF(a)
+      def to(b: B) = toF(b)
+    }
+
+  implicit val stringIsoBigInt: String <=> BigInt =
+    make(BigInt.apply, _.toString)
+
+  implicit val stringIsoBigDecimal: String <=> BigDecimal =
+    make(BigDecimal.apply, _.toString)
+
+  implicit val bigIntIsoJBigInteger: BigInt <=> jm.BigInteger =
+    make(_.bigInteger, BigInt.apply)
+
+  implicit val bigDecimalIsoJBigDecimal: BigDecimal <=> jm.BigDecimal =
+    make(_.bigDecimal, BigDecimal.apply)
+
+  implicit val longIsoDate: Long <=> ju.Date =
+    make(new ju.Date(_), _.getTime)
+
+  implicit def bufferIsoArray[A: ClassTag]: mutable.Buffer[A] <=> Array[A] =
+    make(_.toArray, _.toBuffer)
+
+  implicit def seqIsoDataBag[A: Meta]: Seq[A] <=> DataBag[A] =
+    make(DataBag(_), _.fetch())
+
+  implicit def intIsoEnum[E <: Enumeration](implicit enum: E): Int <=> enum.Value =
+    make(enum(_), _.id)
+
+  implicit def intIsoJEnum[E <: jl.Enum[E]](implicit E: ClassTag[E]): Int <=> E =
+    make(ordinal => {
+      val enum = E.runtimeClass.asInstanceOf[Class[E]]
+      ju.EnumSet.allOf(enum).find(_.ordinal == ordinal).get
+    }, _.ordinal)
+
+  def stringIsoEnum[E <: Enumeration](implicit enum: E): String <=> enum.Value =
+    make(name => enum.withName(name), _.toString)
+
+  def stringIsoJEnum[E <: jl.Enum[E]](implicit E: ClassTag[E]): String <=> E =
+    make(jl.Enum.valueOf(E.runtimeClass.asInstanceOf[Class[E]], _), _.name)
+}

--- a/emma-language/src/main/scala/org/emmalanguage/util/package.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/util/package.scala
@@ -1,0 +1,20 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+
+package object util {
+  type <=>[A, B] = Iso[A, B]
+}

--- a/emma-language/src/test/scala/org/emmalanguage/io/parquet/ParquetScalaSupportSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/io/parquet/ParquetScalaSupportSpec.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.parquet
+
+import test.util.tempPath
+
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.FreeSpec
+import org.scalatest.Matchers
+
+class ParquetScalaSupportSpec extends FreeSpec with Matchers with PropertyChecks {
+
+  case class Name(first: String, middle: Option[String], last: String)
+  case class Movie(title: String, year: Int)
+  case class Actor(name: Name, filmography: Seq[Movie])
+
+  "basic example" in {
+    val expected = Seq(
+      Actor(Name("Harry", Some("Dean"), "Stanton"), Seq(
+        Movie("Paris, Texas", 1984),
+        Movie("Seven Psychopaths", 2012)
+      )),
+      Actor(Name("Jamie", Some("Lee"), "Courtis"), Seq(
+        Movie("True Lies", 1994),
+        Movie("A Fish Called Wanda", 1988)
+      )),
+      Actor(Name("Daniel", None, "Day-Lewis"), Seq(
+        Movie("There Will Be Blood", 2007)
+      ))
+    )
+
+    val parquet = new ParquetScalaSupport[Actor](Parquet.default)
+    val path = tempPath("actors.parquet")
+    parquet.write(path)(expected)
+    val actual = parquet.read(path).toStream
+    actual should contain theSameElementsInOrderAs expected
+  }
+}

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
@@ -16,22 +16,25 @@
 package org.emmalanguage
 package api
 
-import io.csv.{CSV, CSVConverter}
+import io.csv._
+import io.parquet._
 
 import org.apache.spark.rdd._
 import org.apache.spark.sql.SparkSession
 
-import scala.language.{higherKinds, implicitConversions}
+import scala.language.higherKinds
+import scala.language.implicitConversions
 import scala.util.hashing.MurmurHash3
 
 /** A `DataBag` implementation backed by a Spark `RDD`. */
 class SparkRDD[A: Meta] private[api](@transient private[api] val rep: RDD[A])(implicit spark: SparkSession)
   extends DataBag[A] {
 
-  import spark.sqlContext.implicits._
   import Meta.Projections._
+  import SparkRDD.encoderForType
+  import SparkRDD.wrap
 
-  import SparkRDD.{encoderForType, wrap}
+  import spark.sqlContext.implicits._
 
   @transient override val m = implicitly[Meta[A]]
 
@@ -79,8 +82,8 @@ class SparkRDD[A: Meta] private[api](@transient private[api] val rep: RDD[A])(im
   // Sinks
   // -----------------------------------------------------
 
-  override def writeCSV(path: String, format: CSV)(implicit converter: CSVConverter[A]): Unit = {
-    spark
+  override def writeCSV(path: String, format: CSV)
+    (implicit converter: CSVConverter[A]): Unit = spark
       .createDataset(rep).write
       .option("header", format.header)
       .option("delimiter", format.delimiter.toString)
@@ -88,14 +91,19 @@ class SparkRDD[A: Meta] private[api](@transient private[api] val rep: RDD[A])(im
       .option("quote", format.quote.getOrElse('"').toString)
       .option("escape", format.escape.getOrElse('\\').toString)
       .option("nullValue", format.nullValue)
-      .mode("overwrite")
-      .csv(path)
-  }
+      .mode("overwrite").csv(path)
 
   override def writeText(path: String): Unit =
-    spark
+    spark.createDataset(rep).write.text(path)
+
+  def writeParquet(path: String, format: Parquet)
+    (implicit converter: ParquetConverter[A]): Unit = spark
       .createDataset(rep).write
-      .text(path)
+      .option("binaryAsString", format.binaryAsString)
+      .option("int96AsTimestamp", format.int96AsTimestamp)
+      .option("cacheMetadata", format.cacheMetadata)
+      .option("codec", format.codec.toString)
+      .mode("overwrite").parquet(path)
 
   def fetch(): Seq[A] = collect
 
@@ -106,7 +114,7 @@ class SparkRDD[A: Meta] private[api](@transient private[api] val rep: RDD[A])(im
   // equals and hashCode
   // -----------------------------------------------------
 
-  override def equals(o: Any) =
+  override def equals(o: Any): Boolean =
     super.equals(o)
 
   override def hashCode(): Int = {
@@ -138,10 +146,10 @@ class SparkRDD[A: Meta] private[api](@transient private[api] val rep: RDD[A])(im
 
 object SparkRDD {
 
+  import Meta.Projections._
+
   import org.apache.spark.sql.Encoder
   import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
-
-  import Meta.Projections._
 
   implicit def encoderForType[T: Meta]: Encoder[T] =
     ExpressionEncoder[T]
@@ -156,22 +164,29 @@ object SparkRDD {
   def apply[A: Meta](values: Seq[A])(implicit spark: SparkSession): SparkRDD[A] =
     spark.sparkContext.parallelize(values)
 
-  def readCSV[A: Meta : CSVConverter](path: String, format: CSV)(implicit spark: SparkSession): SparkRDD[A] =
-    spark.read
+  def readCSV[A: Meta](path: String, format: CSV)
+    (implicit spark: SparkSession): SparkRDD[A] = spark.read
       .option("header", format.header)
       .option("delimiter", format.delimiter.toString)
       .option("charset", format.charset.toString)
       .option("quote", format.quote.getOrElse('"').toString)
       .option("escape", format.escape.getOrElse('\\').toString)
-      .option("comment", format.escape.map(_.toString).getOrElse(null.asInstanceOf[String]))
+      .option("comment", format.escape.map(_.toString).orNull)
       .option("nullValue", format.nullValue)
       .schema(encoderForType[A].schema)
-      .csv(path)
-      .as[A]
-      .rdd
+      .csv(path).as[A].rdd
 
   def readText(path: String)(implicit spark: SparkSession): SparkRDD[String] =
     spark.sparkContext.textFile(path)
+
+  def readParquet[A: Meta](path: String, format: Parquet)
+    (implicit spark: SparkSession): SparkRDD[A] = spark.read
+      .option("binaryAsString", format.binaryAsString)
+      .option("int96AsTimestamp", format.int96AsTimestamp)
+      .option("cacheMetadata", format.cacheMetadata)
+      .option("codec", format.codec.toString)
+      .schema(encoderForType[A].schema)
+      .parquet(path).as[A].rdd
 
   // ---------------------------------------------------------------------------
   // Implicit Rep -> DataBag conversion

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,8 @@
         <flink.version>0.10.0</flink.version>
         <!-- Spark -->
         <spark.version>2.0.1</spark.version>
+        <!-- Parquet -->
+        <parquet.version>1.8.1</parquet.version>
 
         <!-- Logging -->
         <log4j.version>1.2.17</log4j.version>
@@ -284,6 +286,28 @@
                 <artifactId>spark-sql_${scala.tools.version}</artifactId>
                 <version>${spark.version}</version>
                 <scope>${spark.scope}</scope>
+            </dependency>
+
+            <!-- Parquet -->
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-common</artifactId>
+                <version>${parquet.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-encoding</artifactId>
+                <version>${parquet.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-column</artifactId>
+                <version>${parquet.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.parquet</groupId>
+                <artifactId>parquet-hadoop</artifactId>
+                <version>${parquet.version}</version>
             </dependency>
 
             <!-- CSV -->


### PR DESCRIPTION
TODO:
- [x] Rebase / squash
- [x] Create a type class for `ReadSupport` and `WriteSupport`
- [x] Pass configuration from `Parquet` format.
- [x] Write a new spec (or migrate the `Actor` spec).