### PR TITLE
[TEST] Modified KMeans to use breeze.numerics.pow

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/api/package.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/package.scala
@@ -45,11 +45,4 @@ package object api {
     }
   }
   //@formatter:on
-
-  // -----------------------------------------------------
-  // Converters
-  // -----------------------------------------------------
-
-  def comparing[A](lt: (A, A) => Boolean): Ordering[A] =
-    Ordering.fromLessThan(lt)
 }


### PR DESCRIPTION
Also, removed `api.comparing` which was just a forwarder for `Ordering.fromLessThan`.

Closes #152 