### PR TITLE
[IR] Added basic support for caching.

### DIFF
--- a/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
@@ -28,9 +28,10 @@ class FlinkMacro(val c: blackbox.Context) extends MacroCompiler {
   }
 
   private lazy val parallelizePipeline: c.Expr[Any] => u.Tree =
-    pipeline(typeCheck = false)(
+    pipeline()(
       LibSupport.expand,
       Core.lift,
+      Backend.addCacheCalls,
       Comprehension.combine,
       Backend.translateToDataflows(FlinkAPI.bagSymbol),
       Core.inlineLetExprs,

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
@@ -158,6 +158,16 @@ trait Common extends AST {
     //@formatter:on
   }
 
+  protected[emmalanguage] object Runtime extends IRModule {
+    //@formatter:off
+    val module                = api.Sym[ir.Runtime.type].asModule
+
+    val cache                 = op("cache")
+
+    val ops                   = Set(cache)
+    //@formatter:on
+  }
+
   protected[emmalanguage] object GraphRepresentation extends IRModule {
     //@formatter:off
     val module  = api.Sym[ir.GraphRepresentation.type].asModule

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
@@ -43,9 +43,12 @@ trait Compiler extends AlphaEq
   /** The underlying universe object. */
   override val universe: Universe
 
+  /** Implicit types to be removed */
+  lazy val implicitTypes: Set[u.Type] = API.implicitTypes
+
   /** Standard pipeline prefix. Brings a tree into a form convenient for transformation. */
   lazy val preProcess: Seq[u.Tree => u.Tree] = Seq(
-    Source.removeImplicits(API.implicitTypes),
+    Source.removeImplicits(implicitTypes),
     fixSymbolTypes,
     stubTypeTrees,
     unQualifyStatics,

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/ir/Runtime.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/ir/Runtime.scala
@@ -14,26 +14,14 @@
  * limitations under the License.
  */
 package org.emmalanguage
-package compiler.lang.backend
+package compiler.ir
 
-import compiler.Common
-import compiler.lang.core.Core
+import api._
 
-/** Backend-related (but backend-agnostic) transformations. */
-trait Backend extends Common
-  with Caching
-  with Order
-  with TranslateToDataflows {
-  this: Core =>
+/** Dummy IR nodes that model runtime operators (i.e. purely physical operators) in the Emma IR. */
+object Runtime {
 
-  import UniverseImplicits._
+  /** Implement the underlying logical semantics only (identity function). */
+  def cache[A: Meta](xs: DataBag[A]): DataBag[A] = xs
 
-  object Backend {
-
-    /** Delegates to [[TranslateToDataflows.translateToDataflows]]. */
-    def translateToDataflows(to: u.ModuleSymbol) = TranslateToDataflows.translateToDataflows(to)
-
-    /** Delegates to [[Caching.addCacheCalls]]. */
-    lazy val addCacheCalls = Caching.addCacheCalls
-  }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Caching.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Caching.scala
@@ -1,0 +1,139 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler.lang.backend
+
+import compiler.Common
+import compiler.lang.core.Core
+import compiler.ir.DSCFAnnotations._
+import util.Monoids._
+
+import cats.std.all._
+import shapeless._
+
+import scala.collection.breakOut
+
+/** Translating to dataflows. */
+private[backend] trait Caching extends Common {
+  self: Backend with Core =>
+
+  private[backend] object Caching {
+
+    import Core.{Lang => core}
+    import UniverseImplicits._
+
+    private val runtime = Some(core.ModuleRef(Runtime.module))
+    private val cache   = Runtime.cache
+
+    /** Is `sym` a method defining a loop or the body of a loop? */
+    private def isLoop(sym: u.Symbol) = is.method(sym) &&
+      (api.Sym.findAnn[loop](sym).isDefined || api.Sym.findAnn[loopBody](sym).isDefined)
+
+    /** Does `sym` have a type of `DataBag` or a subtype? */
+    private def isDataBag(sym: u.Symbol) =
+      api.Type.constructor(sym.info) =:= API.DataBag
+
+    /** Caches `x` as the new value `y`. */
+    private def cacheAs(x: u.TermSymbol, y: u.TermSymbol) = {
+      val targs = Seq(api.Type.arg(1, x.info))
+      val argss = Seq(Seq(core.Ref(x)))
+      core.ValDef(y, core.DefCall(runtime, cache, targs, argss))
+    }
+
+    /**
+     * Wraps `DataBag` term in `cache(...)` calls if needed.
+     *
+     * A `DataBag` term needs to be wrapped in a a `cache(...)` call iff
+     *
+     * 1. it is used more than once;
+     * 2. it is passed as argument to a loop method;
+     * 3. it is referenced in the closure of a loop method.
+     *
+     * == Preconditions ==
+     *
+     * - The input tree is in Emma Core representation.
+     *
+     * == Postconditions ==
+     *
+     * - A tree where DataBag have been wrapped in `cache(...)` calls if needed.
+     */
+    lazy val addCacheCalls: u.Tree => u.Tree = tree => {
+      // Per DataBag reference, collect flag for access in a loop and ref count.
+      val refs = api.TopDown.withOwnerChain
+        .accumulateWith[Map[u.Symbol, (Boolean, Int)]] {
+          // Increment counter and set flag if referenced in a loop.
+          case Attr.inh(core.BindingRef(target), owners :: _) if isDataBag(target) =>
+            val inLoop = owners.reverseIterator.takeWhile(_ != target.owner).exists(isLoop)
+            Map(target -> (inLoop, 1))
+          // Arguments to loop methods are considered as referenced in the loop.
+          case Attr.none(core.DefCall(None, method, _, argss)) if isLoop(method) =>
+            argss.flatten.collect { case core.Ref(target) if isDataBag(target) =>
+              target -> (true, 1)
+            } (breakOut)
+        } (merge(tuple2Monoid(disj, implicitly))).traverseAny._acc(tree).head
+
+      /** Cache when referenced in a loop or more than once. */
+      def shouldCache(sym: u.Symbol) = {
+        val (inLoop, refCount) = refs(sym)
+        inLoop || refCount > 1
+      }
+
+      /** Creates cached values for parameters of methods and lambdas. */
+      def cacheParams(params: Seq[u.ValDef]): Map[u.Symbol, u.ValDef] =
+        params.collect { case core.ParDef(p, _) if shouldCache(p) =>
+          p -> cacheAs(p, api.ValSym(p.owner, api.TermName.fresh(p), p.info))
+        } (breakOut)
+
+      api.TopDown.withParent.accumulate {
+        // Accumulate cached lambda and method parameters.
+        case core.Lambda(_, params, _) =>
+          cacheParams(params)
+        case core.DefDef(method, _, paramss, _) if !isLoop(method) =>
+          cacheParams(paramss.flatten)
+      } (overwrite).transformWith {
+        case Attr(let @ core.Let(vals, defs, expr), cached :: _, parent :: _, _) =>
+          val params = parent match {
+            case Some(core.Lambda(_, params, _)) => params
+            case Some(core.DefDef(_, _, paramss, _)) => paramss.flatten
+            case _ => Seq.empty
+          }
+
+          // Prepend cached parameters, replace cached vals.
+          val cachedParams = params.map(_.symbol).collect(cached)
+          val cachedVals = vals.flatMap {
+            // Don't cache reads.
+            case value @ core.ValDef(_, core.DefCall(_, method, _, _))
+              if API.sourceOps(method) => Seq(value)
+            case core.ValDef(x, rhs) if shouldCache(x) =>
+              val y = api.TermSym.fresh(x)
+              Seq(core.ValDef(y, rhs), cacheAs(y, x))
+            case value => Seq(value)
+          }
+
+          if (cachedParams.isEmpty && cachedVals.size == vals.size) let
+          else core.Let(cachedParams ++ cachedVals, defs, expr)
+
+        // Dont't replace references in cache(...).
+        case Attr.inh(tree, Some(call) :: _) if call.symbol == cache =>
+          tree
+
+        // Replace references to cached parameters.
+        case Attr.acc(core.Ref(x), cached :: _) if cached.contains(x) =>
+          core.Ref(cached(x).symbol.asTerm)
+      }._tree(tree)
+    }
+  }
+}

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/TranslateToDataflows.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/TranslateToDataflows.scala
@@ -34,8 +34,10 @@ private[backend] trait TranslateToDataflows extends Common {
     import UniverseImplicits._
     import Core.{Lang => core}
 
-    private val modules  = Set[u.TermSymbol](API.bagModuleSymbol, ComprehensionCombinators.module)
-    private val methods  = API.sourceOps | ComprehensionCombinators.ops
+    private val modules  = Set[u.TermSymbol](
+      API.bagModuleSymbol, ComprehensionCombinators.module, Runtime.module)
+
+    private val methods  = API.sourceOps | ComprehensionCombinators.ops | Runtime.ops
     private val scalaSeq = Some(api.ModuleRef(API.scalaSeqModuleSymbol))
 
     /**

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/backend/CachingSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/backend/CachingSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler.lang.backend
+
+import compiler.ir
+
+import api.DataBag
+import compiler.BaseCompilerSpec
+
+/** A spec for order disambiguation. */
+class CachingSpec extends BaseCompilerSpec {
+
+  import compiler._
+
+  val liftPipeline: u.Expr[Any] => u.Tree =
+    pipeline(typeCheck = true)(
+      Core.lift
+    ).compose(_.tree)
+
+  val addCacheCalls: u.Expr[Any] => u.Tree =
+    pipeline(typeCheck = true)(
+      Core.lift,
+      tree => time(Caching.addCacheCalls(tree), "addCacheCalls")
+    ).compose(_.tree)
+
+  "cache DataBag terms" - {
+
+    "used multiple times" in {
+
+      val inp = u.reify {
+        val i = 2
+        val xs = DataBag(1 to 5).withFilter(_ % 2 == 0)
+        val ys = xs.map(_ + i)
+        val zs = xs.map(_ * i)
+        ys union zs
+      }
+
+      val exp = u.reify {
+        val i = 2
+        val xs = ir.Runtime.cache {
+          DataBag(1 to 5).withFilter(_ % 2 == 0)
+        }
+
+        val ys = xs.map(_ + i)
+        val zs = xs.map(_ * i)
+        ys union zs
+      }
+
+      addCacheCalls(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "passed as arguments to a loop method" in {
+
+      val inp = u.reify {
+        val i = 2
+        val N = 5
+        var xs = DataBag(1 to 5)
+        for (_ <- 0 to N) xs = xs.map(_ + i)
+        xs
+      }
+
+      val exp = u.reify {
+        val i = 2
+        val N = 5
+        var xs = DataBag(1 to 5)
+        for (_ <- 0 to N) xs = ir.Runtime.cache {
+          xs.map(_ + i)
+        }
+
+        xs
+      }
+
+      addCacheCalls(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+
+    "referenced in the closure of a loop method" in {
+
+      val inp = u.reify {
+        val i = 2
+        val N = 5
+        var xs = DataBag(1 to 5)
+        val ys = DataBag(1 to 5).withFilter(_ % 2 == 0)
+        for (_ <- 0 to N) xs = xs union ys
+        xs
+      }
+
+      val exp = u.reify {
+        val i = 2
+        val N = 5
+        var xs = DataBag(1 to 5)
+        val ys = ir.Runtime.cache {
+          DataBag(1 to 5).withFilter(_ % 2 == 0)
+        }
+
+        for (_ <- 0 to N)
+          xs = ir.Runtime.cache {
+            xs union ys
+          }
+
+        xs
+      }
+
+      addCacheCalls(inp) shouldBe alphaEqTo(liftPipeline(exp))
+    }
+  }
+}

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
@@ -203,4 +203,15 @@ object SparkDataset {
 
   implicit def wrap[A: Meta](rep: Dataset[A]): SparkDataset[A] =
     new SparkDataset(rep)
+
+  // ---------------------------------------------------------------------------
+  // RuntimeOps
+  // ---------------------------------------------------------------------------
+
+  def cache[A: Meta](xs: DataBag[A])(implicit spark: SparkSession): DataBag[A] =
+    xs match {
+      case xs: SparkRDD[A] => spark.createDataset(xs.rep).cache()
+      case xs: SparkDataset[A] => xs.rep.cache()
+      case _ => xs
+    }
 }

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
@@ -230,4 +230,14 @@ object SparkRDD {
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // RuntimeOps
+  // ---------------------------------------------------------------------------
+
+  def cache[A: Meta](xs: DataBag[A])(implicit spark: SparkSession): DataBag[A] =
+    xs match {
+      case xs: SparkRDD[A] => xs.rep.cache()
+      case xs: SparkDataset[A] => xs.rep.rdd.cache()
+      case _ => xs
+    }
 }

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
@@ -24,8 +24,12 @@ class SparkMacro(val c: blackbox.Context) extends MacroCompiler {
   def parallelizeImpl[T](e: c.Expr[T]): c.Expr[T] = {
     val res = parallelizePipeline(e)
     //c.warning(e.tree.pos, Core.prettyPrint(res))
-    c.Expr[T]((removeShadowedThis andThen unTypeCheck)(res))
+    c.Expr[T]((removeShadowedThis andThen unTypeCheck) (res))
   }
+
+  override lazy val implicitTypes: Set[u.Type] = API.implicitTypes ++ Set(
+    api.Type[org.apache.spark.sql.Encoder[Any]].typeConstructor
+  )
 
   private lazy val parallelizePipeline: c.Expr[Any] => u.Tree =
     pipeline()(

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
@@ -28,9 +28,10 @@ class SparkMacro(val c: blackbox.Context) extends MacroCompiler {
   }
 
   private lazy val parallelizePipeline: c.Expr[Any] => u.Tree =
-    pipeline(typeCheck = false)(
+    pipeline()(
       LibSupport.expand,
       Core.lift,
+      Backend.addCacheCalls,
       Comprehension.combine,
       Backend.translateToDataflows(SparkAPI.rddModuleSymbol),
       Core.inlineLetExprs,


### PR DESCRIPTION
Introduces

- a `ir.Runtime` module for runtime operators and an initial runtime
  operator `cache`;
- a `backend.Caching` module with `addCacheCalls` transformation
  that inserts `cache` calls when necessary.

Adds `Backend.cache` to the `emma.onFlink` and `emma.onSpark` pipelines.

The current implementation is a bit more conservative than what is possible, and (for example) will add `cache` calls to `xs` in the following:

```scala
val xs = DataBag(Seq(1,2,3,4,5))

if (z < 0) f(xs)
else g(xs)
```

A more elaborate version that considers cases such as the one above will be added after #300 is merged. 