### PR TITLE
[IO] Revisited ParquetConverter implementation

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -38,7 +38,6 @@ This project includes:
   Apache Parquet Common under The Apache Software License, Version 2.0
   Apache Parquet Encodings under The Apache Software License, Version 2.0
   Apache Parquet Format (Incubating) under The Apache Software License, Version 2.0
-  Apache Parquet Generator under The Apache Software License, Version 2.0
   Apache Parquet Hadoop under The Apache Software License, Version 2.0
   Apache Parquet Jackson under The Apache Software License, Version 2.0
   Apache XBean :: ASM 5 shaded (repackaged) under null or null

--- a/emma-flink/src/test/scala/org/emmalanguage/api/FlinkDataSetSpec.scala
+++ b/emma-flink/src/test/scala/org/emmalanguage/api/FlinkDataSetSpec.scala
@@ -29,17 +29,16 @@ import java.io.File
 
 class FlinkDataSetSpec extends DataBagSpec with BeforeAndAfter {
 
-  override type Bag[A] = FlinkDataSet[A]
+  override val supportsParquet = false
+
+  override type TestBag[A] = FlinkDataSet[A]
   override type BackendContext = FlinkEnv
 
-  override val Bag = FlinkDataSet
+  override val TestBag = FlinkDataSet
   override val suffix = "flink"
 
   override def withBackendContext[T](f: BackendContext => T): T =
     f(FlinkEnv.getExecutionEnvironment)
-
-  override def readCSV[A: Meta : CSVConverter](path: String, format: CSV)(implicit flink: FlinkEnv): DataBag[A] =
-    FlinkDataSet.readCSV(path, format)
 
   val codegenDir = new File(tempPath("codegen"))
 

--- a/emma-language/src/main/scala/org/emmalanguage/io/parquet/MkParquetConverter.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/parquet/MkParquetConverter.scala
@@ -1,0 +1,105 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package io.parquet
+
+import org.apache.parquet.io.api._
+import org.apache.parquet.schema._
+import Type.Repetition._
+
+import shapeless._
+import shapeless.ops.hlist._
+import shapeless.ops.record._
+
+import scala.language.higherKinds
+
+/** Implicit [[ParquetConverter]] privder. */
+trait MkParquetConverter[A] extends (() => ParquetConverter[A])
+
+/** Derived [[ParquetConverter]] instances. */
+object MkParquetConverter {
+  import util.Default
+  import ParquetConverter._
+
+  /** Lazily make a [[ParquetConverter]] instance. */
+  private def mk[A](instance: => ParquetConverter[A]): MkParquetConverter[A] =
+    new MkParquetConverter[A] { def apply = instance }
+
+  /**
+   * Generic Parquet codec for case classes and tuples (aka product types).
+   * @param gen A Converter between [[A]] and its generic representation [[R]].
+   * @param nonEmpty Evidence that [[A]] has at least one field.
+   * @param unzip A dependent function that unzips the field names [[K]] and field values [[V]] from [[R]].
+   * @param record A dependent Function that zips a list of values [[V]] with the field names [[K]] back into [[R]].
+   * @param converters Resolved implicit [[ParquetConverter]] instances for the value types in [[V]].
+   * @param defaults Resolved implicit [[Default]] instances for the value types in [[V]].
+   * @param keysArr `toArray[Symbol]` for the heterogeneous field names list [[K]].
+   * @param valsArr `toArray[Any]` for the heterogeneous values list [[V]].
+   * @param convArr `toArray[ParquetConverter[_]]` for the `converters` instances.
+   * @param defsArr `toArray[Default[_]]` for the `defaults` instances.
+   * @tparam A The product type for which a Parquet codec is being derived.
+   * @tparam R The generic record representation of [[A]], labelled with field names.
+   * @tparam K For each field in [[A]], the name of that field as a literal [[Symbol]] type.
+   * @tparam V For each field in [[A]], the type of its value, in the same order as [[K]].
+   * @tparam P For each value in [[V]], the resolved implicit [[ParquetConverter]] instance.
+   * @tparam D For each value in [[V]], the resolved implicit [[Default]] instance.
+   * @return A derived [[ParquetConverter]] instance for [[A]].
+   */
+  implicit def product[
+    A, R <: HList, K <: HList, V <: HList, P <: HList, D <: HList
+  ](implicit
+    gen: LabelledGeneric.Aux[A, R],
+    nonEmpty: IsHCons[R],
+    unzip: UnzipFields.Aux[R, K, V],
+    record: ZipWithKeys.Aux[K, V, R],
+    converters: LiftAll.Aux[ParquetConverter, V, P],
+    defaults: LiftAll.Aux[Default, V, D],
+    keysArr: ToArray[K, Symbol],
+    valsArr: ToArray[V, Any],
+    convArr: ToArray[P, ParquetConverter[_]],
+    defsArr: ToArray[D, Default[_]]
+  ): MkParquetConverter[A] = mk(new ParquetConverter[A] {
+    val keys = for (k <- keysArr(unzip.keys)) yield k.name
+    val conv = convArr(converters.instances).asInstanceOf[Array[ParquetConverter[Any]]]
+    val defs = defsArr(defaults.instances).asInstanceOf[Array[Default[Any]]]
+    val indx = keys.indices
+
+    val schema = new GroupType(OPTIONAL, defaultName,
+      (for (i <- indx) yield copy(conv(i).schema)(name = keys(i))): _*)
+
+    def reader(read: A => Unit, top: Boolean) = new GroupConverter {
+      val values  = for (d <- defs) yield d.value
+      val readers = for (i <- indx) yield conv(i).reader(values(i) = _)
+      def getConverter(i: Int) = readers(i)
+      def start() = for (i <- indx) values(i) = defs(i).value
+      def end() = read(gen.from(record(values.foldRight[HList](HNil)(_ :: _).asInstanceOf[V])))
+    }
+
+    def writer(consumer: RecordConsumer, top: Boolean) = {
+      val writers = for (c <- conv) yield c.writer(consumer)
+      def all(values: Array[Any]) = for (i <- indx)
+        if (!defs(i).empty(values(i))) field(consumer, keys(i), i) {
+          writers(i)(values(i))
+        }
+
+      value => if (value != null) {
+        val values = valsArr(unzip.values(gen.to(value)))
+        if (top) message(consumer) { all(values) }
+        else group(consumer) { all(values) }
+      }
+    }
+  })
+}

--- a/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetWriteSupport.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/parquet/ParquetWriteSupport.scala
@@ -18,7 +18,6 @@ package io.parquet
 
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.apache.parquet.hadoop.ParquetFileWriter
 import org.apache.parquet.hadoop.ParquetWriter
 import org.apache.parquet.hadoop.api.WriteSupport
 import org.apache.parquet.io.api._
@@ -55,36 +54,12 @@ private[parquet] object ParquetWriteSupport {
   def builder[A: ParquetConverter](file: Path): WriterBuilder[A] =
     new WriterBuilder[A](new ParquetWriteSupport, file)
 
-  class WriterBuilder[A](support: WriteSupport[A], file: Path) {
-
-    var conf = new Configuration()
-    var mode = ParquetFileWriter.Mode.CREATE
+  class WriterBuilder[A](support: WriteSupport[A], file: Path)
+    extends ParquetWriter.Builder[A, WriterBuilder[A]](file) {
 
     def getWriteSupport(conf: Configuration) = support
+
     def self() = this
-
-    def withConf(conf: Configuration): WriterBuilder[A] = {
-      this.conf = conf
-      this
-    }
-
-    def withWriteMode(mode: ParquetFileWriter.Mode): WriterBuilder[A] = {
-      this.mode = mode
-      this
-    }
-
-    def build(): ParquetWriter[A] = new ParquetWriter[A](
-      file,
-      mode,
-      support,
-      ParquetWriter.DEFAULT_COMPRESSION_CODEC_NAME,
-      ParquetWriter.DEFAULT_BLOCK_SIZE,
-      ParquetWriter.DEFAULT_PAGE_SIZE,
-      ParquetWriter.DEFAULT_PAGE_SIZE,
-      ParquetWriter.DEFAULT_IS_DICTIONARY_ENABLED,
-      ParquetWriter.DEFAULT_IS_VALIDATING_ENABLED,
-      ParquetWriter.DEFAULT_WRITER_VERSION,
-      conf
-    )
   }
+
 }

--- a/emma-language/src/main/scala/org/emmalanguage/util/Default.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/util/Default.scala
@@ -1,0 +1,88 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package util
+
+import scala.collection.generic.CanBuild
+import scala.language.higherKinds
+import scala.reflect.ClassTag
+
+/** Type class for providing a default value for type [[A]]. */
+trait Default[A] {
+  def value: A
+  def nullable: Boolean
+  def empty(x: A): Boolean
+}
+
+/** [[Default]] instances. */
+object Default extends DefaultLowPriority {
+  def apply[A: Default]: Default[A] = implicitly
+
+  implicit val string: Default[String] =
+    new Default[String] {
+      def value = ""
+      def nullable = true
+      def empty(x: String) = x == null || x.isEmpty
+    }
+
+  implicit def optional[A]: Default[Option[A]] =
+    new Default[Option[A]] {
+      def value = None
+      def nullable = true
+      def empty(x: Option[A]) = x == null || x.isEmpty || x.get == null
+    }
+
+  implicit def array[A: ClassTag]: Default[Array[A]] =
+    new Default[Array[A]] {
+      def value = Array.empty
+      def nullable = true
+      def empty(x: Array[A]) = x == null || x.isEmpty
+    }
+
+  implicit def traversable[T[x] <: Traversable[x], E](
+    implicit cbf: CanBuild[E, T[E]]
+  ): Default[T[E]] = new Default[T[E]] {
+    def value = cbf().result()
+    def nullable = true
+    def empty(x: T[E]) = x == null || x.isEmpty
+  }
+
+  implicit def map[M[k, v] <: Map[k, v], K, V](
+    implicit cbf: CanBuild[(K, V), M[K, V]]
+  ): Default[M[K, V]] = new Default[M[K, V]] {
+    def value = cbf().result()
+    def nullable = true
+    def empty(x: M[K, V]) = x == null || x.isEmpty
+  }
+}
+
+/** Low priority [[Default]] instances. */
+trait DefaultLowPriority {
+
+  implicit def anyVal[A <: AnyVal]: Default[A] =
+    new Default[A] {
+      def value = null.asInstanceOf[A]
+      def nullable = false
+      def empty(x: A) = false
+    }
+
+  implicit def anyRef[A >: Null <: AnyRef]: Default[A] =
+    new Default[A] {
+      def value = null
+      def nullable = true
+      def empty(x: A) = x == null
+    }
+}

--- a/emma-language/src/test/scala/org/emmalanguage/api/ScalaSeqSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/api/ScalaSeqSpec.scala
@@ -20,15 +20,12 @@ import io.csv.{CSV, CSVConverter}
 
 class ScalaSeqSpec extends DataBagSpec {
 
-  override type Bag[A] = ScalaSeq[A]
+  override type TestBag[A] = ScalaSeq[A]
   override type BackendContext = LocalEnv
 
-  override val Bag = ScalaSeq
+  override val TestBag = ScalaSeq
   override val suffix = "scala"
 
   override def withBackendContext[T](f: BackendContext => T): T =
     f(LocalEnv.apply)
-
-  override def readCSV[A: Meta : CSVConverter](path: String, format: CSV)(implicit unit: BackendContext): DataBag[A] =
-    ScalaSeq.readCSV(path, format)
 }

--- a/emma-spark/src/test/scala/org/emmalanguage/api/SparkDatasetSpec.scala
+++ b/emma-spark/src/test/scala/org/emmalanguage/api/SparkDatasetSpec.scala
@@ -22,15 +22,12 @@ import org.apache.spark.sql.SparkSession
 
 class SparkDatasetSpec extends DataBagSpec {
 
-  override type Bag[A] = SparkDataset[A]
+  override type TestBag[A] = SparkDataset[A]
   override type BackendContext = SparkSession
 
-  override val Bag = SparkDataset
+  override val TestBag = SparkDataset
   override val suffix = "spark-dataset"
 
   override def withBackendContext[T](f: BackendContext => T): T =
     LocalSparkSession.withSparkSession(f)
-
-  override def readCSV[A: Meta : CSVConverter](path: String, format: CSV)(implicit spark: SparkSession): DataBag[A] =
-    SparkDataset.readCSV(path, format)
 }

--- a/emma-spark/src/test/scala/org/emmalanguage/api/SparkRDDSpec.scala
+++ b/emma-spark/src/test/scala/org/emmalanguage/api/SparkRDDSpec.scala
@@ -22,15 +22,12 @@ import org.apache.spark.sql.SparkSession
 
 class SparkRDDSpec extends DataBagSpec {
 
-  override type Bag[A] = SparkRDD[A]
+  override type TestBag[A] = SparkRDD[A]
   override type BackendContext = SparkSession
 
-  override val Bag = SparkRDD
+  override val TestBag = SparkRDD
   override val suffix = "spark-rdd"
 
   override def withBackendContext[T](f: BackendContext => T): T =
     LocalSparkSession.withSparkSession(f)
-
-  override def readCSV[A : Meta : CSVConverter](path: String, format: CSV)(implicit ctx: BackendContext): DataBag[A] =
-    SparkRDD.readCSV[A](path, format)
 }

--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
         <spark.version>2.1.0</spark.version>
         <spark.indexedrdd.version>0.4.0</spark.indexedrdd.version>
         <!-- Parquet -->
-        <parquet.version>1.7.0</parquet.version>
+        <parquet.version>1.8.1</parquet.version>
 
         <!-- Logging -->
         <log4j.version>1.2.17</log4j.version>

--- a/scalastyle_config.xml
+++ b/scalastyle_config.xml
@@ -71,7 +71,7 @@
  </check>
  <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
   <parameters>
-   <parameter name="maxParameters"><![CDATA[8]]></parameter>
+   <parameter name="maxParameters"><![CDATA[10]]></parameter>
   </parameters>
  </check>
  <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">


### PR DESCRIPTION
* Unified schemas with Spark (reverse engineered):
    - `Option` and refence values treated as optional
    - `Traversable` values with nested group structure
    - `Byte`, `Short` and `Char` isomorphic to `Int`
* Added a `Default` type class for optional fields
* Added helper methods for writing a `message`, `group` or `field`
* Factored out derivation for case classes and reduced priority
* Increased max parameter number to 10 in `scalastyle_config`