### PR TITLE
[API][IR] Parquet fixes

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -39,6 +39,7 @@ This project includes:
   Apache Parquet Common under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
+  Apache Parquet Generator under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
   Apache XBean :: ASM 5 shaded (repackaged) under null or null

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
@@ -47,10 +47,12 @@ trait Common extends AST {
     val empty                 = bagSymbol.companion.info.member(TermName("empty")).asMethod
     val apply                 = bagSymbol.companion.info.member(TermName("apply")).asMethod
     val readCSV               = bagSymbol.companion.info.member(TermName("readCSV")).asMethod
+    val readParquet           = bagSymbol.companion.info.member(TermName("readParquet")).asMethod
     val readText              = bagSymbol.companion.info.member(TermName("readText")).asMethod
     // Sinks
     val fetch                 = bagSymbol.info.decl(TermName("fetch"))
     val writeCSV              = bagSymbol.info.decl(TermName("writeCSV"))
+    val writeParquet          = bagSymbol.info.decl(TermName("writeParquet"))
     val writeText             = bagSymbol.info.decl(TermName("writeText"))
     // Monad ops
     val map                   = bagSymbol.info.decl(TermName("map"))
@@ -80,8 +82,8 @@ trait Common extends AST {
     val top                   = bagSymbol.info.decl(TermName("top"))
     val sample                = bagSymbol.info.decl(TermName("sample"))
 
-    val sourceOps             = Set(empty, apply, readCSV, readText); assertOneOverload(sourceOps)
-    val sinkOps               = Set(fetch, writeCSV, writeText)
+    val sourceOps             = Set(empty, apply, readCSV, readParquet, readText); assertOneOverload(sourceOps)
+    val sinkOps               = Set(fetch, writeCSV, writeParquet, writeText)
     val monadOps              = Set(map, flatMap, withFilter)
     val nestOps               = Set(groupBy)
     val setOps                = Set(union, distinct)
@@ -103,7 +105,8 @@ trait Common extends AST {
 
     val implicitTypes         = Set(
       typeOf[org.emmalanguage.api.Meta[Nothing]].typeConstructor,
-      typeOf[org.emmalanguage.io.csv.CSVConverter[Nothing]].typeConstructor
+      typeOf[org.emmalanguage.io.csv.CSVConverter[Nothing]].typeConstructor,
+      typeOf[org.emmalanguage.io.parquet.ParquetConverter[Nothing]].typeConstructor
     )
 
     // Type constructors

--- a/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetConverter.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetConverter.scala
@@ -54,18 +54,18 @@ object ParquetConverter extends IsoParquetConverters {
 trait IsoParquetConverters extends GenericParquetConverters {
 
   private implicit val binaryIsoArrayByte: Binary <=> Array[Byte] =
-    Iso.make(_.getBytes, Binary.fromReusedByteArray)
+    Iso.make(_.getBytes, Binary.fromByteArray)
 
   private implicit val binaryIsoByte: Binary <=> Byte =
-    Iso.make(_.getBytesUnsafe.head, b => Binary.fromConstantByteArray(Array(b)))
+    Iso.make(_.getBytes.head, b => Binary.fromByteArray(Array(b)))
 
   private implicit val binaryIsoShort: Binary <=> Short =
     Iso.make(bin => {
-      val bytes = bin.getBytesUnsafe
+      val bytes = bin.getBytes
       (bytes(0) + (bytes(1) << 8)).toShort
     }, short => {
       val bytes = Array(short.toByte, (short >> 8).toByte)
-      Binary.fromConstantByteArray(bytes)
+      Binary.fromByteArray(bytes)
     })
 
   private implicit val binaryIsoString: Binary <=> String =

--- a/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetWriteSupport.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetWriteSupport.scala
@@ -18,6 +18,7 @@ package io.parquet
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
+import org.apache.parquet.hadoop.ParquetFileWriter
 import org.apache.parquet.hadoop.ParquetWriter
 import org.apache.parquet.hadoop.api.WriteSupport
 import org.apache.parquet.io.api._
@@ -57,9 +58,36 @@ private[parquet] object ParquetWriteSupport {
   def builder[A: ParquetConverter](file: Path): WriterBuilder[A] =
     new WriterBuilder[A](new ParquetWriteSupport, file)
 
-  class WriterBuilder[A](support: WriteSupport[A], file: Path)
-    extends ParquetWriter.Builder[A, WriterBuilder[A]](file) {
+  class WriterBuilder[A](support: WriteSupport[A], file: Path) {
+
+    var conf = new Configuration()
+    var mode = ParquetFileWriter.Mode.CREATE
+
     def getWriteSupport(conf: Configuration) = support
     def self() = this
+
+    def withConf(conf: Configuration): WriterBuilder[A] = {
+      this.conf = conf
+      this
+    }
+
+    def withWriteMode(mode: ParquetFileWriter.Mode): WriterBuilder[A] = {
+      this.mode = mode
+      this
+    }
+
+    def build(): ParquetWriter[A] = new ParquetWriter[A](
+      file,
+      mode,
+      support,
+      ParquetWriter.DEFAULT_COMPRESSION_CODEC_NAME,
+      ParquetWriter.DEFAULT_BLOCK_SIZE,
+      ParquetWriter.DEFAULT_PAGE_SIZE,
+      ParquetWriter.DEFAULT_PAGE_SIZE,
+      ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED,
+      ParquetWriter.DEFAULT_IS_VALIDATING_ENABLED,
+      ParquetWriter.DEFAULT_WRITER_VERSION,
+      conf
+    )
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,7 @@
         <!-- Spark -->
         <spark.version>2.0.1</spark.version>
         <!-- Parquet -->
-        <parquet.version>1.8.1</parquet.version>
+        <parquet.version>1.7.0</parquet.version>
 
         <!-- Logging -->
         <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
This adds the missing method symbols in `Common.API` and downgraded to Parquet 1.7.0 in order to make the library version compatible with what is bundled with Spark 2.0.1.