### PR TITLE
[IR] Minor fixes in ast and a test for path-dependent types in ANF

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/ast/Bindings.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Bindings.scala
@@ -116,8 +116,10 @@ trait Bindings { this: AST =>
           (Empty(), TypeQuote(lhs.info))
         }
 
-        val dfn = u.ValDef(Sym.mods(lhs), lhs.name, tpt, body)
+        val mod = Sym.mods(lhs)
+        val dfn = u.ValDef(mod, lhs.name, tpt, body)
         setSymbol(dfn, lhs)
+        setType(dfn, u.NoType)
       }
 
       def unapply(bind: u.ValDef): Option[(u.TermSymbol, u.Tree)] =

--- a/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
@@ -16,7 +16,6 @@
 package org.emmalanguage
 package ast
 
-import scala.annotation.tailrec
 import scala.reflect.api.Universe
 
 /**
@@ -191,10 +190,11 @@ trait CommonAST {
     def method(tpe: Type): Boolean =
       !(tpe =:= tpe.finalResultType)
 
-    /** Is `sym` a stable path? */
-    @tailrec def stable(tpe: Type): Boolean = tpe match {
-      case u.SingleType(u.NoPrefix, _) => true
-      case u.SingleType(prefix, _)     => is.stable(prefix)
+    /** Is `tpe` a stable path? */
+    def stable(tpe: Type): Boolean = tpe match {
+      case u.ThisType(_)      => true
+      case u.SuperType(_, _)  => true
+      case u.SingleType(_, _) => true
       case _ => false
     }
 

--- a/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/CommonAST.scala
@@ -16,7 +16,9 @@
 package org.emmalanguage
 package ast
 
+import scala.reflect.ClassTag
 import scala.reflect.api.Universe
+import scala.reflect.macros.Attachments
 
 /**
  * Implements various utility functions that mitigate and/or workaround deficiencies in Scala's
@@ -44,10 +46,26 @@ trait CommonAST {
   // Abstract methods
   // ----------------------------------------------------------------------------------------------
 
+  /** Meta information (attachments). */
+  trait Meta {
+    def all: Attachments
+    def apply[T: ClassTag]: T = get[T].get
+    def contains[T: ClassTag]: Boolean = all.contains[T]
+    def get[T: ClassTag]: Option[T] = all.get[T]
+    def remove[T: ClassTag](): Unit
+    def update[T: ClassTag](att: T): Unit
+  }
+
   private[ast] def freshNameSuffix: Char
 
   /** Returns `tpt` with its original field set. */
   private[ast] def setOriginal(tpt: TypeTree, original: Tree): TypeTree
+
+  /** Returns the meta information associated with `sym`. */
+  def meta(sym: Symbol): Meta
+
+  /** Returns the meta information associated with `tree`. */
+  def meta(tree: Tree): Meta
 
   /** Returns the enclosing named entity (class, method, value, etc). */
   def enclosingOwner: Symbol

--- a/emma-language/src/main/scala/org/emmalanguage/ast/JavaAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/JavaAST.scala
@@ -19,6 +19,7 @@ package ast
 import com.typesafe.scalalogging.slf4j.Logger
 import org.slf4j.LoggerFactory
 
+import scala.reflect.ClassTag
 import scala.reflect.runtime
 import scala.reflect.runtime.JavaUniverse
 import scala.tools.reflect.ToolBox
@@ -47,6 +48,18 @@ trait JavaAST extends AST {
 
   private[ast] def setOriginal(tpt: TypeTree, original: Tree): TypeTree =
     tpt.setOriginal(original)
+
+  def meta(sym: Symbol) = new Meta {
+    def all = sym.attachments
+    def remove[T: ClassTag]() = sym.removeAttachment[T]
+    def update[T: ClassTag](att: T) = sym.updateAttachment(att)
+  }
+
+  def meta(tree: Tree) = new Meta {
+    def all = tree.attachments
+    def remove[T: ClassTag]() = tree.removeAttachment[T]
+    def update[T: ClassTag](att: T) = tree.updateAttachment(att)
+  }
 
   lazy val enclosingOwner =
     typeCheck(q"val x = ()").symbol.owner

--- a/emma-language/src/main/scala/org/emmalanguage/ast/JavaAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/JavaAST.scala
@@ -55,16 +55,20 @@ trait JavaAST extends AST {
     value <- Option(tb.inferImplicitValue(tpe)) if value.nonEmpty
   } yield value.setType(value.tpe.finalResultType)
 
-  def warning(msg: String, pos: Position = NoPosition): Unit =
-    logger.warn(s"Warning at $pos\n$msg")
+  def warning(msg: String, pos: Position = NoPosition): Unit = {
+    val at = if (is.defined(pos)) s"($pos)" else ""
+    logger.warn(s"Warning:$at $msg")
+  }
 
-  def abort(msg: String, pos: Position = NoPosition): Nothing =
-    throw ToolBoxError(s"Error at $pos:\n$msg")
+  def abort(msg: String, pos: Position = NoPosition): Nothing = {
+    val at = if (is.defined(pos)) s"($pos)" else ""
+    throw ToolBoxError(s"Error:$at $msg")
+  }
 
   def parse(code: String): Tree =
     try tb.parse(code)
     catch { case err: ToolBoxError => throw ToolBoxError(s"""
-      |Parsing failed for tree:
+      |Parsing error: ${err.getMessage}
       |================
       |$code
       |================
@@ -74,7 +78,7 @@ trait JavaAST extends AST {
   def typeCheck(tree: Tree, typeMode: Boolean = false): Tree =
     try if (typeMode) tb.typecheck(tree, tb.TYPEmode) else tb.typecheck(tree)
     catch { case err: ToolBoxError => throw ToolBoxError(s"""
-      |Type-check failed for tree:
+      |Type-checking error: ${err.getMessage}
       |================
       |${showCode(tree)}
       |================
@@ -87,7 +91,7 @@ trait JavaAST extends AST {
     typeCheck(reify(()).tree)
     binary
   } catch { case err: ToolBoxError => throw ToolBoxError(s"""
-    |Compilation failed for tree:
+    |Compilation error: ${err.getMessage}
     |================
     |${showCode(tree)}
     |================

--- a/emma-language/src/main/scala/org/emmalanguage/ast/MacroAST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/MacroAST.scala
@@ -16,6 +16,7 @@
 package org.emmalanguage
 package ast
 
+import scala.reflect.ClassTag
 import scala.reflect.macros.blackbox
 import scala.tools.nsc.Global
 import scala.util.control.NonFatal
@@ -30,11 +31,24 @@ trait MacroAST extends AST {
   val c: blackbox.Context
   val universe: c.universe.type = c.universe
   import universe._
+  import internal._
 
   private[ast] def freshNameSuffix: Char = 'm'
 
   private[ast] def setOriginal(tpt: TypeTree, original: Tree): TypeTree =
     internal.setOriginal(tpt, original)
+
+  def meta(sym: Symbol): Meta = new Meta {
+    def all = attachments(sym)
+    def remove[T: ClassTag]() = removeAttachment[T](sym)
+    def update[T: ClassTag](att: T) = updateAttachment(sym, att)
+  }
+
+  def meta(tree: Tree): Meta = new Meta {
+    def all = attachments(tree)
+    def remove[T: ClassTag]() = removeAttachment[T](tree)
+    def update[T: ClassTag](att: T) = updateAttachment(tree, att)
+  }
 
   def enclosingOwner: Symbol =
     c.internal.enclosingOwner

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Methods.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Methods.scala
@@ -176,16 +176,18 @@ trait Methods { this: AST =>
         assert(paramss.size == method.paramLists.size, s"Wrong number of $this parameter lists")
         assert(paramss.flatten.size == method.paramLists.flatten.size,
           s"Shape of $this parameter lists doesn't match")
+        val mod = Sym.mods(method)
         val tps = method.typeParams.map(typeDef)
         val pss = method.paramLists.map(_.map(p => ParDef(p.asTerm)))
         val src = tparams ++ paramss.flatten
         val dst = method.typeParams ++ method.paramLists.flatten
         val rhs = Sym.subst(method, src zip dst)(body)
         val res = method.info.finalResultType
-        assert(rhs.tpe <:< method.info.finalResultType,
-          s"$this body type ${rhs.tpe} is not a subtype of return type $res")
-        val dfn = u.DefDef(Sym.mods(method), method.name, tps, pss, TypeQuote(res), rhs)
+        assert(rhs.tpe <:< res, s"$this body type ${rhs.tpe} is not a subtype of return type $res")
+        val tpt = TypeQuote(res)
+        val dfn = u.DefDef(mod, method.name, tps, pss, tpt, rhs)
         setSymbol(dfn, method)
+        setType(dfn, u.NoType)
       }
 
       def unapply(defn: u.DefDef)

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
@@ -39,9 +39,10 @@ trait Symbols { this: AST =>
       // Predefined symbols
       // ------------------------------------------------------------------------------------------
 
-      lazy val none    = u.NoSymbol
-      lazy val foreach = Type[TraversableOnce[Nothing]]
-        .member(TermName.foreach).asMethod
+      lazy val implicitly = predef.info.member(TermName("implicitly")).asMethod
+      lazy val foreach    = Type[TraversableOnce[Any]].member(TermName.foreach).asMethod
+      lazy val none       = u.NoSymbol
+      lazy val predef     = PredefModule
 
       /** A map of all tuple symbols by number of elements. */
       lazy val tuple: Map[Int, u.ClassSymbol] =
@@ -292,10 +293,8 @@ trait Symbols { this: AST =>
       def encl: u.Symbol = enclosingOwner
 
       /** Extracts the owner of `tree`, if any. */
-      def of(tree: u.Tree): u.Symbol = tree
-        .find(is.owner)
-        .map(_.symbol.owner)
-        .getOrElse(Sym.none)
+      def of(tree: u.Tree): u.Symbol =
+        tree.find(is.owner).fold(Sym.none)(_.symbol.owner)
 
       /** Returns a chain of the owners of `sym` starting at `sym` and ending at `_root_`. */
       def chain(sym: u.Symbol): Stream[u.Symbol] =

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
@@ -120,7 +120,7 @@ trait Common extends AST {
     val ops = sourceOps | sinkOps | monadOps | nestOps | setOps | foldOps
 
     val implicitTypes = Set(
-      api.Type[Meta[Any]].typeConstructor,
+      api.Type[org.emmalanguage.api.Meta[Any]].typeConstructor,
       api.Type[CSVConverter[Any]].typeConstructor,
       api.Type[ParquetConverter[Any]].typeConstructor
     )


### PR DESCRIPTION
Closes #259 

Note that singleton types are still not supported, because types are widened when creating new symbols. Therefore this would not work:
```scala
def abcx(abc: A.B.C) = abc.x
val act = anf({ abcx(A.B.C) })
val exp = id({
  val A$1 = this.A
  val B$1 = A$1.B
  val C$1 = B$1.C
  abcx(C$1)
})
```

The reason is that `scalac` cannot unify `A.B.C` and `B$1.C`. For this to work, `B$1` has to be of type `A$1.B.type`, i.e. a singleton type. This is a separate issue.