### PR TITLE
[IR] Ported CFG to quiver and extended with control flow

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -43,7 +43,7 @@ This project includes:
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
   Apache XBean :: ASM 5 shaded (repackaged) under null or null
-  ASM Core under BSD
+  ASM Core under Apache License, Version 2.0
   Bean Validation API under The Apache Software License, Version 2.0
   bijection-avro under Apache 2
   bijection-core under Apache 2
@@ -176,6 +176,7 @@ This project includes:
   kernelLaws under MIT
   Kryo under New BSD License
   kryo serializers under The Apache Software License, Version 2.0
+  Kryo Shaded under New BSD License
   laws under MIT
   leveldbjni-all under The BSD 3-Clause License
   LZ4 and xxHash under The Apache Software License, Version 2.0
@@ -194,7 +195,6 @@ This project includes:
   Protocol Buffer Java API under New BSD license
   Py4J under The New BSD License
   pyrolite under MIT License
-  ReflectASM under New BSD License
   RoaringBitmap under Apache 2
   Scala Compiler under BSD 3-Clause
   Scala Library under BSD 3-Clause
@@ -208,6 +208,7 @@ This project includes:
   scalactic under the Apache License, ASL Version 2.0
   Scalap under BSD 3-Clause
   scalatest under the Apache License, ASL Version 2.0
+  scalaz-core under BSD-style
   scopt under MIT License
   ServiceLocator Default Implementation under CDDL + GPLv2 with classpath exception
   Servlet API under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0

--- a/emma-language/pom.xml
+++ b/emma-language/pom.xml
@@ -101,13 +101,6 @@
             <artifactId>parquet-hadoop</artifactId>
         </dependency>
 
-        <!-- Serialization -->
-        <dependency>
-            <groupId>com.twitter</groupId>
-            <artifactId>chill_${scala.tools.version}</artifactId>
-            <version>0.5.2</version>
-        </dependency>
-
         <!-- Logging -->
         <dependency>
             <groupId>log4j</groupId>

--- a/emma-language/pom.xml
+++ b/emma-language/pom.xml
@@ -124,6 +124,12 @@
             <groupId>io.spray</groupId>
             <artifactId>spray-json_${scala.tools.version}</artifactId>
         </dependency>
+
+        <!-- Functional graphs -->
+        <dependency>
+            <groupId>io.verizon.quiver</groupId>
+            <artifactId>core_${scala.tools.version}</artifactId>
+        </dependency>
     </dependencies>
 
     <profiles>

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/cf/ControlFlow.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/cf/ControlFlow.scala
@@ -26,7 +26,7 @@ trait ControlFlow extends Common
 
   object ControlFlow {
 
-    /** Delegates to [[CFG.graph()]]. */
-    def cfg(monad: u.ClassSymbol = API.bagSymbol) = CFG.graph(monad)
+    /** Delegates to [[CFG.graph]]. */
+    lazy val cfg: u.Tree => CFG.FlowGraph[u.TermSymbol] = CFG.graph
   }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/util/Monoids.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/util/Monoids.scala
@@ -17,6 +17,7 @@ package org.emmalanguage
 package util
 
 import cats.Monoid
+import quiver.Graph
 import shapeless._
 
 import scala.collection.SortedSet
@@ -97,5 +98,11 @@ object Monoids {
   def reverse[A](implicit A: Monoid[A]): Monoid[A] = new Monoid[A] {
     def empty = A.empty
     def combine(x: A, y: A) = A.combine(y, x)
+  }
+
+  /** Graph union forms a monoid. */
+  implicit def graphUnion[V, A, B]: Monoid[Graph[V, A, B]] = new Monoid[Graph[V, A, B]] {
+    def empty = quiver.empty[V, A, B]
+    def combine(x: Graph[V, A, B], y: Graph[V, A, B]) = x union y
   }
 }

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/cf/CFGSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/cf/CFGSpec.scala
@@ -20,6 +20,7 @@ import api._
 import api.model._
 import compiler.BaseCompilerSpec
 import compiler.ir.ComprehensionSyntax._
+import compiler.ir.DSCFAnnotations._
 import io.csv._
 
 /** A spec for comprehension normalization. */
