### PR TITLE
Add `MutableBag` abstraction

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -16,16 +16,14 @@ specific language governing permissions and limitations
 under the License.
 
 This project includes:
-  akka-actor under Apache License, Version 2.0
-  akka-remote under Apache License, Version 2.0
-  akka-slf4j under Apache License, Version 2.0
   An open source Java toolkit for Amazon S3 under Apache License, Version 2.0
   ANTLR 4 Runtime under The BSD License
   aopalliance version 1.0 repackaged as a module under CDDL + GPLv2 with classpath exception
   Apache Avro under The Apache Software License, Version 2.0
   Apache Avro IPC under The Apache Software License, Version 2.0
   Apache Avro Mapred API under The Apache Software License, Version 2.0
-  Apache Commons FileUpload under The Apache Software License, Version 2.0
+  Apache Commons CLI under Apache License, Version 2.0
+  Apache Commons Collections under Apache License, Version 2.0
   Apache Commons Lang under The Apache Software License, Version 2.0
   Apache Commons Math under The Apache Software License, Version 2.0
   Apache Hadoop Annotations under The Apache Software License, Version 2.0
@@ -45,15 +43,12 @@ This project includes:
   Apache XBean :: ASM 5 shaded (repackaged) under null or null
   ASM Core under Apache License, Version 2.0
   Bean Validation API under The Apache Software License, Version 2.0
-  bijection-avro under Apache 2
-  bijection-core under Apache 2
   breeze under Apache 2
   breeze-macros under Apache 2
   catsJVM under MIT
   chill under Apache 2
-  chill-avro under Apache 2
-  chill-bijection under Apache 2
   chill-java under Apache 2
+  Commons BeanUtils Bean Collections under The Apache Software License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
   Commons Codec under The Apache Software License, Version 2.0
@@ -90,13 +85,19 @@ This project includes:
   emma-spark under The Apache License, Version 2.0
   empty under The Apache License, Version 2.0
   FindBugs-jsr305 under The Apache Software License, Version 2.0
+  flakka-actor under Apache License, Version 2.0
+  flakka-remote under Apache License, Version 2.0
+  flakka-slf4j under Apache License, Version 2.0
+  flink-annotations under The Apache Software License, Version 2.0
   flink-clients under The Apache Software License, Version 2.0
   flink-core under The Apache Software License, Version 2.0
   flink-java under The Apache Software License, Version 2.0
+  flink-metrics-core under The Apache Software License, Version 2.0
   flink-optimizer under The Apache Software License, Version 2.0
   flink-runtime under The Apache Software License, Version 2.0
   flink-scala under The Apache Software License, Version 2.0
   flink-shaded-hadoop2 under The Apache Software License, Version 2.0
+  force-shading under The Apache Software License, Version 2.0
   Fortran to Java ARPACK under The BSD License
   free under MIT
   Graphite Integration for Metrics under Apache License 2.0
@@ -116,7 +117,6 @@ This project includes:
   HK2 API module under CDDL + GPLv2 with classpath exception
   HK2 Implementation Utilities under CDDL + GPLv2 with classpath exception
   HttpClient under Apache License
-  HttpCore under Apache License
   Jackson under The Apache Software License, Version 2.0
   Jackson Integration for Metrics under Apache License 2.0
   Jackson-annotations under The Apache Software License, Version 2.0
@@ -128,6 +128,7 @@ This project includes:
   jasper-compiler under The Apache Software License, Version 2.0
   jasper-runtime under The Apache Software License, Version 2.0
   Java Servlet API under CDDL + GPLv2 with classpath exception
+  java-xmlbuilder under Apache License, Version 2.0
   JavaBeans Activation Framework (JAF) under Common Development and Distribution License (CDDL) v1.0
   Javassist under MPL 1.1 or LGPL 2.1 or Apache License 2.0
   javax.annotation API under CDDL + GPLv2 with classpath exception
@@ -161,8 +162,6 @@ This project includes:
   Jetty :: XML utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty Server under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   Jetty Utilities under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
-  Joda-Convert under Apache 2
-  Joda-Time under Apache 2
   JSch under BSD
   json4s-ast under ASL
   json4s-core under ASL
@@ -175,7 +174,6 @@ This project includes:
   kernel under MIT
   kernelLaws under MIT
   Kryo under New BSD License
