### PR TITLE
[API] Added conversion methods to backend-specific distributed collections.

### DIFF
--- a/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
@@ -29,7 +29,7 @@ import scala.language.implicitConversions
 import scala.util.hashing.MurmurHash3
 
 /** A `DataBag` implementation backed by a Flink `DataSet`. */
-class FlinkDataSet[A: Meta] private[api](@transient private val rep: DataSet[A]) extends DataBag[A] {
+class FlinkDataSet[A: Meta] private[api](@transient private[api] val rep: DataSet[A]) extends DataBag[A] {
 
   import FlinkDataSet.typeInfoForType
   import FlinkDataSet.wrap

--- a/emma-flink/src/main/scala/org/emmalanguage/api/converter/flink.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/converter/flink.scala
@@ -1,0 +1,36 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package api.converter
+
+import api.DataBag
+import api.FlinkDataSet
+
+import org.apache.flink.api.scala.DataSet
+
+object flink {
+
+  /** Converts a `DataBag[A]` into a Flink `DataSet[A]`. */
+  implicit val datasetConverter = new CollConverter[DataSet] {
+    override def apply[A](bag: DataBag[A]) = bag match {
+      case bag: FlinkDataSet[A] =>
+        bag.rep
+      case _ =>
+        throw new RuntimeException(s"Cannot convert a DataBag of type ${bag.getClass.getSimpleName} to Dataset")
+    }
+  }
+
+}

--- a/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
@@ -16,8 +16,11 @@
 package org.emmalanguage
 package api
 
+import converter.CollConverter
 import io.csv._
 import io.parquet._
+
+import scala.language.higherKinds
 
 /** An abstraction for homogeneous distributed collections. */
 trait DataBag[A] extends Serializable {
@@ -167,6 +170,12 @@ trait DataBag[A] extends Serializable {
    * @return The contents of the DataBag as a scala Seq.
    */
   def fetch(): Seq[A]
+
+  /**
+   * Converts this bag into a distributed collection of type `DColl[A]`.
+   */
+  def as[DColl[_]](implicit converter: CollConverter[DColl]): DColl[A] =
+    converter(this)
 
   // -----------------------------------------------------
   // Pre-defined folds
@@ -392,7 +401,7 @@ object DataBag {
   /**
    * Reads a `DataBag[String]` elements from the specified `path`.
    *
-   * @param path   The location where the data will be read from.
+   * @param path The location where the data will be read from.
    */
   def readText(path: String): DataBag[String] =
     ScalaSeq.readText(path)

--- a/emma-language/src/main/scala/org/emmalanguage/api/converter/CollConverter.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/converter/CollConverter.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package api.converter
+
+import api.DataBag
+
+import scala.language.higherKinds
+
+/** Converts a `DataBag[A]` into a distributed collection of type `Coll[A]`. */
+trait CollConverter[DColl[_]] {
+  def apply[A](bag: DataBag[A]): DColl[A]
+}

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
@@ -51,6 +51,7 @@ trait Common extends AST {
     val readText              = bagSymbol.companion.info.member(TermName("readText")).asMethod
     // Sinks
     val fetch                 = bagSymbol.info.decl(TermName("fetch"))
+    val as                    = bagSymbol.info.decl(TermName("as"))
     val writeCSV              = bagSymbol.info.decl(TermName("writeCSV"))
     val writeParquet          = bagSymbol.info.decl(TermName("writeParquet"))
     val writeText             = bagSymbol.info.decl(TermName("writeText"))
@@ -83,7 +84,7 @@ trait Common extends AST {
     val sample                = bagSymbol.info.decl(TermName("sample"))
 
     val sourceOps             = Set(empty, apply, readCSV, readParquet, readText); assertOneOverload(sourceOps)
-    val sinkOps               = Set(fetch, writeCSV, writeParquet, writeText)
+    val sinkOps               = Set(fetch, as, writeCSV, writeParquet, writeText)
     val monadOps              = Set(map, flatMap, withFilter)
     val nestOps               = Set(groupBy)
     val setOps                = Set(union, distinct)

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
@@ -27,8 +27,9 @@ import scala.language.implicitConversions
 import scala.util.hashing.MurmurHash3
 
 /** A `DataBag` implementation backed by a Spark `RDD`. */
-class SparkRDD[A: Meta] private[api](@transient private[api] val rep: RDD[A])(implicit spark: SparkSession)
-  extends DataBag[A] {
+class SparkRDD[A: Meta] private[api]
+  (@transient private[api] val rep: RDD[A])
+  (@transient private[api] implicit val spark: SparkSession) extends DataBag[A] {
 
   import Meta.Projections._
   import SparkRDD.encoderForType

--- a/emma-spark/src/main/scala/org/emmalanguage/api/converter/spark.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/converter/spark.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package api.converter
+
+import api.DataBag
+import api.SparkDataset
+import api.SparkRDD
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.Dataset
+
+import scala.language.higherKinds
+
+object spark {
+
+  /** Converts a `DataBag[A]` into a Spark `Dataset[A]`. */
+  implicit val datasetConverter = new CollConverter[Dataset] {
+    def apply[A](bag: DataBag[A]): Dataset[A] = bag match {
+      case bag: SparkDataset[A] =>
+        bag.rep
+      case bag: SparkRDD[A] =>
+        val encoder = SparkDataset.encoderForType[A](bag.m)
+        bag.spark.createDataset(bag.rep)(encoder)
+      case _ =>
+        throw new RuntimeException(s"Cannot convert a DataBag of type ${bag.getClass.getSimpleName} to Dataset")
+    }
+  }
+
+  /** Converts a `DataBag[A]` into a Spark `RDD[A]`. */
+  implicit val rddConverter = new CollConverter[RDD] {
+    def apply[A](bag: DataBag[A]): RDD[A] = bag match {
+      case bag: SparkDataset[A] =>
+        bag.rep.rdd
+      case bag: SparkRDD[A] =>
+        bag.rep
+      case _ =>
+        throw new RuntimeException(s"Cannot convert a DataBag of type ${bag.getClass.getSimpleName} to RDD")
+    }
+  }
+}


### PR DESCRIPTION
Resolves #296.

Unfortunately I was not able to figure out a way to make all implicit instances available automatically with the

```scala
import org.emmalanguage.api._
```

import. For Spark-related conversions, one now has to additionally

```scala
import org.emmalanguage.api.conversions.spark._
```

and for Flink similarly


```scala
import org.emmalanguage.api.conversions.flink._
```