@@ -48,6 +49,7 @@ class CFGSpec extends BaseCompilerSpec {
         val count$1 = paths$1.size
         val added$1 = 0L
 
+        @doWhileLoop
         def doWhile$1(added$3: Long, count$3: Long, paths$3: DataBag[Edge[Long]]): Unit = {
           val closure = comprehension[Edge[Long], DataBag] {
             val e1 = generator[Edge[Long], DataBag](paths$3)
@@ -70,7 +72,7 @@ class CFGSpec extends BaseCompilerSpec {
           val added$2 = count$2 - count$3
           val isReady = added$2 > 0
 
-          def suffix$1(): Unit = {
+          @suffix def suffix$1(): Unit = {
             paths$2.writeCSV(output, csv$1)
           }
 
@@ -81,14 +83,19 @@ class CFGSpec extends BaseCompilerSpec {
         doWhile$1(added$1, count$1, paths$1)
       })
 
-      val CFG.Graph(_, _, flow, nest) =
-        ControlFlow.cfg()(tree).map(_.name.toString)
+      val graph = ControlFlow.cfg(tree)
+      val nest = graph.nest.vmap(_.name.toString)
+      val ctrl = graph.ctrl.vmap(_.name.toString)
+      val data = graph.data.vmap(_.name.toString)
 
-      flow("closure") should contain ("paths$3")                  // comprehension
-      flow("e1")      should contain ("paths$3")                  // generator
-      flow("union$1") should contain allOf ("paths$3", "closure") // regular value
-      flow("added$3") should contain allOf ("added$1", "added$2") // method parameter
-      nest("closure") should contain allOf ("e1", "e2", "src$1", "src$2", "dst$1", "dst$2")
+      nest.successors("closure")   should contain allOf (
+        "e1", "e2", "src$1", "src$2", "dst$1", "dst$2")
+      ctrl.successors("doWhile$1") should contain allOf ("doWhile$1", "suffix$1")
+      ctrl.successors("suffix$1")  shouldBe 'empty
+      data.predecessors("closure") should contain ("paths$3")                  // comprehension
+      data.predecessors("e1")      should contain ("paths$3")                  // generator
+      data.predecessors("union$1") should contain allOf ("paths$3", "closure") // regular value
+      data.predecessors("added$3") should contain allOf ("added$1", "added$2") // method parameter
     }
 
     "with nested methods" in {
@@ -104,7 +111,7 @@ class CFGSpec extends BaseCompilerSpec {
         val rate = barbers.map(f$1).sum
         val time$1 = ((0 max (customers - barbers.length - 1)) / rate).toLong - 1
         val less$1 = time$1 < 0
-        def else$1(): Int = {
+        @elseBranch def else$1(): Int = {
           val f$2 = (x$2: Int) => {
             val div$2 = time$1 / x$2
             val sum$1 = div$2 + 1
@@ -113,41 +120,41 @@ class CFGSpec extends BaseCompilerSpec {
           val served$1 = barbers.map(f$2).sum
           suffix$1(served$1)
         }
-        def suffix$1(served$2: Long): Int = {
+        @suffix def suffix$1(served$2: Long): Int = {
           val remaining$1 = customers - served$2
-          def while$1(barber$2: Int, remaining$2: Long, time$2: Long): Int = {
+          @whileLoop def while$1(barber$2: Int, remaining$2: Long, time$2: Long): Int = {
             val greater$1 = remaining$2 > 0
-            def body$1(barber$3: Int, remaining$3: Long, time$3: Long): Int = {
+            @loopBody def body$1(barber$3: Int, remaining$3: Long, time$3: Long): Int = {
               val time$4 = time$3 + barbers.map(b => b - time$3 % b).min
               val iter$1 = barbers.zipWithIndex.toIterator
               val bi$1 = null.asInstanceOf[(Int, Int)]
-              def while$2(barber$4: Int, bi$2: (Int, Int), remaining$4: Long): Int = {
+              @whileLoop def while$2(barber$4: Int, bi$2: (Int, Int), remaining$4: Long): Int = {
                 val hasNext$1 = iter$1.hasNext
-                def body$2(barber$5: Int, bi$3: (Int, Int), remaining$5: Long): Int = {
+                @loopBody def body$2(barber$5: Int, bi$3: (Int, Int), remaining$5: Long): Int = {
                   val bi$4 = iter$1.next()
                   val b = bi$4._1
                   val i = bi$4._2
                   val eq$1 = time$4 % b == 0
-                  def then$1(): Int = {
+                  @thenBranch def then$1(): Int = {
                     val remaining$7 = remaining$5 - 1
                     val eq$2 = remaining$7 == 0
-                    def then$2(): Int = {
+                    @thenBranch def then$2(): Int = {
                       val barber$9 = i + 1
                       suffix$2(barber$9)
                     }
-                    def suffix$2(barber$10: Int): Int = {
+                    @suffix def suffix$2(barber$10: Int): Int = {
                       suffix$3(barber$10, remaining$7)
                     }
                     if (eq$2) then$2()
                     else suffix$2(barber$5)
                   }
-                  def suffix$3(barber$11: Int, remaining$8: Long): Int = {
+                  @suffix def suffix$3(barber$11: Int, remaining$8: Long): Int = {
                     while$2(barber$11, bi$4, remaining$8)
                   }
                   if (eq$1) then$1()
                   else suffix$3(barber$5, remaining$5)
                 }
-                def suffix$4(barber$12: Int, remaining$9: Long): Int = {
+                @suffix def suffix$4(barber$12: Int, remaining$9: Long): Int = {
                   while$1(barber$12, remaining$9, time$4)
                 }
                 if (hasNext$1) body$2(barber$4, bi$2, remaining$4)
@@ -155,7 +162,7 @@ class CFGSpec extends BaseCompilerSpec {
               }
               while$2(barber$3, bi$1, remaining$3)
             }
-            def suffix$5(barber$13: Int): Int = {
+            @suffix def suffix$5(barber$13: Int): Int = {
               barber$13
             }
             if (greater$1) body$1(barber$2, remaining$2, time$2)
@@ -166,8 +173,13 @@ class CFGSpec extends BaseCompilerSpec {
         if (less$1) suffix$1(0L) else else$1()
       })
 
-      val CFG.Graph(_, defs, flow, nest) =
-        ControlFlow.cfg()(tree).transitive.map(_.name.toString)
+      val graph = ControlFlow.cfg(tree)
+      val nest = graph.nest.vmap(_.name.toString)
+      val ctrl = graph.ctrl.vmap(_.name.toString)
+      val data = graph.data.vmap(_.name.toString)
+      val nestT = nest.tclose
+      val ctrlT = ctrl.tclose
+      val dataT = data.tclose
 
       // Method parameters
       val Seq(b13, b12, b11, bs@_*) = for {
@@ -175,17 +187,17 @@ class CFGSpec extends BaseCompilerSpec {
         if i < 6 || i > 8
       } yield s"barber$$$i"
 
-      flow(b13)   should contain allOf (b12, b11, bs: _*)
-      flow("f$2") should contain ("barbers")
-      nest("f$1") should contain ("div$1")
-      nest("f$2") should contain allOf ("div$2", "sum$1")
+      nestT.successors("f$1")   should contain ("div$1")
+      nestT.successors("f$2")   should contain allOf ("div$2", "sum$1")
+      dataT.predecessors(b13)   should contain allOf (b12, b11, bs: _*)
+      dataT.predecessors("f$2") should contain ("barbers")
       // Phi nodes for method parameters
-      defs.keys should contain allOf (b12, b11, bs: _*)
-      // No phi nodes for lambda parameters
-      defs.keys should contain noneOf ("x$1", "x$2")
-      // No flow for lambda parameters
-      flow.get("x$1") should be ('empty)
-      flow.get("x$2") should be ('empty)
+      data.nodes should contain allOf (b12, b11, bs: _*)
+      // No data flow for lambda parameters
+      data.predecessors("x$1") shouldBe 'empty
+      data.predecessors("x$2") shouldBe 'empty
+      ctrlT.successors("suffix$1") should contain allOf (
+        "while$1", "while$2", (for (i <- 2 to 5) yield s"suffix$$$i"): _*)
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,6 @@
 
         <!-- Other dependencies -->
         <scopt.version>3.5.0</scopt.version>
-        <reflections.version>0.9.9</reflections.version><!-- TODO: remove -->
         <scala-arm.version>1.4</scala-arm.version>
 
         <!-- Test configuration -->
@@ -366,13 +365,6 @@
                 <artifactId>scopt_${scala.tools.version}</artifactId>
                 <version>${scopt.version}</version>
                 <scope>compile</scope>
-            </dependency>
-
-            <!-- Dynamic loading -->
-            <dependency>
-                <groupId>org.reflections</groupId>
-                <artifactId>reflections</artifactId>
-                <version>${reflections.version}</version>
             </dependency>
 
             <!-- Auto-Resource Management -->

--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,7 @@
         <!-- Other dependencies -->
         <scopt.version>3.5.0</scopt.version>
         <scala-arm.version>1.4</scala-arm.version>
+        <quiver.version>5.4.12</quiver.version>
 
         <!-- Test configuration -->
         <excludedSurefireGroups>org.emmalanguage.examples.ExampleTest</excludedSurefireGroups>
@@ -379,6 +380,13 @@
                 <groupId>io.spray</groupId>
                 <artifactId>spray-json_${scala.tools.version}</artifactId>
                 <version>1.3.2</version>
+            </dependency>
+
+            <!-- Functional graphs -->
+            <dependency>
+                <groupId>io.verizon.quiver</groupId>
+                <artifactId>core_${scala.tools.version}</artifactId>
+                <version>${quiver.version}</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
[quiver](https://github.com/Verizon/quiver) is a functional graph library for Scala (ported from Haskell). Before the graph contained only data-flow, now it is extended with control-flow (method calls). Nesting includes methods, comprehensions and lambdas (it's almost equivalent to the ownership relation).
- Data flows from RHS to LHS (and via `phi` nodes for method parameters);
    - Lambda parameters currently contain no incoming `data` edges.
- Control flows from method caller to callee;
- Nesting flows from outer to inner.