-  kryo serializers under The Apache Software License, Version 2.0
   Kryo Shaded under New BSD License
   laws under MIT
   leveldbjni-all under The BSD 3-Clause License
@@ -211,7 +209,6 @@ This project includes:
   scalaz-core under BSD-style
   scopt under MIT License
   ServiceLocator Default Implementation under CDDL + GPLv2 with classpath exception
-  Servlet API under Apache Software License - Version 2.0 or Eclipse Public License - Version 1.0
   servlet-api under Commons Development and Distribution License, Version 1.0
   SLF4J API Module under MIT License
   SLF4J LOG4J-12 Binding under MIT License
@@ -230,6 +227,7 @@ This project includes:
   spray-json under Apache 2
   StAX API under The Apache Software License, Version 2.0
   stream-lib under Apache License, Version 2.0
+  Streaming API for XML under Sun Binary Code License
   test-interface under BSD
   The Netty Project under Apache License, Version 2.0
   Uncommons Maths under Apache License, Version 2.0

--- a/NOTICE
+++ b/NOTICE
@@ -48,6 +48,7 @@ This project includes:
   catsJVM under MIT
   chill under Apache 2
   chill-java under Apache 2
+  com.ankurdave:part_2.10 under Apache License, Version 2.0
   Commons BeanUtils Bean Collections under The Apache Software License, Version 2.0
   Commons BeanUtils Core under The Apache Software License, Version 2.0
   Commons CLI under The Apache Software License, Version 2.0
@@ -222,6 +223,7 @@ This project includes:
   Spark Project SQL under Apache 2.0 License
   Spark Project Tags under Apache 2.0 License
   Spark Project Unsafe under Apache 2.0 License
+  spark-indexedrdd under Apache-2.0
   spire under BSD-style
   spire-macros under BSD-style
   spray-json under Apache 2

