### PR TITLE
[IR] Added a post-pass to remove `this.*` qualifiers.

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/test/TestMacros.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/test/TestMacros.scala
@@ -1,0 +1,49 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package test
+
+import compiler.MacroCompiler
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+/**
+ * Macros needed for the test cases.
+ *
+ * These are defined here and not in the `test` folder, because they need to be compiled
+ * in an earlier compilation run.
+ */
+class TestMacros(val c: blackbox.Context) extends MacroCompiler {
+
+  val idPipeline: c.Expr[Any] => u.Tree =
+    identity().compose(_.tree)
+
+  def removeShadowedThisImpl[T](e: c.Expr[T]): c.Expr[T] = {
+    //c.warning(e.tree.pos, "(1) " + c.universe.showCode(e.tree))
+    val res = (idPipeline andThen removeShadowedThis andThen reTypeCheck) (e)
+    //c.warning(e.tree.pos, "(2) " + c.universe.showCode(res))
+    c.Expr(res)
+  }
+
+  lazy val reTypeCheck: u.Tree => u.Tree = tree => typeCheck(unTypeCheck(tree))
+}
+
+object TestMacros {
+
+  final def removeShadowedThis[T](e: T): T = macro TestMacros.removeShadowedThisImpl[T]
+
+}

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/RemoveShadowedThisSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/RemoveShadowedThisSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler
+
+import test.TestMacros
+
+import org.scalatest.FreeSpec
+import org.scalatest.Matchers
+
+class RemoveShadowedThisSpec extends FreeSpec with Matchers {
+
+  class A {
+    outer =>
+    val a = 42
+    val b = a
+
+    class B {
+      middle =>
+      val a = 0
+
+      class A {
+        inner =>
+        val a = -42
+
+        val v = TestMacros.removeShadowedThis(b == 42)
+        val x = TestMacros.removeShadowedThis(B.this.a == 0)
+        val y = TestMacros.removeShadowedThis(outer.a == 42 && middle.a == 0 && inner.a == -42)
+      }
+
+    }
+
+  }
+
+  val A1 = new A
+  val B1 = new A1.B
+  val A2 = new B1.A
+
+  "should remove shadowed `this.` prefix " in {
+    A2.v shouldBe true
+  }
+
+  "should not remove non-shadowed `this.` prefix" in {
+    A2.x shouldBe true
+  }
+
+  "should not change access via self-objects" ignore {
+    A2.y shouldBe true
+  }
+
+}

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
@@ -24,7 +24,7 @@ class SparkMacro(val c: blackbox.Context) extends MacroCompiler {
   def parallelizeImpl[T](e: c.Expr[T]): c.Expr[T] = {
     val res = parallelizePipeline(e)
     //c.warning(e.tree.pos, Core.prettyPrint(res))
-    c.Expr[T](unTypeCheck(res))
+    c.Expr[T]((removeShadowedThis andThen unTypeCheck)(res))
   }
 
   private lazy val parallelizePipeline: c.Expr[Any] => u.Tree =


### PR DESCRIPTION
This is a somewhat hacky solution for #295 which removes the `this.*` qualifiers from the input tree.
This solves the issue with trees which do not produce valid code with `showCode` such as

```scala
class A {
  val x = 42;
  class A {
    scala.Predef.println(A.this.x) // breaks here
  }
}
```

The transformation is not sound and can break due to variable capture, e.g. if `x` were also defined in the inner `A` in the case above the semantics of the program will change after the transformation.

Fixes #295.