### PR TITLE
[IR] Allowed control flow in generators and Combination

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
@@ -65,6 +65,12 @@ trait Symbols { this: AST =>
       // Utility methods
       // ------------------------------------------------------------------------------------------
 
+      /** Returns the symbol corresponding to a type. */
+      def apply[T: u.WeakTypeTag]: u.Symbol = {
+        val sym = symbolOf[T]
+        if (sym.isModuleClass) sym.asClass.module else sym
+      }
+
       /** Returns the flags associated with `sym`. */
       def flags(sym: u.Symbol): u.FlagSet =
         internal.flags(sym)

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
@@ -81,7 +81,7 @@ trait Symbols { this: AST =>
 
       /** Returns any annotation of type `A` associated with `sym`. */
       def findAnn[A: TypeTag](sym: u.Symbol): Option[u.Annotation] =
-        sym.annotations.find(_.tree.tpe =:= Type[A])
+        sym.annotations.find(_.tree.tpe <:< Type[A])
 
       /** Copy / extractor for symbol attributes. */
       object With {

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Transversers.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Transversers.scala
@@ -170,7 +170,7 @@ trait Transversers { this: AST =>
       if (acc != HNil) state = acc |+| accumulation(tree)
 
     /** Resets the state so that another tree can be traversed. */
-    protected final def reset(): Unit = {
+    protected def reset(): Unit = {
       state = grammar.initAcc
       stack = grammar.initInh :: Nil
       cache.clear()
@@ -606,7 +606,13 @@ trait Transversers { this: AST =>
         (grammar: AttrGrammar[A, I, S])(template: Attr[A, I, S] =?> Tree)
         : Transform[A, I, S] = new Transform[A, I, S](grammar, template) {
           val matches: mutable.Set[Tree] = mutable.Set.empty
-          override final def transform(tree: Tree): Tree = {
+
+          override def reset() = {
+            super.reset()
+            matches.clear()
+          }
+
+          override final def transform(tree: Tree) = {
             val recur = super.transform(tree)
             val children = tree.children
             if (children.exists(matches)) {
@@ -690,7 +696,13 @@ trait Transversers { this: AST =>
         (grammar: AttrGrammar[A, I, S])(callback: Attr[A, I, S] =?> Unit)
         : Traversal[A, I, S] = new Traversal[A, I, S](grammar, callback) {
           val matches: mutable.Set[Tree] = mutable.Set.empty
-          override final def traverse(tree: Tree): Unit = {
+
+          override def reset() = {
+            super.reset()
+            matches.clear()
+          }
+
+          override final def traverse(tree: Tree) = {
             super.traverse(tree)
             val children = tree.children
             if (children.exists(matches)) {

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
@@ -185,7 +185,7 @@ trait Common extends AST {
     val loopBody      = api.Sym[loopBody].asClass
 
     private def ann(sym: u.ClassSymbol) =
-      u.Annotation(api.Inst(sym.info, argss = Seq(Seq.empty)))
+      u.Annotation(api.Inst(sym.toType, argss = Seq(Seq.empty)))
 
     // Annotation trees
     val suffixAnn     = ann(suffix)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
@@ -169,6 +169,40 @@ trait Common extends AST {
     //@formatter:on
   }
 
+  protected[emmalanguage] object DSCFAnnotations extends IRModule {
+    import ir.DSCFAnnotations._
+    //@formatter:off
+    val module        = api.Sym[ir.DSCFAnnotations.type].asModule
+
+    // Annotation symbols
+    val branch        = api.Sym[branch].asClass
+    val loop          = api.Sym[loop].asClass
+    val suffix        = api.Sym[suffix].asClass
+    val thenBranch    = api.Sym[thenBranch].asClass
+    val elseBranch    = api.Sym[elseBranch].asClass
+    val whileLoop     = api.Sym[whileLoop].asClass
+    val doWhileLoop   = api.Sym[doWhileLoop].asClass
+    val loopBody      = api.Sym[loopBody].asClass
+
+    private def ann(sym: u.ClassSymbol) =
+      u.Annotation(api.Inst(sym.info, argss = Seq(Seq.empty)))
+
+    // Annotation trees
+    val suffixAnn     = ann(suffix)
+    val thenAnn       = ann(thenBranch)
+    val elseAnn       = ann(elseBranch)
+    val whileAnn      = ann(whileLoop)
+    val doWhileAnn    = ann(doWhileLoop)
+    val loopBodyAnn   = ann(loopBody)
+
+    val ops           = Set.empty[u.MethodSymbol]
+    //@formatter:on
+  }
+
+  private def assertOneOverload(ops: Traversable[u.MethodSymbol]) =
+    for (op <- ops) assert(op.alternatives.size == 1,
+      s"`$op` should have exactly one overload. (see `changeStaticCalls` in translateToDataflows)")
+
   /** Common validation helpers. */
   object Validation {
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/ir/DSCFAnnotations.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/ir/DSCFAnnotations.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler.ir
+
+import scala.annotation._
+
+object DSCFAnnotations {
+
+  sealed trait continuation extends StaticAnnotation
+  trait branch extends continuation
+  trait loop   extends continuation
+
+  class suffix      extends continuation
+  class thenBranch  extends branch
+  class elseBranch  extends branch
+  class whileLoop   extends loop
+  class doWhileLoop extends loop
+  class loopBody    extends continuation
+}

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
@@ -228,8 +228,9 @@ trait Comprehension extends Common
         val symbol = ComprehensionCombinators.equiJoin
 
         def apply(kx: u.Tree, ky: u.Tree)(xs: u.Tree, ys: u.Tree): u.Tree = {
-          val keyTpe = api.Type.arg(2, kx.tpe)
-          assert(keyTpe =:= api.Type.arg(2, ky.tpe))
+          val keyTpe = api.Type.lub(Seq(
+            api.Type.arg(2, kx.tpe),
+            api.Type.arg(2, ky.tpe)))
 
           core.DefCall(module, symbol,
             Seq(Core.bagElemTpe(xs), Core.bagElemTpe(ys), keyTpe),

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/ANF.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/ANF.scala
@@ -255,15 +255,15 @@ private[core] trait ANF extends Common {
           }
 
           // Flatten nested let expressions in expr position without control flow.
-          val (exprVals, flatExpr) = expr match {
-            case core.Let(nestedVals, Seq(), nestedExpr) =>
-              (nestedVals, nestedExpr)
+          val (exprVals, flatDefs, flatExpr) = expr match {
+            case core.Let(nestedVals, nestedDefs, nestedExpr) =>
+              (nestedVals, nestedDefs, nestedExpr)
             case _ =>
-              (Seq.empty, expr)
+              (Seq.empty, defs, expr)
           }
 
           val (trimmedVals, trimmedExpr) = trimVals(flatVals ++ exprVals, flatExpr)
-          core.Let(trimmedVals, defs, trimmedExpr)
+          core.Let(trimmedVals, flatDefs, trimmedExpr)
       }.andThen(_.tree)
 
     // ---------------
@@ -289,7 +289,7 @@ private[core] trait ANF extends Common {
         case _ => false
       }
       def inExpr = let.expr match {
-        case core.Let(_, Seq(), _) => true
+        case core.Let(_, _, _) => true
         case _ => false
       }
       inStats || inExpr

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
@@ -301,6 +301,13 @@ trait Core extends Common
     /** Delegates to [[ANF.uninlineLetExprs]]. */
     lazy val uninlineLetExprs = ANF.uninlineLetExprs
 
+    /** Delegates to [[DSCF.stripAnnotations]]. */
+    lazy val stripAnnotations = DSCF.stripAnnotations
+
+    /** Delegates to [[DSCF.mapSuffix]]. */
+    def mapSuffix(let: u.Block, res: Option[u.Type] = None)
+      (f: (Seq[u.ValDef], u.Tree) => u.Block): u.Block = DSCF.mapSuffix(let, res)(f)
+
     // -------------------------------------------------------------------------
     // DCE API
     // -------------------------------------------------------------------------

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
@@ -63,556 +63,319 @@ class CombinationSpec extends BaseCompilerSpec {
   // Spec tests
   // ---------------------------------------------------------------------------
 
-  "apply once " - {
-
-    "MatchFilter" in {
-
-      val inp = u.reify {
-        comprehension[User, DataBag] {
-          val u = generator[User, DataBag] {
-            val f$1 = (u: User) => {
-              val x$4 = u.id
-              val x$5 = x$4 > 0
-              x$5
-            }
-            val ir$1 = users.withFilter(f$1)
-            ir$1
-          }
-          guard {
-            val x$1 = u.id
-            val x$2 = x$1 < 11
-            x$2
-          }
-          head {
-            u
-          }
+  "match once " - {
+    "filter" in {
+      val inp = u.reify(comprehension[User, DataBag] {
+        val u = generator[User, DataBag] {
+          users withFilter { _.id > 0 }
         }
-      }
+        guard { u.id < 11 }
+        head { u }
+      })
 
-      val exp = u.reify {
-        comprehension[User, DataBag] {
-          val u = generator[User, DataBag] {
-            val f$1 = (u: User) => {
-              val x$4 = u.id
-              val x$5 = x$4 > 0
-              x$5
-            }
-            val ir$1 = users.withFilter(f$1)
-            val f$2 = (u: User) => {
-              val x$1 = u.id
-              val x$2 = x$1 < 11
-              x$2
-            }
-            val ir$2 = ir$1.withFilter(f$2)
-            ir$2
-          }
-          head {
-            u
-          }
+      val exp = u.reify(comprehension[User, DataBag] {
+        val u = generator[User, DataBag] {
+          val filtered$1 = users withFilter { _.id > 0 }
+          filtered$1 withFilter { _.id < 11 }
         }
-      }
+        head { u }
+      })
 
       applyOnce(MatchFilter)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "MatchFlatMap" in {
-
-      val users$1 = users
-
-      val inp = u.reify {
-        comprehension[Long, DataBag] {
-          val x = generator[User, DataBag] {
-            users$1
-          }
-          val y = generator[Long, DataBag] {
-            val ir1 = x.id
-            val ir2 = Seq(ir1, ir1)
-            val ir3 = DataBag(ir2)
-            ir3
-          }
-          head {
-            y
-          }
+    "flatMap" in {
+      val inp = u.reify(comprehension[Long, DataBag] {
+        val x = generator[User, DataBag] { users }
+        val y = generator[Long, DataBag] {
+          DataBag(Seq(x.id, x.id))
         }
-      }
+        head { y }
+      })
 
-      val exp = u.reify {
-        comprehension[Long, DataBag] {
-          val y = generator[Long, DataBag] {
-            val f = (fx: User) => {
-              val ir1 = fx.id
-              val ir2 = Seq(ir1, ir1)
-              val ir3 = DataBag(ir2)
-              ir3
-            }
-            val ir4 = users$1 flatMap f
-            ir4
-          }
-          head {
-            y
-          }
+      val exp = u.reify(comprehension[Long, DataBag] {
+        val y = generator[Long, DataBag] {
+          users flatMap { x => DataBag(Seq(x.id, x.id)) }
         }
-      }
+        head { y }
+      })
 
       applyOnce(MatchFlatMap)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "MatchFlatMap2" in {
+    "flatMap2" in {
+      val inp = u.reify(comprehension[(User, Long, User), DataBag] {
+        val x = generator[User, DataBag] { users }
+        val y = generator[Long, DataBag] {
+          DataBag(Seq(x.id, x.id))
+        }
+        guard { x.id != y }
+        val z = generator[User, DataBag] {
+          DataBag(Seq(x))
+        }
+        head { (x, y, z) }
+      })
 
-      val users$1 = users
-
-      val inp = u.reify {
-        comprehension[(User, Long), DataBag] {
-          val x = generator[User, DataBag] {
-            users$1
-          }
-          val y = generator[Long, DataBag] {
-            val ir1 = x.id
-            val ir2 = Seq(ir1, ir1)
-            val ir3 = DataBag(ir2)
-            ir3
-          }
-          guard {
-            x.id != y
-          }
-          val z = generator[User, DataBag] {
-            DataBag(Seq(x))
-          }
-          head {
-            (x, y)
+      val exp = u.reify(comprehension[(User, Long, User), DataBag] {
+        val xy = generator[(User, Long), DataBag] {
+          users flatMap { x =>
+            DataBag(Seq(x.id, x.id)) map { (x, _) }
           }
         }
-      }
-
-      val exp = u.reify {
-        comprehension[(User, Long), DataBag] {
-          val xy = generator[(User, Long), DataBag] {
-            val f = (fArg: User) => {
-              val ir1 = fArg.id
-              val ir2 = Seq(ir1, ir1)
-              val ir3 = DataBag(ir2)
-              val g = (gArg: Long) => (fArg, gArg)
-              val ir5 = ir3 map g
-              ir5
-            }
-            val ir4 = users$1 flatMap f
-            ir4
-          }
-          guard {
-            val xy1 = xy._1
-            val xy2 = xy._2
-            xy1.id != xy2
-          }
-          val z = generator[User, DataBag] {
-            DataBag(Seq(xy._1))
-          }
-          head {
-            (xy._1, xy._2)
-          }
+        guard {
+          val x = xy._1
+          val y = xy._2
+          x.id != y
         }
-      }
+        val z = generator[User, DataBag] {
+          DataBag(Seq(xy._1))
+        }
+        head {
+          val x = xy._1
+          val y = xy._2
+          (x, y, z)
+        }
+      })
 
       applyOnce(MatchFlatMap2)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "MatchCross (simple)" in {
+    "cross (simple)" in {
+      val inp = u.reify(comprehension[(User, User), DataBag] {
+        val x = generator[User, DataBag] { users }
+        val y = generator[User, DataBag] { users }
+        head { (x, y) }
+      })
 
-      val inp = u.reify {
-        comprehension[(User, User), DataBag] {
-          val x = generator[User, DataBag] {
-            users
-          }
-          val y = generator[User, DataBag] {
-            users
-          }
-          head {
-            (x,y)
-          }
+      val exp = u.reify(comprehension[(User, User), DataBag] {
+        val xy = generator[(User, User), DataBag] {
+          cross(users, users)
         }
-      }
-
-      val exp = u.reify {
-        comprehension[(User, User), DataBag] {
-          val c = generator[(User, User), DataBag] {
-            cross(users, users)
-          }
-          head {
-            (c._1,c._2)
-          }
-        }
-      }
+        head { (xy._1, xy._2) }
+      })
 
       applyOnce(MatchCross)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "MatchCross (complicated)" in {
-
-      val inp = u.reify {
-        comprehension[String, DataBag] {
-          val u = generator[DataBag[User], DataBag] {
-            DataBag(Seq(users, users))
-          }
-          val x = generator[User, DataBag] {
-            u
-          }
-          val y = generator[Int, DataBag] {
-            DataBag(Seq(1,2,3)) union DataBag(Seq(4,5,6))
-          }
-          val z = generator[Long, DataBag] {
-            DataBag(Seq(x.id + x.id))
-          }
-          guard {
-            y != 0
-          }
-          head {
-            (x.id + y + z).toString
-          }
+    "cross (complex)" in {
+      val inp = u.reify(comprehension[String, DataBag] {
+        val u = generator[DataBag[User], DataBag] {
+          DataBag(Seq(users, users))
         }
-      }
-
-      val exp = u.reify {
-        comprehension[String, DataBag] {
-          val u = generator[DataBag[User], DataBag] {
-            DataBag(Seq(users, users))
-          }
-          val c = generator[(User, Int), DataBag] {
-            cross(u, DataBag(Seq(1,2,3)) union DataBag(Seq(4,5,6)))
-          }
-          val z = generator[Long, DataBag] {
-            val c1 = c._1
-            DataBag(Seq(c1.id + c1.id))
-          }
-          guard {
-            c._2 != 0
-          }
-          head {
-            val c1 = c._1
-            val c2 = c._2
-            (c1.id + c2 + z).toString
-          }
+        val x = generator[User, DataBag] { u }
+        val y = generator[Int, DataBag] {
+          DataBag(Seq(1,2,3)) union DataBag(Seq(4,5,6))
         }
-      }
+        val z = generator[Long, DataBag] {
+          DataBag(Seq(x.id + x.id))
+        }
+        guard { y != 0 }
+        head { (x.id + y + z).toString }
+      })
+
+      val exp = u.reify(comprehension[String, DataBag] {
+        val u = generator[DataBag[User], DataBag] {
+          DataBag(Seq(users, users))
+        }
+        val xy = generator[(User, Int), DataBag] {
+          val union$1 = DataBag(Seq(1,2,3)) union DataBag(Seq(4,5,6))
+          cross(u, union$1)
+        }
+        val z = generator[Long, DataBag] {
+          val x = xy._1
+          DataBag(Seq(x.id + x.id))
+        }
+        guard { xy._2 != 0 }
+        head {
+          val x = xy._1
+          val y = xy._2
+          (x.id + y + z).toString
+        }
+      })
 
       applyOnce(MatchCross)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "MatchEquiJoin (simple)" in {
+    "equiJoin (simple)" in {
+      val inp = u.reify(comprehension[(User, User), DataBag] {
+        val x = generator[User, DataBag] { users }
+        val y = generator[User, DataBag] { users }
+        guard { x.id == y.id }
+        head { (x, y) }
+      })
 
-      val users$1 = users
-
-      val inp = u.reify {
-        comprehension[(User, User), DataBag] {
-          val x = generator[User, DataBag] {
-            users$1
-          }
-          val y = generator[User, DataBag] {
-            users$1
-          }
-          guard {
-            x.id == y.id
-          }
-          head {
-            (x,y)
-          }
+      val exp = u.reify(comprehension[(User, User), DataBag] {
+        val xy = generator[(User, User), DataBag] {
+          val users$1 = users
+          val users$2 = users
+          val kx = (x: User) => x.id
+          val ky = (y: User) => y.id
+          equiJoin(kx, ky)(users$1, users$2)
         }
-      }
-
-      val exp = u.reify {
-        comprehension[(User, User), DataBag] {
-          val j = generator[(User, User), DataBag] {
-            val k1 = (x: User) => x.id
-            val k2 = (y: User) => y.id
-            equiJoin(k1, k2)(users$1, users$1)
-          }
-          head {
-            (j._1, j._2)
-          }
-        }
-      }
+        head { (xy._1, xy._2) }
+      })
 
       applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "MatchEquiJoin (reversed)" in {
+    "equiJoin (reversed)" in {
+      val inp = u.reify(comprehension[(User, User), DataBag] {
+        val x = generator[User, DataBag] { users }
+        val y = generator[User, DataBag] { users }
+        // lhs of `==` refers to the second generator, rhs refers to the first
+        guard { y.id == x.id }
+        head { (x, y) }
+      })
 
-      val users$1 = users
-
-      val inp = u.reify {
-        comprehension[(User, User), DataBag] {
-          val x = generator[User, DataBag] {
-            users$1
-          }
-          val y = generator[User, DataBag] {
-            users$1
-          }
-          guard {
-            y.id == x.id // lhs of `==` refers to the second generator, rhs refers to the first
-          }
-          head {
-            (x,y)
-          }
+      val exp = u.reify(comprehension[(User, User), DataBag] {
+        val xy = generator[(User, User), DataBag] {
+          val users$1 = users
+          val users$2 = users
+          val kx = (x: User) => x.id
+          val ky = (y: User) => y.id
+          equiJoin(kx, ky)(users$1, users$2)
         }
-      }
-
-      val exp = u.reify {
-        comprehension[(User, User), DataBag] {
-          val j = generator[(User, User), DataBag] {
-            val k1 = (x: User) => x.id
-            val k2 = (y: User) => y.id
-            equiJoin(k1, k2)(users$1, users$1)
-          }
-          head {
-            (j._1, j._2)
-          }
-        }
-      }
+        head { (xy._1, xy._2) }
+      })
 
       applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "MatchEquiJoin (not applicable)" in {
+    "equiJoin (not applicable)" in {
+      val inp = u.reify(comprehension[(User, User), DataBag] {
+        val x = generator[User, DataBag] { users }
+        val y = generator[User, DataBag] { users }
+        // the lhs of `==` refers to both x and y, so this is not an equiJoin
+        guard { x.id + y.id == y.id }
+        head { (x, y) }
+      })
 
-      val matchEquiJoinOnce = applyOnce(MatchEquiJoin)
-
-      val inp = u.reify {
-        comprehension[(User, User), DataBag] {
-          val x = generator[User, DataBag] {
-            users
-          }
-          val y = generator[User, DataBag] {
-            users
-          }
-          guard {
-            x.id + y.id == y.id // the lhs of `==` refers to both x and y, so this is not an equiJoin
-          }
-          head {
-            (x,y)
-          }
-        }
-      }
-
-      matchEquiJoinOnce(inp) shouldBe alphaEqTo(liftPipeline(inp))
+      applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(inp))
     }
 
-    "MatchEquiJoin (complicated)" in {
-
-      val inp = u.reify {
-        val a = 5
-        comprehension[(Short), DataBag] {
-          val w = generator[Int, DataBag] {
-            DataBag(Seq(8))
-          }
-          val x = generator[Int, DataBag] {
-            DataBag(Seq(1,2,3)) union DataBag(Seq(4,5,6))
-          }
-          val y = generator[User, DataBag] {
-            users union users
-          }
-          guard {
-            val aa = a * a
-            val b = 8
-            val c = x + 2
-            y.id * aa + b == aa + x + c
-          }
-          val z = generator[Long, DataBag] {
-            DataBag(Seq(3L, 6L))
-          }
-          guard {
-            z != x && z != y.id
-          }
-          head {
-            (x + y.name.first.length - z).asInstanceOf[Short]
-          }
+    "equiJoin (complex)" in {
+      val inp = u.reify(comprehension[Short, DataBag] {
+        val w = generator[Int, DataBag] {
+          DataBag(Seq(8))
         }
-      }
-
-      val exp = u.reify {
-        val a: Int = 5
-        comprehension[Short, DataBag] {
-          val w: Int = generator[Int, DataBag] {
-            val apply$1 = Seq(8)
-            val apply$2 = DataBag[Int](apply$1)
-            apply$2
-          }
-          val j: (Int, User) = generator[(Int, User), DataBag] {
-            val plus$1: DataBag[Int] = DataBag(Seq(1,2,3)) union DataBag(Seq(4,5,6))
-            val plus$2: DataBag[User] = users union users
-            val kx$3 = (kxArg$3: Int) => {
-              val aa: Int = a * a
-              val c: Int = kxArg$3 + 2
-              val p$3: Int = aa + kxArg$3
-              val p$4: Int = p$3 + c
-              val cast = p$4.asInstanceOf[Long] // This is added if the key functions' return types are not equal
-              cast
-            }
-            val ky$3 = (kyArg$3: User) => {
-              val aa$3: Int = a * a
-              val b$3: Int = 8
-              val id$1$3: Long = kyArg$3.id
-              val pr$2$3: Long = id$1$3 * aa$3
-              val p$2$3: Long = pr$2$3 + b$3
-              val cast = p$2$3.asInstanceOf[Long] // This is added if the key functions' return types are not equal
-              cast
-            }
-            val ir$3: DataBag[(Int, User)] = equiJoin[Int, User, Long](kx$3, ky$3)(plus$1, plus$2)
-            ir$3
-          }
-          val z: Long = generator[Long, DataBag] {
-            DataBag(Seq(3L, 6L))
-          }
-          guard {
-            val j1 = j._1
-            val j2 = j._2
-            z != j1 && z != j2.id
-          }
-          head[Short] {
-            //(j._1 + j._2.name.first.length - z).asInstanceOf[Short]
-            val j1 = j._1
-            val j2 = j._2
-            val name$6 = j2.name
-            val first$6 = name$6.first
-            val length$6 = first$6.length
-            val `+$18` = j1 + length$6
-            val `-$6` = `+$18` - z
-            val asInstanceOf$8 = `-$6`.asInstanceOf[Short]
-            asInstanceOf$8
-          }
+        val x = generator[Int, DataBag] {
+          DataBag(Seq(1,2,3)) union DataBag(Seq(4,5,6))
         }
-      }
+        val y = generator[User, DataBag] {
+          users union users
+        }
+        guard { y.id * 37 == 27 + 2 * x }
+        val z = generator[Long, DataBag] {
+          DataBag(Seq(3L, 6L))
+        }
+        guard { z != x && z != y.id }
+        head { (x + y.name.first.length - z * w).asInstanceOf[Short] }
+      })
+
+      val exp = u.reify(comprehension[Short, DataBag] {
+        val w = generator[Int, DataBag] {
+          DataBag[Int](Seq(8))
+        }
+        val xy = generator[(Int, User), DataBag] {
+          val union$1 = DataBag(Seq(1,2,3)) union DataBag(Seq(4,5,6))
+          val union$2 = users union users
+          val kx = (x: Int) => (27 + 2 * x).asInstanceOf[Long]
+          val ky = (y: User) => y.id * 37
+          equiJoin[Int, User, Long](kx, ky)(union$1, union$2)
+        }
+        val z = generator[Long, DataBag] {
+          DataBag(Seq(3L, 6L))
+        }
+        guard {
+          val x = xy._1
+          val y = xy._2
+          z != x && z != y.id
+        }
+        head {
+          val x = xy._1
+          val y = xy._2
+          (x + y.name.first.length - z * w).asInstanceOf[Short]
+        }
+      })
 
       applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
     "residual" in {
+      val inp = u.reify(comprehension[User, DataBag] {
+        val x = generator[User, DataBag] { users }
+        head { x }
+      })
 
-      val users$1 = users
-
-      val inp = u.reify {
-        comprehension[User, DataBag] {
-          val x = generator[User, DataBag] {
-            users$1
-          }
-          head {
-            x
-          }
-        }
-      }
-
-      val exp = u.reify {
-        users$1 map { x => x }
-      }
-
-      applyOnce(MatchResidual)(inp) shouldBe alphaEqTo(liftPipeline(exp))
-      combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
+      val exp = u.reify(users map { x => x })
+      val lifted = liftPipeline(exp)
+      applyOnce(MatchResidual)(inp) shouldBe alphaEqTo(lifted)
+      combine(inp) shouldBe alphaEqTo(lifted)
     }
   }
 
   "combine" - {
-
-    "two crosses" in {
-
-      val users$1 = users
-
-      val inp = u.reify {
-        comprehension[(User, User, Int), DataBag] {
-          val x = generator[User, DataBag] {
-            users$1.distinct
-          }
-          val y = generator[User, DataBag] {
-            users$1 union users
-          }
-          val z = generator[Int, DataBag] {
-            DataBag(Seq(1,2,3))
-          }
-          head {
-            (x,y,z)
-          }
+    "three-way cross" in {
+      val inp = u.reify(comprehension[(User, User, Int), DataBag] {
+        val x = generator[User, DataBag] { users.distinct }
+        val y = generator[User, DataBag] { users union users }
+        val z = generator[Int, DataBag] {
+          DataBag(Seq(1,2,3))
         }
-      }
+        head { (x, y, z) }
+      })
 
       val exp = u.reify {
         cross(
           cross(
-            users$1.distinct,
-            users$1 union users
-          ),
+            users.distinct,
+            users union users),
           DataBag(Seq(1, 2, 3))
-        ) map { c =>
-          val c1 = c._1
-          val c2 = c._2
-          val c11 = c1._1
-          val c12 = c1._2
-          (c11, c12, c2)
+        ) map { xy =>
+          val x = xy._1
+          val y = xy._2
+          val x1 = x._1
+          val y1 = x._2
+          (x1, y1, y)
         }
       }
 
       combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "filter after cross" in {
-
-      val inp = u.reify {
-        comprehension[(User, User), DataBag] {
-          val x = generator[User, DataBag] {
-            users
-          }
-          val y = generator[User, DataBag] {
-            users
-          }
-          guard {
-            x.id != y.id
-          }
-          head {
-            (x,y)
-          }
-        }
-      }
+    "cross then filter" in {
+      val inp = u.reify(comprehension[(User, User), DataBag] {
+        val x = generator[User, DataBag] { users }
+        val y = generator[User, DataBag] { users }
+        guard { x.id != y.id }
+        head { (x, y) }
+      })
 
       val exp = u.reify {
-        cross(
-          users,
-          users
-        ).withFilter { a =>
-          val a1 = a._1
-          val a2 = a._2
-          a1.id != a2.id
-        } map {
-          c => (c._1, c._2)
-        }
+        cross(users, users) withFilter { xy =>
+          val x = xy._1
+          val y = xy._2
+          x.id != y.id
+        } map { xy => (xy._1, xy._2) }
       }
 
       combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "two filters, then cross" in {
-
-      val inp = u.reify {
-        comprehension[(User, User), DataBag] {
-          val x = generator[User, DataBag] {
-            users
-          }
-          val y = generator[User, DataBag] {
-            users
-          }
-          guard {
-            x.id != 3
-          }
-          guard {
-            y.id != 5
-          }
-          head {
-            (x,y)
-          }
-        }
-      }
+    "filter twice then cross" in {
+      val inp = u.reify(comprehension[(User, User), DataBag] {
+        val x = generator[User, DataBag] { users }
+        val y = generator[User, DataBag] { users }
+        guard { x.id != 3 }
+        guard { y.id != 5 }
+        head { (x, y) }
+      })
 
       val exp = u.reify {
         cross(
-          users.withFilter(a => a.id != 3),
-          users.withFilter(a => a.id != 5)
-        ) map {
-          c => (c._1, c._2)
-        }
+          users withFilter { _.id != 3 },
+          users withFilter { _.id != 5 }
+        ) map { xy => (xy._1, xy._2) }
       }
 
       combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
@@ -620,117 +383,239 @@ class CombinationSpec extends BaseCompilerSpec {
   }
 
   "combine nested" - {
-    
     "in head" in {
-
-      val inp = u.reify {
-        comprehension[DataBag[User], DataBag] {
-          val x = generator[DataBag[User], DataBag] {
-            DataBag(Seq(users,users))
-          }
-          head {
-            comprehension[User, DataBag] {
-              val y = generator[User, DataBag] {
-                x
-              }
-              head {
-                y
-              }
-            }
+      val inp = u.reify(comprehension[DataBag[User], DataBag] {
+        val x = generator[DataBag[User], DataBag] {
+          DataBag(Seq(users,users))
+        }
+        head {
+          comprehension[User, DataBag] {
+            val y = generator[User, DataBag] { x }
+            head { y }
           }
         }
-      }
+      })
 
       val exp = u.reify {
-        val d = DataBag(Seq(users, users))
-        val f1 = (f1Arg: DataBag[User]) => {
-          val f2 = (f2Arg: User) => {
-            f2Arg
-          }
-          val ir1 = f1Arg map f2
-          ir1
-        }
-        val ir2 = d map f1
-        ir2
+        val nested$1 = DataBag(Seq(users, users))
+        nested$1 map { _ map { x => x } }
       }
 
       combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "complicated" in {
-
-      val users$1 = users
-
-      val inp = u.reify {
-        comprehension[DataBag[User], DataBag] {
-          val x = generator[DataBag[User], DataBag] {
-            DataBag(Seq(users$1,users$1))
+    "complex" in {
+      val inp = u.reify(comprehension[DataBag[User], DataBag] {
+        val x = generator[DataBag[User], DataBag] {
+          DataBag(Seq(users,users))
+        }
+        val y = generator[Long, DataBag] {
+          val nested = comprehension[Long, DataBag] {
+            val w = generator[User, DataBag] { x union x }
+            head { w.id }
           }
-          val y = generator[Long, DataBag] {
-            val ir1 = comprehension[Long, DataBag] {
-              val w = generator[User, DataBag] {
-                x union x
-              }
-              head {
-                w.id
-              }
-            }
-            ir1
-          }
-          head {
-            comprehension[User, DataBag] {
-              val z = generator[User, DataBag] {
-                x
-              }
-              guard {
-                z.id != y
-              }
-              head {
-                z
-              }
-            }
+          nested
+        }
+        head {
+          comprehension[User, DataBag] {
+            val z = generator[User, DataBag] { x }
+            guard { z.id != y }
+            head { z }
           }
         }
-      }
+      })
 
       val exp = u.reify {
-        val apply$120 = Seq(users$1, users$1)
-        val apply$121 = DataBag(apply$120)
-        val f$26 = (fArg$26: DataBag[User]) => {
-          val plus$9 = fArg$26 union fArg$26
-          val f$30 = (fArg$30: User) => {
-            val id$68 = fArg$30.id
-            id$68
-          }
-          val ir1 = plus$9 map f$30
-          val g$8 = (gArg$8: Long) => {
-            val ir2$8 = (fArg$26, gArg$8)
-            ir2$8
-          }
-          val xy0$8 = ir1 map g$8
-          xy0$8
+        val nested$1 = DataBag(Seq(users, users))
+        val fmapped$1 = nested$1 flatMap { xs$1 =>
+          val union$1 = xs$1 union xs$1
+          val mapped$1 = union$1 map { _.id }
+          mapped$1 map { (xs$1, _) }
         }
-        val ir$58 = apply$121 flatMap f$26
-        val f$28 = (fArg: (DataBag[User], Long)) => {
-          val fArg1 = fArg._1
-          val fArg2 = fArg._2
-          val p$11 = (pArg$11: User) => {
-            val id$69 = pArg$11.id
-            val `!=$32` = id$69 != fArg2
-            `!=$32`
-          }
-          val ir$64 = fArg1 withFilter p$11
-          val f$32 = (fArg$32: User) => {
-            fArg$32
-          }
-          val ir$66 = ir$64 map f$32
-          ir$66
+        fmapped$1 map { xy =>
+          val x = xy._1
+          val y = xy._2
+          val filtered$1 = x withFilter { _.id != y }
+          filtered$1 map { x => x }
         }
-        val ir$60 = ir$58 map f$28
-        ir$60
       }
 
       combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+  }
+
+  "match once with control flow" - {
+    "filter" in {
+      val inp = u.reify(comprehension[User, DataBag] {
+        val u = generator[User, DataBag] {
+          var us = users
+          while (us.size < 100) us = us union us
+          us
+        }
+        guard { u.id < 11 }
+        head { u }
+      })
+
+      val exp = u.reify(comprehension[User, DataBag] {
+        val u = generator[User, DataBag] {
+          var us = users
+          while (us.size < 100) us = us union us
+          us.withFilter(_.id < 11)
+        }
+        head { u }
+      })
+
+      applyOnce(MatchFilter)(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "flatMap" in {
+      val inp = u.reify(comprehension[Long, DataBag] {
+        val x = generator[User, DataBag] {
+          var us = users
+          while (us.size < 100) us = us union us
+          us
+        }
+        val y = generator[Long, DataBag] {
+          DataBag(Seq(x.id, x.id))
+        }
+        head { y }
+      })
+
+      val exp = u.reify(comprehension[Long, DataBag] {
+        val y = generator[Long, DataBag] {
+          var us = users
+          while (us.size < 100) us = us union us
+          us flatMap { x => DataBag(Seq(x.id, x.id)) }
+        }
+        head { y }
+      })
+
+      applyOnce(MatchFlatMap)(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "flatMap2" in {
+      val inp = u.reify(comprehension[(User, Long, User), DataBag] {
+        val x = generator[User, DataBag] {
+          var us = users
+          while (us.size < 100) us = us union us
+          us
+        }
+        val y = generator[Long, DataBag] {
+          DataBag(Seq(x.id, x.id))
+        }
+        guard { x.id != y }
+        val z = generator[User, DataBag] {
+          DataBag(Seq(x))
+        }
+        head { (x, y, z) }
+      })
+
+      val exp = u.reify(comprehension[(User, Long, User), DataBag] {
+        val xy = generator[(User, Long), DataBag] {
+          var us = users
+          while (us.size < 100) us = us union us
+          us flatMap { x =>
+            DataBag(Seq(x.id, x.id)) map { (x, _) }
+          }
+        }
+        guard {
+          val x = xy._1
+          val y = xy._2
+          x.id != y
+        }
+        val z = generator[User, DataBag] {
+          DataBag(Seq(xy._1))
+        }
+        head {
+          val x = xy._1
+          val y = xy._2
+          (x, y, z)
+        }
+      })
+
+      applyOnce(MatchFlatMap2)(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "cross" in {
+      val inp = u.reify(comprehension[(User, User), DataBag] {
+        val x = generator[User, DataBag] {
+          var us1 = users
+          while (us1.size < 100) us1 = us1 union us1
+          us1
+        }
+        val y = generator[User, DataBag] {
+          var us2 = users
+          do us2 = us2 union us2 while (us2.size < 100)
+          us2
+        }
+        head { (x, y) }
+      })
+
+      val exp = u.reify(comprehension[(User, User), DataBag] {
+        val xy = generator[(User, User), DataBag] {
+          var us1 = users
+          while (us1.size < 100) us1 = us1 union us1
+          var us2 = users
+          do us2 = us2 union us2 while (us2.size < 100)
+          cross(us1, us2)
+        }
+        head { (xy._1, xy._2) }
+      })
+
+      applyOnce(MatchCross)(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "equiJoin" in {
+      val inp = u.reify(comprehension[(User, User), DataBag] {
+        val x = generator[User, DataBag] {
+          var us1 = users
+          while (us1.size < 100) us1 = us1 union us1
+          us1
+        }
+        val y = generator[User, DataBag] {
+          var us2 = users
+          do us2 = us2 union us2 while (us2.size < 100)
+          us2
+        }
+        guard { x.id == y.id }
+        head { (x, y) }
+      })
+
+      val exp = u.reify(comprehension[(User, User), DataBag] {
+        val xy = generator[(User, User), DataBag] {
+          var us1 = users
+          while (us1.size < 100) us1 = us1 union us1
+          var us2 = users
+          do us2 = us2 union us2 while (us2.size < 100)
+          val kx = (x: User) => x.id
+          val ky = (y: User) => y.id
+          equiJoin(kx, ky)(us1, us2)
+        }
+        head { (xy._1, xy._2) }
+      })
+
+      applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "residual" in {
+      val inp = u.reify(comprehension[User, DataBag] {
+        val x = generator[User, DataBag] {
+          var us = users
+          while (us.size < 100) us = us union us
+          us
+        }
+        head { x }
+      })
+
+      val exp = u.reify {
+        var us = users
+        while (us.size < 100) us = us union us
+        us map { x => x }
+      }
+
+      val lifted = liftPipeline(exp)
+      applyOnce(MatchResidual)(inp) shouldBe alphaEqTo(lifted)
+      combine(inp) shouldBe alphaEqTo(lifted)
     }
   }
 }


### PR DESCRIPTION
Note that the first generator will never contain control flow, because it's not nested in a lambda. Subsequent generators, however, may contain control flow, since they are nested in `flatMap` calls.

This takes care of the problem only on comprehension level. `Core.flatten` will also require modification to work with nested `Let` blocks that contain control flow, but this is a separate issue.

- [x] This needs some additional tests.