--- a/emma-examples/emma-examples-flink/pom.xml
+++ b/emma-examples/emma-examples-flink/pom.xml
@@ -76,10 +76,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-java_${scala.tools.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients_${scala.tools.version}</artifactId>
         </dependency>
 

--- a/emma-examples/emma-examples-flink/src/test/scala/org/emmalanguage/examples/graphs/FlinkConnectedComponentsIntegrationSpec.scala
+++ b/emma-examples/emma-examples-flink/src/test/scala/org/emmalanguage/examples/graphs/FlinkConnectedComponentsIntegrationSpec.scala
@@ -16,13 +16,25 @@
 package org.emmalanguage
 package examples.graphs
 
-import api.emma
+import api._
+import examples.graphs.model._
 
-/** Graph model objects. */
-object model {
-  case class Edge[V](src: V, dst: V)
-  case class LEdge[V, L](@emma.pk src: V, @emma.pk dst: V, label: L)
-  case class LVertex[V, L](@emma.pk id: V, label: L)
-  case class Triangle[V](x: V, y: V, z: V)
-  case class Message[K, V](@emma.pk tgt: K, payload: V)
+import org.apache.flink.api.scala.ExecutionEnvironment
+
+class FlinkConnectedComponentsIntegrationSpec extends BaseConnectedComponentsIntegrationSpec {
+
+  def connectedComponents(edges: Seq[Edge[Int]]): Seq[LVertex[Int, Int]] =
+    FlinkConnectedComponentsIntegrationSpec(edges)
+}
+
+object FlinkConnectedComponentsIntegrationSpec {
+
+  def apply(edges: Seq[Edge[Int]]): Seq[LVertex[Int, Int]] =
+    emma.onFlink {
+      val es = DataBag(edges)
+      val rs = ConnectedComponents[Int](es)
+      rs.fetch()
+    }
+
+  implicit lazy val flinkEnv = ExecutionEnvironment.getExecutionEnvironment
 }

--- a/emma-examples/emma-examples-library/src/main/scala/org/emmalanguage/examples/graphs/ConnectedComponents.scala
+++ b/emma-examples/emma-examples-library/src/main/scala/org/emmalanguage/examples/graphs/ConnectedComponents.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.graphs
+
+import api._
+import model._
+
+import Ordering.Implicits._
+
+@emma.lib
+object ConnectedComponents {
+
+  def apply[V: Ordering : Meta.Tag](edges: DataBag[Edge[V]]): DataBag[LVertex[V, V]] = {
+    val vertices = edges.map(_.src).distinct
+
+    // initial state
+    val state = MutableBag(vertices.map(v => v -> v))
+    // collection of vertices whose label changed in the last iteration
+    var delta = state.bag()
+
+    while (delta.nonEmpty) {
+      val messages = for {
+        Tuple2(k, v) <- delta
+        Edge(src, dst) <- edges
+        if k == src
+      } yield Message(dst, v)
+
+      delta = state.update(
+        messages.groupBy(_.tgt)
+      )((_, vOpt, ms) => for {
+        v <- vOpt
+        m = ms.map(_.payload).max
+        if m > v
+      } yield m)
+    }
+
+    // return solution set
+    for ((vid, cmp) <- state.bag()) yield LVertex(vid, cmp)
+  }
+}

--- a/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/examples/graphs/BaseConnectedComponentsIntegrationSpec.scala
+++ b/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/examples/graphs/BaseConnectedComponentsIntegrationSpec.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package examples.graphs
+
+import examples.graphs.model._
+import test.util._
+
+import org.scalatest.BeforeAndAfter
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+
+import java.io.File
+
+trait BaseConnectedComponentsIntegrationSpec extends FlatSpec with Matchers with BeforeAndAfter {
+
+  val codegenDir = tempPath("codegen")
+
+  before {
+    new File(codegenDir).mkdirs()
+    addToClasspath(new File(codegenDir))
+  }
+
+  after {
+    deleteRecursive(new File(codegenDir))
+  }
+
+  "Connected components" should "find all connected sub-graphs" in {
+    val act = connectedComponents(Seq(
+      Edge(1, 2), Edge(1, 5), Edge(1, 7),
+      Edge(2, 1), Edge(2, 5), Edge(2, 7),
+      Edge(3, 3),
+      Edge(4, 6),
+      Edge(5, 1), Edge(5, 2),
+      Edge(6, 4),
+      Edge(7, 1),
+      Edge(7, 2)
+    ))
+
+    val exp = Seq(
+      LVertex(1, 7),
+      LVertex(2, 7),
+      LVertex(3, 3),
+      LVertex(4, 6),
+      LVertex(5, 7),
+      LVertex(6, 6),
+      LVertex(7, 7)
+    )
+
+    act should contain theSameElementsAs exp
+  }
+
+  def connectedComponents(edges: Seq[Edge[Int]]): Seq[LVertex[Int, Int]]
+}

--- a/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/examples/graphs/NaiveConnectedComponentsIntegrationSpec.scala
+++ b/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/examples/graphs/NaiveConnectedComponentsIntegrationSpec.scala
@@ -16,13 +16,11 @@
 package org.emmalanguage
 package examples.graphs
 
-import api.emma
+import api._
+import examples.graphs.model._
 
-/** Graph model objects. */
-object model {
-  case class Edge[V](src: V, dst: V)
-  case class LEdge[V, L](@emma.pk src: V, @emma.pk dst: V, label: L)
-  case class LVertex[V, L](@emma.pk id: V, label: L)
-  case class Triangle[V](x: V, y: V, z: V)
-  case class Message[K, V](@emma.pk tgt: K, payload: V)
+class NaiveConnectedComponentsIntegrationSpec extends BaseConnectedComponentsIntegrationSpec {
+
+  def connectedComponents(edges: Seq[Edge[Int]]): Seq[LVertex[Int, Int]] =
+    ConnectedComponents[Int](DataBag(edges)).fetch()
 }

--- a/emma-examples/emma-examples-spark/src/test/scala/org/emmalanguage/examples/graphs/SparkConnectedComponentsIntegrationSpec.scala
+++ b/emma-examples/emma-examples-spark/src/test/scala/org/emmalanguage/examples/graphs/SparkConnectedComponentsIntegrationSpec.scala
@@ -16,13 +16,26 @@
 package org.emmalanguage
 package examples.graphs
 
-import api.emma
+import api._
+import examples.graphs.model._
 
-/** Graph model objects. */
-object model {
-  case class Edge[V](src: V, dst: V)
-  case class LEdge[V, L](@emma.pk src: V, @emma.pk dst: V, label: L)
-  case class LVertex[V, L](@emma.pk id: V, label: L)
-  case class Triangle[V](x: V, y: V, z: V)
-  case class Message[K, V](@emma.pk tgt: K, payload: V)
+import org.apache.spark.sql.SparkSession
+
+class SparkConnectedComponentsIntegrationSpec extends BaseConnectedComponentsIntegrationSpec {
+
+  def connectedComponents(edges: Seq[Edge[Int]]): Seq[LVertex[Int, Int]] =
+    SparkConnectedComponentsIntegrationSpec(edges)
+}
+
+object SparkConnectedComponentsIntegrationSpec {
+
+  def apply(edges: Seq[Edge[Int]]): Seq[LVertex[Int, Int]] =
+    emma.onSpark {
+      ConnectedComponents[Int](DataBag(edges)).fetch()
+    }
+
+  implicit lazy val sparkSession = SparkSession.builder()
+    .master("local[*]")
+    .appName(this.getClass.getSimpleName)
+    .getOrCreate()
 }

--- a/emma-flink/pom.xml
+++ b/emma-flink/pom.xml
@@ -73,10 +73,6 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-java_${scala.tools.version}</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.flink</groupId>
             <artifactId>flink-clients_${scala.tools.version}</artifactId>
         </dependency>
     </dependencies>

--- a/emma-flink/src/main/scala/org/emmalanguage/api/FlinkMutableBag.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/FlinkMutableBag.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package api
+
+import FlinkDataSet.cache
+import FlinkMutableBag.State
+import api.Meta.Projections._
+import api.converter.flink._
+
+import org.apache.flink.api.scala.DataSet
+import org.apache.flink.api.scala.ExecutionEnvironment
+import org.apache.flink.util.Collector
+
+class FlinkMutableBag[K: Meta, V: Meta] private
+(
+  /* Distributed state modeled naively as a mutable reference to an immutable bag. */
+  var ss: DataBag[State[K, V]]
+)(
+  implicit flink: ExecutionEnvironment
+) extends MutableBag[K, V] with Serializable {
+
+  import FlinkDataSet.typeInfoForType
+  import FlinkDataSet.wrap
+
+  def update[M: Meta](ms: DataBag[Group[K, M]])(f: UpdateFunction[M]): DataBag[(K, V)] = {
+    ss = cache((ss.as[DataSet] fullOuterJoin ms.as[DataSet]).where(0).equalTo(0)(
+      (s: State[K, V], m: Group[K, M], out: Collector[State[K, V]]) => {
+        val rs = Option(m) match {
+          case Some(m) =>
+            val vOld = Option(s)
+            val vNew = f(m.key, vOld.map(_.v), m.values)
+            vNew.map(State(m.key, _, true)) orElse vOld.map(_.copy(changed = false))
+          case None =>
+            Option(s).map(_.copy(changed = false))
+        }
+        rs.foreach(out.collect)
+      }))
+
+    for (s <- ss if s.changed) yield s.k -> s.v
+  }
+
+  def bag(): DataBag[(K, V)] =
+    for (s <- ss) yield s.k -> s.v
+
+  def copy(): MutableBag[K, V] =
+    new FlinkMutableBag[K, V](ss)
+}
+
+object FlinkMutableBag {
+
+  case class State[K, V](k: K, v: V, changed: Boolean = true)
+
+  def apply[K: Meta, V: Meta](
+    init: DataBag[(K, V)]
+  )(
+    implicit flink: ExecutionEnvironment
+  ): MutableBag[K, V] = new FlinkMutableBag(cache(for {
+    (k, v) <- init
+  } yield State(k, v)))
+
+  private[api] val tempNames = Stream.iterate(0)(_ + 1)
+    .map(i => f"stateful$i%03d")
+    .toIterator
+}

--- a/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
@@ -34,12 +34,14 @@ class FlinkMacro(val c: blackbox.Context) extends MacroCompiler {
       Backend.addCacheCalls,
       Comprehension.combine,
       Backend.translateToDataflows(FlinkAPI.bagSymbol),
+      Core.refineModules(Map(MutableBagAPI.module -> FlinkAPI.mutableBagModuleSymbol)),
       Core.inlineLetExprs,
       Core.trampoline
     ).compose(_.tree)
 
   private object FlinkAPI {
     lazy val bagSymbol = universe.rootMirror.staticModule(s"$rootPkg.api.FlinkDataSet")
+    lazy val mutableBagModuleSymbol = universe.rootMirror.staticModule(s"$rootPkg.api.FlinkMutableBag")
   }
 
 }

--- a/emma-language/src/main/scala/org/emmalanguage/api/Group.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/Group.scala
@@ -16,4 +16,4 @@
 package org.emmalanguage
 package api
 
-case class Group[K, +V](key: K, values: V)
+case class Group[K, +V](@emma.pk key: K, values: V)

--- a/emma-language/src/main/scala/org/emmalanguage/api/MutableBag.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/MutableBag.scala
@@ -1,0 +1,80 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package api
+
+import api.Meta.Projections._
+
+import scala.collection.breakOut
+
+/** A mutable bag abstraction. */
+trait MutableBag[K, V] {
+
+  /* The update function type. */
+  type UpdateFunction[M] = (K, Option[V], M) => Option[V]
+
+  /**
+   * Performs an update operation with the following semantics.
+   *
+   * For each `m` in `ms`, the implementation will call
+   *
+   * - `f(m.key, Some(v), m.value)` if `(m.key, v)` is in the underlying mutable bag;
+   * - `f(m.key, None, m.value)` if `(m.key, v)` is not in the underlying mutable bag;
+   *
+   * Each `f` call can optionally return an `v` value to be associated with the current `k`.
+   *
+   * The collection of updated values is merged in the underlying mutable bag and
+   * returned as final result.
+   *
+   * The functional semantics of the function rely on the assumption that `K` is a
+   * unique key in `ms`. Otherwise, the implied state update is non-deterministic.
+   */
+  def update[M: Meta](ms: DataBag[Group[K, M]])(f: UpdateFunction[M]): DataBag[(K, V)]
+
+  /** Returns the underluing data of this `MutableBag` as an (immutable) `DataBag`. */
+  def bag(): DataBag[(K, V)]
+
+  /** Creates a copy of this `MutableBag`. Can be used for by-value assignment. */
+  def copy(): MutableBag[K, V]
+}
+
+/** A mutable bag companion abstraction. */
+object MutableBag {
+
+  def apply[K: Meta, V: Meta](init: DataBag[(K, V)]): MutableBag[K, V] =
+    new MutableBag[K, V] {
+
+      /* Local state - a (mutable) reference to an (immutable) map of type `(K, V)`. */
+      private var sm: Map[K, V] = init.fetch().map(identity[(K, V)])(breakOut)
+
+      def update[M: Meta](ms: DataBag[Group[K, M]])(f: UpdateFunction[M]): DataBag[(K, V)] = {
+        val delta = for {
+          m <- ms.fetch()
+          v <- f(m.key, sm.get(m.key), m.values)
+        } yield m.key -> v
+
+        sm = sm ++ delta
+
+        DataBag(delta)
+      }
+
+      def bag(): DataBag[(K, V)] =
+        DataBag(sm.toSeq)
+
+      def copy(): MutableBag[K, V] =
+        MutableBag(bag())
+    }
+}

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
@@ -133,6 +133,20 @@ trait Common extends AST {
     //@formatter:on
   }
 
+  protected[emmalanguage] object MutableBagAPI extends IRModule {
+    //@formatter:off
+    val module                = api.Sym[org.emmalanguage.api.MutableBag.type].asModule
+    val clzSym                = api.Sym[org.emmalanguage.api.MutableBag[Any, Any]].asClass
+
+    val apply                 = op("apply")
+    val update                = methodIn(clzSym, "update")
+    val bag                   = methodIn(clzSym, "bag")
+    val copy                  = methodIn(clzSym, "copy")
+
+    val ops                   = Set(apply, update, bag, copy)
+    //@formatter:on
+  }
+
   protected[emmalanguage] object ComprehensionSyntax extends IRModule {
     //@formatter:off
     val module                = api.Sym[ir.ComprehensionSyntax.type].asModule

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Order.scala
@@ -41,7 +41,7 @@ private[backend] trait Order extends Common {
      * If a lambda is given as an argument to one of these methods,
      * then that lambda will be called from higher-order context.
      */
-    val combinators = API.ops ++ ComprehensionCombinators.ops
+    val combinators = API.ops ++ ComprehensionCombinators.ops ++ MutableBagAPI.ops
 
     /**
      * Disambiguates order in a tree and gives information on which parts of the code might be executed

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
@@ -358,6 +358,17 @@ trait Core extends Common
           s"The tree:\n-----\n$xs\n-----\nIts type: `${xs.tpe}`")
       api.Type.arg(1, xs.tpe)
     }
+
+    /**
+     * Refine modules.
+     */
+    def refineModules(map: Map[u.ModuleSymbol, u.ModuleSymbol]): u.Tree => u.Tree = {
+      import Lang._
+      api.TopDown.transform({
+        case DefCall(Some(Ref(tgt: u.ModuleSymbol)), method, targs, argss)
+          if map.contains(tgt) => DefCall(Some(Ref(map(tgt))), method, targs, argss)
+      })._tree
+    }
   }
 
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DCE.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DCE.scala
@@ -24,8 +24,8 @@ import scala.collection.breakOut
 private[core] trait DCE extends Common {
   self: Core =>
 
-  import UniverseImplicits._
   import Core.{Lang => core}
+  import UniverseImplicits._
 
   private[core] object DCE {
 
@@ -62,7 +62,7 @@ private[core] trait DCE extends Common {
           val liveRefs = vals.foldRight(refs(expr) | refsInDefs) {
             // When we have a DefCall that is returning a unit, then treat this val as used
             case (core.ValDef(lhs, rhs @ api.DefCall(_, method, _, _)), live)
-              if method.returnType =:= api.Type[Unit] => live | refs(rhs) + lhs
+              if maybeMutable(method) => live | refs(rhs) + lhs
             case (core.ValDef(lhs, rhs), live) =>
               if (live(lhs)) live | refs(rhs) else live
           }
@@ -72,5 +72,11 @@ private[core] trait DCE extends Common {
           if (liveVals.size == vals.size && liveDefs.size == defs.size) let
           else core.Let(liveVals, liveDefs, expr)
       }.andThen(_.tree)
+
+    private def maybeMutable(method: u.MethodSymbol): Boolean = {
+      method.returnType =:= api.Type[Unit]
+    } || {
+      MutableBagAPI.update == method
+    }
   }
 }

--- a/emma-spark/pom.xml
+++ b/emma-spark/pom.xml
@@ -66,5 +66,9 @@
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.tools.version}</artifactId>
         </dependency>
+        <dependency>
+            <groupId>amplab</groupId>
+            <artifactId>spark-indexedrdd</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkMutableBag.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkMutableBag.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package api
+
+import api.Meta.Projections._
+import api.converter.spark._
+
+import edu.berkeley.cs.amplab.spark.indexedrdd.IndexedRDD
+import edu.berkeley.cs.amplab.spark.indexedrdd.KeySerializer
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.SparkSession
+
+import java.util.UUID
+
+class SparkMutableBag[K: Meta, V: Meta]
+(
+  init: DataBag[(K, V)]
+)(
+  implicit spark: SparkSession
+) extends MutableBag[K, V] with Serializable {
+
+  import SparkMutableBag.keySerializer
+
+  /* Distrubted state - a (mutable) reference to an (immutable) indexed collection. */
+  @transient var si = IndexedRDD(init.as[RDD]).cache()
+
+  def update[M: Meta](ms: DataBag[Group[K, M]])(f: UpdateFunction[M]): DataBag[(K, V)] = {
+    // update messages as RDD
+    val delta = (si rightOuterJoin ms.map(m => m.key -> m.values).as[RDD])
+      .flatMap { case (k, (ov, m)) => f(k, ov, m).map(v => k -> v) }
+
+    si = si.multiputRDD(delta)
+
+    // return the result wrapped in a DataSet
+    new SparkRDD(delta)
+  }
+
+  def bag(): DataBag[(K, V)] =
+    new SparkRDD(si.map(identity[(K, V)]))
+
+  def copy(): MutableBag[K, V] =
+    new SparkMutableBag(bag())
+}
+
+object SparkMutableBag {
+  def apply[K: Meta, V: Meta](
+    init: DataBag[(K, V)]
+  )(
+    implicit spark: SparkSession
+  ): MutableBag[K, V] = new SparkMutableBag[K, V](init)
+
+  implicit private def keySerializer[K](implicit m: Meta[K]): KeySerializer[K] = {
+    import scala.reflect.runtime.universe._
+
+    val ttag = m.ttag
+
+    if (ttag.tpe == typeOf[Long]) IndexedRDD.longSer.asInstanceOf[KeySerializer[K]]
+    else if (ttag.tpe == typeOf[String]) IndexedRDD.stringSer.asInstanceOf[KeySerializer[K]]
+    else if (ttag.tpe == typeOf[Short]) IndexedRDD.shortSer.asInstanceOf[KeySerializer[K]]
+    else if (ttag.tpe == typeOf[Int]) IndexedRDD.intSet.asInstanceOf[KeySerializer[K]]
+    else if (ttag.tpe == typeOf[BigInt]) IndexedRDD.bigintSer.asInstanceOf[KeySerializer[K]]
+    else if (ttag.tpe == typeOf[UUID]) IndexedRDD.uuidSer.asInstanceOf[KeySerializer[K]]
+    else throw new RuntimeException(s"Unsupported Key type ${ttag.tpe}")
+  }
+}

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
@@ -38,12 +38,14 @@ class SparkMacro(val c: blackbox.Context) extends MacroCompiler {
       Backend.addCacheCalls,
       Comprehension.combine,
       Backend.translateToDataflows(SparkAPI.rddModuleSymbol),
+      Core.refineModules(Map(MutableBagAPI.module -> SparkAPI.mutableBagModuleSymbol)),
       Core.inlineLetExprs,
       Core.trampoline
     ).compose(_.tree)
 
   private object SparkAPI {
     lazy val rddModuleSymbol = universe.rootMirror.staticModule(s"$rootPkg.api.SparkRDD")
+    lazy val mutableBagModuleSymbol = universe.rootMirror.staticModule(s"$rootPkg.api.SparkMutableBag")
     lazy val sessionSymbol = universe.rootMirror.staticClass(s"org.apache.spark.sql.SparkSession")
     lazy val sessionType = sessionSymbol.info
   }

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
         <!-- Hadoop -->
         <hadoop.version>2.2.0</hadoop.version>
         <!-- Flink -->
-        <flink.version>0.10.0</flink.version>
+        <flink.version>1.2.0</flink.version>
         <!-- Spark -->
         <spark.version>2.0.1</spark.version>
         <!-- Parquet -->
@@ -258,12 +258,6 @@
             <dependency>
                 <groupId>org.apache.flink</groupId>
                 <artifactId>flink-scala_${scala.tools.version}</artifactId>
-                <version>${flink.version}</version>
-                <scope>${flink.scope}</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.flink</groupId>
-                <artifactId>flink-java_${scala.tools.version}</artifactId>
                 <version>${flink.version}</version>
                 <scope>${flink.scope}</scope>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -129,6 +129,7 @@
         <flink.version>1.2.0</flink.version>
         <!-- Spark -->
         <spark.version>2.0.1</spark.version>
+        <spark.indexedrdd.version>0.4.0</spark.indexedrdd.version>
         <!-- Parquet -->
         <parquet.version>1.7.0</parquet.version>
 
@@ -168,6 +169,14 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
+
+    <repositories>
+        <!-- Spark Packages Repo -->
+        <repository>
+            <id>spark</id>
+            <url>http://dl.bintray.com/spark-packages/maven</url>
+        </repository>
+    </repositories>
 
     <dependencyManagement>
         <dependencies>
@@ -280,6 +289,11 @@
                 <artifactId>spark-sql_${scala.tools.version}</artifactId>
                 <version>${spark.version}</version>
                 <scope>${spark.scope}</scope>
+            </dependency>
+            <dependency>
+                <groupId>amplab</groupId>
+                <artifactId>spark-indexedrdd</artifactId>
+                <version>${spark.indexedrdd.version}</version>
             </dependency>
 
             <!-- Parquet -->

--- a/tools/license-mappings.xml
+++ b/tools/license-mappings.xml
@@ -33,4 +33,10 @@
         <artifactId>jettison</artifactId>
         <license>Apache License, Version 2.0</license>
     </artifact>
+    <artifact>
+        <groupId>com.ankurdave</groupId>
+        <artifactId>part_2.10</artifactId>
+        <version>0.1</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
 </license-lookup>


### PR DESCRIPTION
This is a somewhat simplified port of the `StatefulBag` abstraction from the old master branch.

The implementation is based on an abstract trait (`MutableBag`) with concrete implementations for Flink and Spark.

To validate that the current state works with a `ConnectedComponents` algorithm.

The main idea behind the port is that it will allow us to translate loop structures over a `MutableBag` instance to Flink's `iterateWithDelta` calls. I will propose backend-specific transformations for Flink's bulk- and delta-iterations in the next days.