### PR TITLE
[IR] Simplified ANF and DSCF to match spec closer

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/ast/Transversers.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Transversers.scala
@@ -293,9 +293,9 @@ trait Transversers { this: AST =>
       inherit { case api.Owner(sym) => sym } (last(default))
 
     /** Inherits the owner chain of the current node. */
-    def withOwnerChain = inherit(Attr.collect[Vector, Symbol] {
-      case api.Owner(sym) => sym
-    })
+    def withOwnerChain = inheritInit(Vector(api.Owner.encl)) {
+      case Attr.none(api.Owner(sym)) => Vector(sym)
+    }
 
     /** Synthesizes all term definitions contained in the current node and its children. */
     def withDefs = synthesize(Attr.group {
@@ -381,6 +381,12 @@ trait Transversers { this: AST =>
 
     override def transform(tree: Tree): Tree =
       at(tree)(super.transform(tree))
+
+    override def transformStats(stats: List[Tree], owner: Symbol) =
+      super.transformStats(stats, owner).filter {
+        case api.Empty(_) => false
+        case _ => true
+      }
 
     protected final def accTransform(tree: Tree): Tree = {
       accumulate(tree)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
@@ -18,10 +18,9 @@ package compiler.lang.core
 
 import compiler.Common
 import compiler.lang.source.Source
-import compiler.ir.DSCFAnnotations.suffix
+import compiler.ir.DSCFAnnotations._
 import util.Monoids._
 
-import cats.std.all._
 import shapeless._
 
 import scala.collection.breakOut
@@ -47,16 +46,16 @@ private[core] trait DSCF extends Common {
    *     ..prefix
    *     ..condStats
    *     val cond = condExpr
-   *     def suffix$1(..vars, res) = { .. }
-   *     def thn$1(..vars) = {
+   *     def suffix$1(res, ..vars) = { ... }
+   *     def thn$1() = {
    *       ..thnStats
-   *       suffix$1(..vars, thnExpr)
+   *       suffix$1(thnExpr, ..vars)
    *     }
-   *     def els$1(..vars) = {
+   *     def els$1() = {
    *       ..elsStats
-   *       suffix$1(..vars, elsExpr)
+   *       suffix$1(elsExpr, ..vars)
    *     }
-   *     if (cond) thn$1(..vars) else els$1(..vars)
+   *     if (cond) thn$1() else els$1()
    *   }
    *
    *   { // while loop
@@ -64,12 +63,12 @@ private[core] trait DSCF extends Common {
    *     def while$1(..vars) = {
    *       ..condStats
    *       val cond = condExpr
-   *       def body$1(..vars) = {
-   *         ..body
+   *       def body$1() = {
+   *         ..bodyStats
    *         while$1(..vars)
    *       }
-   *       def suffix$2(..vars) = { .. }
-   *       if (cond) body$1(..vars) else suffix$2(..vars)
+   *       def suffix$2() = { ... }
+   *       if (cond) body$1() else suffix$2()
    *     }
    *     while$1(..vars)
    *   }
@@ -77,11 +76,11 @@ private[core] trait DSCF extends Common {
    *   { // do-while loop
    *     ..prefix
    *     def doWhile$1(..vars) = {
-   *       ..body
+   *       ..bodyStats
    *       ..condStats
    *       val cond = condExpr
-   *       def suffix$3(..vars) = { .. }
-   *       if (cond) doWhile$1(..vars) else suffix$3(..vars)
+   *       def suffix$3() = { ... }
+   *       if (cond) doWhile$1(..vars) else suffix$3()
    *     }
    *     doWhile$3(..vars)
    *   }
@@ -89,23 +88,18 @@ private[core] trait DSCF extends Common {
    */
   private[core] object DSCF {
 
-    import u.Flag._
     import API.DSCFAnnotations._
     import UniverseImplicits._
+    import ANF.AsBlock
     import Core.{Lang => core}
     import Source.{Lang => src}
 
-    /** Creates a monomorphic method symbol (no type arguments, one parameter list). */
-    private def monomorphic(own: u.Symbol, nme: u.TermName,
-      pss: Seq[u.TermSymbol], res: u.Type, ann: u.Annotation
-    ): u.MethodSymbol = api.DefSym(own, nme, Seq.empty, Seq(pss), res, ans = Seq(ann))
+    private val noParams: Seq[Seq[u.TermSymbol]] = Seq(Seq.empty)
+    private val noArgs:   Seq[Seq[u.Tree]]       = Seq(Seq.empty)
 
     /** Ordering symbols by their name. */
     implicit private val byName: Ordering[u.TermSymbol] =
       Ordering.by(_.name.toString)
-
-    /** Attribute that tracks the two latest values of a variable. */
-    private type Trace = Map[(u.Symbol, u.TermName), List[u.TermSymbol]]
 
     /** The Direct-Style Control-Flow (DSCF) transformation. */
     lazy val transform: u.Tree => u.Tree = api.TopDown
@@ -113,35 +107,32 @@ private[core] trait DSCF extends Common {
       .synthesize(Attr.collect[SortedSet, u.TermSymbol] {
         // Collect all variable assignments in a set sorted by name.
         case src.VarMut(lhs, _) => lhs
-      }).accumulate { case core.DefDef(_, _, paramss, _) =>
-        // Accumulate all parameters (to refresh them at the end).
-        (for (core.ParDef(lhs, _) <- paramss.flatten) yield lhs).toVector
-      }.accumulateWith[Trace] {
-        // Accumulate the two latest values of a variable in a map per owner.
-        case Attr.inh(src.VarDef(lhs, _), owners :: _) =>
-          trace(lhs, owners)
-        case Attr.inh(src.VarMut(lhs, _), owners :: _) =>
-          trace(lhs, owners)
+      }).accumulateWith[Map[(u.Symbol, u.TermName), u.Tree]] {
+        // Accumulate the latest state of each variable per owner.
+        case Attr(VarState(x, rhs), latest :: _, owners :: _, _) =>
+          Map((owners.last, x.name) -> (rhs match {
+            case src.VarRef(y) => currentState(y, latest, owners)
+            case _ => rhs
+          }))
         case Attr.none(core.DefDef(method, _, paramss, _)) =>
-          (for (core.ParDef(lhs, _) <- paramss.flatten)
-            yield (method, lhs.name) -> List(lhs)).toMap
-      } (merge(sliding(2))).transformSyn {
-        // Linear transformations
-        case Attr(src.VarDef(lhs, rhs), trace :: _, owners :: _, _) =>
-          core.ValDef(latest(lhs, owners, trace).head, rhs)
-        case Attr(src.VarMut(lhs, rhs), trace :: _, owners :: _, _) =>
-          val curr #:: prev #:: _ = latest(lhs, owners, trace)
-          core.ValDef(curr, api.Tree.rename(Seq(lhs -> prev))(rhs))
-        case Attr(src.VarRef(lhs), trace :: _, owners :: _, _) =>
-          core.BindingRef(latest(lhs, owners, trace).head)
+          paramss.flatten.map { case core.ParDef(p, _) =>
+            (method, api.TermName.original(p.name)) -> core.Ref(p)
+          } (breakOut)
+      } (overwrite).transformSyn {
+        // Eliminate variables
+        case Attr.none(src.VarDef(_, _)) => api.Empty()
+        case Attr.none(src.VarMut(_, _)) => api.Empty()
+        case Attr(src.VarRef(x), latest :: _, owners :: _, _) =>
+          currentState(x, latest, owners)
 
-        // Control-flow elimination
-        case Attr(block @ src.Block(stats, expr), _, owners :: _, syn) =>
+        // Eliminate control-flow
+        case Attr(block @ src.Block(stats, expr), _, (_ :+ owner) :: _, syn) =>
           // Extract required attributes
           val tpe = expr.tpe
-          val owner = owners.lastOption.getOrElse(api.Owner.encl)
-          def uses(tree: u.Tree) = syn(tree)(Nat._2)
-          def mods(tree: u.Tree) = syn(tree) match { case ms :: ds :: _ => ms diff ds.keySet }
+          def uses(tree: u.Tree) = syn(tree).tail.tail.head
+          def mods(tree: u.Tree) = syn(tree) match {
+            case mods :: vars :: _ => mods diff vars.keySet
+          }
 
           stats.span { // Split blocks
             case src.ValDef(_, src.Branch(_, _, _)) => false
@@ -151,64 +142,48 @@ private[core] trait DSCF extends Common {
             // Linear
             case (_, Seq()) => block
 
-            // Already normalized
-            case (_, Seq(
-              core.ValDef(x, core.Branch(_,
-                core.Atomic(_) | core.DefCall(_, _, _, _),
-                core.Atomic(_) | core.DefCall(_, _, _, _))),
-              suffix@_*)) if (expr match {
-                case core.ValRef(`x`) => true
-                case _ => false
-              }) && suffix.forall {
-                case core.DefDef(_, _, _, _) => true
-                case _ => false
-              } => block
-
-            // If branch
+            // { ..prefix; val x = if (cond) thn else els; ..suffix; expr }
             case (prefix, Seq(src.ValDef(lhs, src.Branch(cond, thn, els)), suffix@_*)) =>
               // Suffix
-              val sufBody = src.Block(suffix, expr)
-              val sufUses = uses(sufBody)
-              val sufVars = (mods(thn) | mods(els)) & sufUses.keySet
-              val sufArgs = varArgs(sufVars)
-              val usesRes = sufUses(lhs) > 0
-              val sufPars = varPars(sufVars) ++ (if (usesRes) Some(lhs) else None)
-              val sufName = api.TermName.fresh("suffix")
-              val sufMeth = monomorphic(owner, sufName, sufPars, tpe, suffixAnn)
+              val suffBody = src.Block(suffix, expr)
+              val suffUses = uses(suffBody)
+              val lhsFree  = suffUses(lhs) > 0
+              val suffVars = ((mods(thn) | mods(els)) & suffUses.keySet).toSeq
+              val suffArgs = varArgs(suffVars)
+              val suffPars = if (lhsFree) lhs +: varPars(suffVars) else varPars(suffVars)
+              val suffName = api.TermName.fresh("suffix")
+              val suffMeth = monomorphic(owner, suffName, suffPars, tpe, suffixAnn)
+              val suffCont = core.DefDef(suffMeth, paramss = Seq(suffPars), body = suffBody)
 
-              def branchDefCall(name: u.TermName, body: u.Tree, ann: u.Annotation) = body match {
+              def branchCont(name: u.TermName, body: u.Tree, ann: u.Annotation) = body match {
                 case src.Block(branchStats, branchExpr) =>
                   val meth = monomorphic(owner, name, Seq.empty, tpe, ann)
-                  val call = core.DefCall(None, meth, argss = Seq(Seq.empty))
-                  val args = sufArgs ++ (if (usesRes) Some(branchExpr) else None)
-                  val defn = core.DefDef(meth, paramss = Seq(Seq.empty),
-                    body = src.Block(branchStats, core.DefCall(None, sufMeth, argss = Seq(args))))
-                  (Some(defn), call)
+                  val call = core.DefCall(None, meth, argss = noArgs)
+                  val args = if (lhsFree) branchExpr +: suffArgs else suffArgs
+                  val body = src.Block(branchStats, core.DefCall(None, suffMeth, argss = Seq(args)))
+                  val cont = core.DefDef(meth, paramss = noParams, body = body)
+                  (Some(cont), call)
 
                 case _ =>
-                  val call = core.DefCall(None, sufMeth,
-                    argss = Seq(sufArgs ++ (if (usesRes) Some(body) else None)))
+                  val argss = Seq(if (lhsFree) body +: suffArgs else suffArgs)
+                  val call  = core.DefCall(None, suffMeth, argss = argss)
                   (None, call)
               }
 
               // Branches
-              val (thnDefn, thnCall) = branchDefCall(api.TermName.fresh("then"), thn, thenAnn)
-              val (elsDefn, elsCall) = branchDefCall(api.TermName.fresh("else"), els, elseAnn)
-              src.Block(prefix ++ Seq(thnDefn, elsDefn,
-                Some(core.DefDef(sufMeth, paramss = Seq(sufPars), body = sufBody))
-              ).flatten, core.Branch(cond, thnCall, elsCall))
+              val (thnCont, thnCall) = branchCont(api.TermName.fresh("then"), thn, thenAnn)
+              val (elsCont, elsCall) = branchCont(api.TermName.fresh("else"), els, elseAnn)
+              src.Block(Seq.concat(prefix, Some(suffCont), thnCont, elsCont),
+                expr = core.Branch(cond, thnCall, elsCall))
 
-            // While loop
-            case (prefix, Seq(loop @ src.While(cond, src.Block(bodyStats, _)), suffix@_*)) =>
-              val (condStats, condExpr) = decompose(cond)
-
+            // { ..prefix; while ({ ..condStats; condExpr }) { ..bodyStats; () }; ..suffix; expr }
+            case (prefix, Seq(loop @ src.While(AsBlock(condStats, condExpr), AsBlock(bodyStats, _)), suffix@_*)) =>
               // Loop
-              val loopVars = mods(loop)
-              val loopArgs = varArgs(loopVars)
+              val loopVars = mods(loop).toSeq
               val loopPars = varPars(loopVars)
               val loopName = api.TermName.fresh("while")
               val loopMeth = monomorphic(owner, loopName, loopPars, tpe, whileAnn)
-              val loopCall = core.DefCall(None, loopMeth, argss = Seq(loopArgs))
+              val loopCall = core.DefCall(None, loopMeth, argss = Seq(varArgs(loopVars)))
 
               // Suffix
               val suffName = api.TermName.fresh("suffix")
@@ -221,43 +196,39 @@ private[core] trait DSCF extends Common {
               src.Block(prefix :+
                 core.DefDef(loopMeth, paramss = Seq(loopPars),
                   body = src.Block(condStats ++ Seq(
-                    core.DefDef(bodyMeth, paramss = Seq(Seq.empty),
+                    core.DefDef(bodyMeth, paramss = noParams,
                       body = src.Block(bodyStats, loopCall)),
-                    core.DefDef(suffMeth, paramss = Seq(Seq.empty),
+                    core.DefDef(suffMeth, paramss = noParams,
                       body = src.Block(suffix, expr))),
                     core.Branch(condExpr,
-                      core.DefCall(None, bodyMeth, argss = Seq(Seq.empty)),
-                      core.DefCall(None, suffMeth, argss = Seq(Seq.empty))))),
+                      thn = core.DefCall(None, bodyMeth, argss = noArgs),
+                      els = core.DefCall(None, suffMeth, argss = noArgs)))),
                 loopCall)
 
-            // Do-while loop
-            case (prefix, Seq(loop @ src.DoWhile(cond, src.Block(bodyStats, _)), suffix@_*)) =>
-              val (condStats, condExpr) = decompose(cond)
-
+            // { ..prefix; do { ..bodyStats; () } while ({ ..condStats; condExpr }); ..suffix; expr }
+            case (prefix, Seq(loop @ src.DoWhile(AsBlock(condStats, condExpr), AsBlock(bodyStats, _)), suffix@_*)) =>
               // Loop
-              val loopVars = mods(loop)
-              val loopArgs = varArgs(loopVars)
+              val loopVars = mods(loop).toSeq
               val loopPars = varPars(loopVars)
               val loopName = api.TermName.fresh("doWhile")
               val loopMeth = monomorphic(owner, loopName, loopPars, tpe, doWhileAnn)
-              val loopCall = core.DefCall(None, loopMeth, argss = Seq(loopArgs))
+              val loopCall = core.DefCall(None, loopMeth, argss = Seq(varArgs(loopVars)))
 
               // Suffix
-              val sufName = api.TermName.fresh("suffix")
-              val sufMeth = monomorphic(loopMeth, sufName, Seq.empty, tpe, suffixAnn)
+              val suffName = api.TermName.fresh("suffix")
+              val suffMeth = monomorphic(loopMeth, suffName, Seq.empty, tpe, suffixAnn)
 
               src.Block(prefix :+
                 core.DefDef(loopMeth, paramss = Seq(loopPars),
-                  body = src.Block(bodyStats ++ condStats ++ Seq(
-                    core.DefDef(sufMeth, paramss = Seq(Seq.empty),
-                      body = src.Block(suffix, expr))),
-                    core.Branch(condExpr, loopCall,
-                      core.DefCall(None, sufMeth, argss = Seq(Seq.empty))))),
+                  body = src.Block(
+                    stats = Seq.concat(bodyStats, condStats, Seq(
+                      core.DefDef(suffMeth, paramss = noParams,
+                        body = src.Block(suffix, expr)))),
+                    expr = core.Branch(condExpr, loopCall,
+                      els = core.DefCall(None, suffMeth, argss = noArgs)))),
                 loopCall)
           }
-      }.andThen { case Attr.acc(tree, _ :: params :: _) =>
-        api.Tree.refresh(params)(tree) // Refresh all DefDef parameters.
-      }
+      }._tree
 
     /** Applies `f` to the deepest suffix (i.e. without control flow) in a let block. */
     def mapSuffix(let: u.Block, res: Option[u.Type] = None)
@@ -303,31 +274,32 @@ private[core] trait DSCF extends Common {
     // Helper methods
     // ---------------
 
-    /** Decomposes a `tree` into statements and expression (if it's a block). */
-    private def decompose(tree: u.Tree) = tree match {
-      case src.Block(stats, expr) => (stats, expr)
-      case _ => (Seq.empty, tree)
+    /** Creates a monomorphic method symbol (no type arguments, one parameter list). */
+    private def monomorphic(own: u.Symbol, nme: u.TermName,
+      pss: Seq[u.TermSymbol], res: u.Type, ann: u.Annotation
+    ): u.MethodSymbol = api.DefSym(own, nme, Seq.empty, Seq(pss), res, ans = Seq(ann))
+
+    /** Converts a seqeunce of variable symbols to an argumenet list. */
+    private def varArgs(vars: Seq[u.TermSymbol]) =
+      for (x <- vars) yield src.Ref(x)
+
+    /** Converts a sequence of variable symbols to a parameter list. */
+    private def varPars(vars: Seq[u.TermSymbol]) =
+      for (x <- vars) yield api.ParSym(x.owner, api.TermName.fresh(x), x.info)
+
+    /** Looks up the current state of a variable, given an environment and the owner chain. */
+    private def currentState(x: u.TermSymbol,
+      latest: Map[(u.Symbol, u.TermName), u.Tree],
+      owners: Seq[u.Symbol]
+    ) = owners.reverseIterator.map(_ -> x.name).collectFirst(latest).get
+
+    /** Extractor for [[src.VarDef]] or [[src.VarMut]], i.e. a state change. */
+    private object VarState {
+      def unapply(tree: u.Tree): Option[(u.TermSymbol, u.Tree)] = tree match {
+        case src.VarDef(x, rhs) => Some(x, rhs)
+        case src.VarMut(x, rhs) => Some(x, rhs)
+        case _ => None
+      }
     }
-
-    /** Creates a fresh symbol for the latest value of a variable. */
-    private def trace(variable: u.TermSymbol, owners: Seq[u.Symbol]) = {
-      val owner = owners.lastOption.getOrElse(api.Owner.encl)
-      val name = api.TermName.fresh(variable)
-      val value = api.ValSym(owner, name, variable.info)
-      Map((owner, variable.name) -> List(value.asTerm))
-    }
-
-    /** Returns a stream of the latest values of a variable. */
-    private def latest(variable: u.TermSymbol, owners: Seq[u.Symbol], trace: Trace) =
-      (api.Owner.encl +: owners).reverseIterator
-        .flatMap(trace(_, variable.name).reverse).toStream
-
-    /** Variables -> Parameters mapping. */
-    private def varPars(vars: SortedSet[u.TermSymbol]): Seq[u.TermSymbol] =
-      vars.toSeq.map(api.Sym.With(_)(flg = PARAM).asTerm)
-
-    /** Variables -> Arguments mapping. */
-    private def varArgs(vars: SortedSet[u.TermSymbol]): Seq[u.Ident] =
-      vars.toSeq.map(src.VarRef(_))
   }
 }

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DSCFSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DSCFSpec.scala
@@ -17,11 +17,13 @@ package org.emmalanguage
 package compiler.lang.core
 
 import compiler.BaseCompilerSpec
+import compiler.ir.DSCFAnnotations._
 
 /** A spec for the `DSCF.lnf` transformation. */
 class DSCFSpec extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
 
   val dscfPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
@@ -36,74 +38,67 @@ class DSCFSpec extends BaseCompilerSpec {
 
   "While Loop" - {
     "with trivial body" in {
-
-      val act = dscfPipeline(u.reify {
+      val act = dscfPipeline(reify {
         var i = 0
-        while (i < 100) {
-          i += 1
-        }
+        while (i < 100) i += 1
         println(i)
       })
 
-      val exp = anfPipeline(u.reify {
-        val i$1 = 0
-        def while$1(i: Int): Unit = {
+      val exp = anfPipeline(reify {
+        @whileLoop def while$1(i: Int): Unit = {
           val x$1 = i < 100
-          def body$1(): Unit = {
+          @loopBody def body$1(): Unit = {
             val i$3 = i + 1
             while$1(i$3)
           }
-          def suffix$1(): Unit = {
+          @suffix def suffix$1(): Unit = {
             println(i)
           }
           if (x$1) body$1()
           else suffix$1()
         }
-        while$1(i$1)
+        while$1(0)
       })
 
       act shouldBe alphaEqTo(exp)
     }
 
     "with non-trivial body" in {
-
-      val act = dscfPipeline(u.reify {
+      val act = dscfPipeline(reify {
         var i = 0
-        while (i < 100) {
+        while (i < 100)
           if (i % 2 == 0) i += 2
           else i *= 2
-        }
         println(i)
       })
 
-      val exp = anfPipeline(u.reify {
-        val i$1 = 0
-        def while$1(i: Int): Unit = {
+      val exp = anfPipeline(reify {
+        @whileLoop def while$1(i: Int): Unit = {
           val x$1 = i < 100
-          def body$1(): Unit = {
+          @loopBody def body$1(): Unit = {
             val x$2 = i % 2
             val x$3 = x$2 == 0
-            def then$1(): Unit = {
+            @suffix def suffix$2(i$5: Int): Unit = {
+              while$1(i$5)
+            }
+            @thenBranch def then$1(): Unit = {
               val i$3 = i + 2
               suffix$2(i$3)
             }
-            def else$1(): Unit = {
+            @elseBranch def else$1(): Unit = {
               val i$4 = i * 2
               suffix$2(i$4)
-            }
-            def suffix$2(i$5: Int): Unit = {
-              while$1(i$5)
             }
             if (x$3) then$1()
             else else$1()
           }
-          def suffix$1(): Unit = {
+          @suffix def suffix$1(): Unit = {
             println(i)
           }
           if (x$1) body$1()
           else suffix$1()
         }
-        while$1(i$1)
+        while$1(0)
       })
 
       act shouldBe alphaEqTo(exp)
@@ -111,29 +106,24 @@ class DSCFSpec extends BaseCompilerSpec {
   }
 
   "Do-While Loop" - {
-
     "with trivial body" in {
-
-      val act = dscfPipeline(u.reify {
+      val act = dscfPipeline(reify {
         var i = 0
-        do {
-          i += 1
-        } while (i < 100)
+        do i += 1 while (i < 100)
         println(i)
       })
 
-      val exp = anfPipeline(u.reify {
-        val i$1 = 0
-        def doWhile$1(i$2: Int): Unit = {
+      val exp = anfPipeline(reify {
+        @doWhileLoop def doWhile$1(i$2: Int): Unit = {
           val i$3 = i$2 + 1
           val x$1 = i$3 < 100
-          def suffix$1(): Unit = {
+          @suffix def suffix$1(): Unit = {
             println(i$3)
           }
           if (x$1) doWhile$1(i$3)
           else suffix$1()
         }
-        doWhile$1(i$1)
+        doWhile$1(0)
       })
 
       act shouldBe alphaEqTo(exp)
@@ -141,7 +131,7 @@ class DSCFSpec extends BaseCompilerSpec {
 
     "with non-trivial body" in {
 
-      val act = dscfPipeline(u.reify {
+      val act = dscfPipeline(reify {
         var i = 0
         do {
           if (i % 2 == 0) i += 2
@@ -150,31 +140,30 @@ class DSCFSpec extends BaseCompilerSpec {
         println(i)
       })
 
-      val exp = anfPipeline(u.reify {
-        val i$1 = 0
-        def doWhile$1(i$2: Int): Unit = {
+      val exp = anfPipeline(reify {
+        @doWhileLoop def doWhile$1(i$2: Int): Unit = {
           val x$2 = i$2 % 2
           val x$3 = x$2 == 0
-          def then$1(): Unit = {
-            val i$3 = i$2 + 2
-            suffix$2(i$3)
-          }
-          def else$1(): Unit = {
-            val i$4 = i$2 * 2
-            suffix$2(i$4)
-          }
-          def suffix$2(i$5: Int): Unit = {
+          @suffix def suffix$2(i$5: Int): Unit = {
             val x$1 = i$5 < 100
-            def suffix$1(): Unit = {
+            @suffix def suffix$1(): Unit = {
               println(i$5)
             }
             if (x$1) doWhile$1(i$5)
             else suffix$1()
           }
+          @thenBranch def then$1(): Unit = {
+            val i$3 = i$2 + 2
+            suffix$2(i$3)
+          }
+          @elseBranch def else$1(): Unit = {
+            val i$4 = i$2 * 2
+            suffix$2(i$4)
+          }
           if (x$3) then$1()
           else else$1()
         }
-        doWhile$1(i$1)
+        doWhile$1(0)
       })
 
       act shouldBe alphaEqTo(exp)
@@ -182,18 +171,14 @@ class DSCFSpec extends BaseCompilerSpec {
   }
 
   "Taylor Series expansion for sin(x) around x = 0" in {
-
-    val act = dscfPipeline(u.reify {
+    val act = dscfPipeline(reify {
       val sin = (x: Double) => {
         val K = 13
         val xsq = x * x
-
         var k = 1
         var num = x
         var den = 1
-
         var S = 0.0
-
         do {
           val frac = num / den
           if (k % 2 == 0) S -= frac
@@ -204,48 +189,39 @@ class DSCFSpec extends BaseCompilerSpec {
         } while (k < K)
         S
       }
-
       sin(Math.PI / 2)
     })
 
-    val exp = anfPipeline(u.reify {
+    val exp = anfPipeline(reify {
       val sin = (x: Double) => {
         val K = 13
         val xsq = x * x
-
-        val k$1 = 1
-        val num$1 = x
-        val den$1 = 1
-
-        val S$1 = 0.0
-
-        def B$2(S$2: Double, den$2: Int, k$2: Int, num$2: Double): Double = {
+        @doWhileLoop def B$2(S$2: Double, den$2: Int, k$2: Int, num$2: Double): Double = {
           val frac = num$2 / den$2
           val c$1 = k$2 % 2 == 0
-          def B$3(): Double = {
-            val S$3 = S$2 - frac
-            B$5(S$3)
-          }
-          def B$4(): Double = {
-            val S$4 = S$2 + frac
-            B$5(S$4)
-          }
-          def B$5(S$5: Double): Double = {
+          @suffix def B$5(S$5: Double): Double = {
             val k$3 = k$2 + 1
             val num$3 = num$2 * xsq
             val den$3 = den$2 * ((2 * k$3 - 2) * (2 * k$3 - 1))
             val c$2 = k$3 < K
-            def B$6(): Double = {
+            @suffix def B$6(): Double = {
               S$5
             }
             if (c$2) B$2(S$5, den$3, k$3, num$3)
             else B$6()
           }
+          @thenBranch def B$3(): Double = {
+            val S$3 = S$2 - frac
+            B$5(S$3)
+          }
+          @elseBranch def B$4(): Double = {
+            val S$4 = S$2 + frac
+            B$5(S$4)
+          }
           if (c$1) B$3() else B$4()
         }
-        B$2(S$1, den$1, k$1, num$1)
+        B$2(0.0, 1, 1, x)
       }
-
       sin(Math.PI / 2)
     })
 
@@ -253,8 +229,7 @@ class DSCFSpec extends BaseCompilerSpec {
   }
 
   "Google Code Jam 2015 A1 - Haircut (verified)" in {
-
-    val act = dscfPipeline(u.reify {
+    val act = dscfPipeline(reify {
       implicit val zipSeqWithIdx = Seq.canBuildFrom[(Int, Int)]
       val customers = 4
       val barbers = Seq(10, 5)
@@ -278,53 +253,48 @@ class DSCFSpec extends BaseCompilerSpec {
       barber
     })
 
-    val exp = anfPipeline(u.reify {
+    val exp = anfPipeline(reify {
       implicit val zipSeqWithIdx = Seq.canBuildFrom[(Int, Int)]
       val customers = 4
       val barbers = Seq(10, 5)
-      val barber$1 = 0
       val rate = barbers.map(1.0 / _).sum
       val time$1 = ((0 max (customers - barbers.length - 1)) / rate).toLong - 1
       val less$1 = time$1 < 0
-      def else$1(): Int = {
-        val served$1 = barbers.map(time$1 / _ + 1).sum
-        suffix$1(served$1)
-      }
-      def suffix$1(served$2: Long): Int = {
+      @suffix def suffix$1(served$2: Long): Int = {
         val remaining$1 = customers - served$2
-        def while$1(barber$2: Int, remaining$2: Long, time$2: Long): Int = {
+        @whileLoop def while$1(barber$2: Int, remaining$2: Long, time$2: Long): Int = {
           val greater$1 = remaining$2 > 0
-          def body$1(): Int = {
+          @loopBody def body$1(): Int = {
             val time$4 = time$2 + barbers.map(b => b - time$2 % b).min
             val iter$1 = barbers.zipWithIndex.toIterator
             val bi$1 = null.asInstanceOf[(Int, Int)]
-            def while$2(barber$4: Int, bi$2: (Int, Int), remaining$4: Long): Int = {
+            @whileLoop def while$2(barber$4: Int, bi$2: (Int, Int), remaining$4: Long): Int = {
               val hasNext$1 = iter$1.hasNext
-              def body$2(): Int = {
+              @loopBody def body$2(): Int = {
                 val bi$4 = iter$1.next()
                 val b = bi$4._1
                 val i = bi$4._2
                 val eq$1 = time$4 % b == 0
-                def then$1(): Int = {
+                @suffix def suffix$3(barber$11: Int, remaining$8: Long): Int = {
+                  while$2(barber$11, bi$4, remaining$8)
+                }
+                @thenBranch def then$1(): Int = {
                   val remaining$7 = remaining$4 - 1
                   val eq$2 = remaining$7 == 0
-                  def then$2(): Int = {
+                  @suffix def suffix$2(barber$10: Int): Int = {
+                    suffix$3(barber$10, remaining$7)
+                  }
+                  @thenBranch def then$2(): Int = {
                     val barber$9 = i + 1
                     suffix$2(barber$9)
-                  }
-                  def suffix$2(barber$10: Int): Int = {
-                    suffix$3(barber$10, remaining$7)
                   }
                   if (eq$2) then$2()
                   else suffix$2(barber$4)
                 }
-                def suffix$3(barber$11: Int, remaining$8: Long): Int = {
-                  while$2(barber$11, bi$4, remaining$8)
-                }
                 if (eq$1) then$1()
                 else suffix$3(barber$4, remaining$4)
               }
-              def suffix$4(): Int = {
+              @suffix def suffix$4(): Int = {
                 while$1(barber$4, remaining$4, time$4)
               }
               if (hasNext$1) body$2()
@@ -332,22 +302,27 @@ class DSCFSpec extends BaseCompilerSpec {
             }
             while$2(barber$2, bi$1, remaining$2)
           }
-          def suffix$5(): Int = {
+          @suffix def suffix$5(): Int = {
             barber$2
           }
           if (greater$1) body$1()
           else suffix$5()
         }
-        while$1(barber$1, remaining$1, time$1)
+        while$1(0, remaining$1, time$1)
       }
-      if (less$1) suffix$1(0L) else else$1()
+      @elseBranch def else$1(): Int = {
+        val served$1 = barbers.map(time$1 / _ + 1).sum
+        suffix$1(served$1)
+      }
+      if (less$1) suffix$1(0L)
+      else else$1()
     })
 
     act shouldBe alphaEqTo(exp)
   }
 
   "Google Code Jam 2016 Qual - Counting sheep (verified)" in {
-    val act = dscfPipeline(u.reify {
+    val act = dscfPipeline(reify {
       val t1 = 1
       val step = 88
       if (step == 0) {
@@ -370,38 +345,38 @@ class DSCFSpec extends BaseCompilerSpec {
       }
     })
 
-    val exp = anfPipeline(u.reify {
+    val exp = anfPipeline(reify {
       val t1 = 1
       val step = 88
       val eq$1 = step == 0
-      def then$1(): Unit = {
+      @suffix def suffix$3(println$3: Unit): Unit = {
+        println$3
+      }
+      @thenBranch def then$1(): Unit = {
         val println$1 = println(s"Case #$t1: INSOMNIA")
         suffix$3(println$1)
       }
-      def else$1(): Unit = {
-        val sheep$1 = step
-        val digits$1 = 0
-        def while$1(digits$2: Int, sheep$2: Int): Unit = {
+      @elseBranch def else$1(): Unit = {
+        @whileLoop def while$1(digits$2: Int, sheep$2: Int): Unit = {
           val neq$1 = digits$2 != 1023
-          def body$1(): Unit = {
-            val current$1 = sheep$2
-            def while$2(current$2: Int, digits$4: Int): Unit = {
+          @loopBody def body$1(): Unit = {
+            @whileLoop def while$2(current$2: Int, digits$4: Int): Unit = {
               val neq$2 = current$2 != 0
-              def body$2(): Unit = {
+              @loopBody def body$2(): Unit = {
                 val digits$6 = digits$4 | (1 << (current$2 % 10))
                 val current$4 = current$2 / 10
                 while$2(current$4, digits$6)
               }
-              def suffix$1(): Unit = {
+              @suffix def suffix$1(): Unit = {
                 val sheep$4 = sheep$2 + step
                 while$1(digits$4, sheep$4)
               }
               if (neq$2) body$2()
               else suffix$1()
             }
-            while$2(current$1, digits$2)
+            while$2(sheep$2, digits$2)
           }
-          def suffix$2(): Unit = {
+          @suffix def suffix$2(): Unit = {
             val sheep$6 = sheep$2 - step
             val println$2 = println(s"Case #$t1: ${sheep$6}")
             suffix$3(println$2)
@@ -409,17 +384,17 @@ class DSCFSpec extends BaseCompilerSpec {
           if (neq$1) body$1()
           else suffix$2()
         }
-        while$1(digits$1, sheep$1)
+        while$1(0, step)
       }
-      def suffix$3(println$3: Unit): Unit = println$3
-      if (eq$1) then$1() else else$1()
+      if (eq$1) then$1()
+      else else$1()
     })
 
     act shouldBe alphaEqTo(exp)
   }
 
   "Google Code Jam 2016 Qual - Fractiles (verified)" in {
-    val act = dscfPipeline(u.reify {
+    val act = dscfPipeline(reify {
       val (tiles, complexity) = (2, 3)
       val one = BigInt(1)
       val necessary = tiles min complexity
@@ -430,8 +405,7 @@ class DSCFSpec extends BaseCompilerSpec {
         var level = 1
         while (level < necessary) {
           level += 1
-          tile = (tile - one) * tiles +
-            tile % tiles + one
+          tile = (tile - one) * tiles + tile % tiles + one
         }
 
         infoGain += level
@@ -442,43 +416,40 @@ class DSCFSpec extends BaseCompilerSpec {
       check.reverse.mkString(" ")
     })
 
-    val exp = anfPipeline(u.reify {
+    val exp = anfPipeline(reify {
       val (tiles, complexity) = (2, 3)
       val one = BigInt(1)
       val necessary = tiles min complexity
-      val infoGain$1 = 0
       val check$1 = List.empty[BigInt]
-      val tile$1 = one
-      def while$1(check$2: List[BigInt], infoGain$2: Int, tile$2: BigInt): String = {
+      @whileLoop def while$1(check$2: List[BigInt], infoGain$2: Int, tile$2: BigInt): String = {
         val less$1 = infoGain$2 < tiles
-        def body$1(): String = {
-          val level$1 = 1
-          def while$2(level$2: Int, tile$4: BigInt): String = {
+        @loopBody def body$1(): String = {
+          @whileLoop def while$2(level$2: Int, tile$4: BigInt): String = {
             val less$2 = level$2 < necessary
-            def body$2(): String = {
+            @loopBody def body$2(): String = {
               val level$4 = level$2 + 1
-              val tile$6 = (tile$4 - one) * tiles +
-                tile$4 % tiles + one
+              val tile$6 = (tile$4 - one) * tiles + tile$4 % tiles + one
               while$2(level$4, tile$6)
             }
-            def suffix$1(): String = {
+            @suffix def suffix$1(): String = {
               val infoGain$4 = infoGain$2 + level$2
               val check$4 = check$2.::(tile$4)
               val tile$9 = infoGain$4 + 1
-              while$1(check$4, infoGain$4, tile$9)
+              val tile$10: BigInt = tile$9
+              while$1(check$4, infoGain$4, tile$10)
             }
             if (less$2) body$2()
             else suffix$1()
           }
-          while$2(level$1, tile$2)
+          while$2(1, tile$2)
         }
-        def suffix$2(): String = {
+        @suffix def suffix$2(): String = {
           check$2.reverse.mkString(" ")
         }
         if (less$1) body$1()
         else suffix$2()
       }
-      while$1(check$1, infoGain$1, tile$1)
+      while$1(check$1, 0, one)
     })
 
     act shouldBe alphaEqTo(exp)

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/TrampolineSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/TrampolineSpec.scala
@@ -17,6 +17,7 @@ package org.emmalanguage
 package compiler.lang.core
 
 import compiler.BaseCompilerSpec
+import compiler.ir.DSCFAnnotations._
 
 import scala.util.control.TailCalls._
 
@@ -24,6 +25,7 @@ import scala.util.control.TailCalls._
 class TrampolineSpec extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
 
   val trampolinePipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
@@ -39,18 +41,14 @@ class TrampolineSpec extends BaseCompilerSpec {
     ).compose(_.tree)
 
   "Taylor Series expansion for sin(x) around x = 0" in {
-
-    val act = trampolinePipeline(u.reify {
+    val act = trampolinePipeline(reify {
       val sin = (x: Double) => {
         val K = 13
         val xsq = x * x
-
         var k = 1
         var num = x
         var den = 1
-
         var S = 0.0
-
         do {
           val frac = num / den
           if (k % 2 == 0) S -= frac
@@ -61,48 +59,39 @@ class TrampolineSpec extends BaseCompilerSpec {
         } while (k < K)
         S
       }
-
       sin(Math.PI / 2)
     })
 
-    val exp = anfPipeline(u.reify {
+    val exp = anfPipeline(reify {
       val sin = (x: Double) => {
         val K = 13
         val xsq = x * x
-
-        val k$1 = 1
-        val num$1 = x
-        val den$1 = 1
-
-        val S$1 = 0.0
-
-        def B$2(S$2: Double, den$2: Int, k$2: Int, num$2: Double): TailRec[Double] = {
+        @whileLoop def B$2(S$2: Double, den$2: Int, k$2: Int, num$2: Double): TailRec[Double] = {
           val frac = num$2 / den$2
           val c$1 = k$2 % 2 == 0
-          def B$3(): TailRec[Double] = {
-            val S$3 = S$2 - frac
-            tailcall(B$5(S$3))
-          }
-          def B$4(): TailRec[Double] = {
-            val S$4 = S$2 + frac
-            tailcall(B$5(S$4))
-          }
-          def B$5(S$5: Double): TailRec[Double] = {
+          @suffix def B$5(S$5: Double): TailRec[Double] = {
             val k$3 = k$2 + 1
             val num$3 = num$2 * xsq
             val den$3 = den$2 * ((2 * k$3 - 2) * (2 * k$3 - 1))
             val c$2 = k$3 < K
-            def B$6(): TailRec[Double] = {
+            @suffix def B$6(): TailRec[Double] = {
               done(S$5)
             }
             if (c$2) tailcall(B$2(S$5, den$3, k$3, num$3))
             else tailcall(B$6())
           }
+          @thenBranch def B$3(): TailRec[Double] = {
+            val S$3 = S$2 - frac
+            tailcall(B$5(S$3))
+          }
+          @elseBranch def B$4(): TailRec[Double] = {
+            val S$4 = S$2 + frac
+            tailcall(B$5(S$4))
+          }
           if (c$1) tailcall(B$3()) else tailcall(B$4())
         }
-        B$2(S$1, den$1, k$1, num$1).result
+        B$2(0.0, 1, 1, x).result
       }
-
       val sin$1 = sin(Math.PI / 2)
       sin$1
     })
@@ -111,8 +100,7 @@ class TrampolineSpec extends BaseCompilerSpec {
   }
 
   "Google Code Jam 2015 A1 - Haircut (verified)" in {
-
-    val act = trampolinePipeline(u.reify {
+    val act = trampolinePipeline(reify {
       implicit val zipSeqWithIdx = Seq.canBuildFrom[(Int, Int)]
       val customers = 4
       val barbers = Seq(10, 5)
@@ -136,53 +124,48 @@ class TrampolineSpec extends BaseCompilerSpec {
       barber
     })
 
-    val exp = anfPipeline(u.reify {
+    val exp = anfPipeline(reify {
       implicit val zipSeqWithIdx = Seq.canBuildFrom[(Int, Int)]
       val customers = 4
       val barbers = Seq(10, 5)
-      val barber$1 = 0
       val rate = barbers.map(1.0 / _).sum
       val time$1 = ((0 max (customers - barbers.length - 1)) / rate).toLong - 1
       val less$1 = time$1 < 0
-      def else$1(): TailRec[Int] = {
-        val served$1 = barbers.map(time$1 / _ + 1).sum
-        tailcall(suffix$1(served$1))
-      }
-      def suffix$1(served$2: Long): TailRec[Int] = {
+      @suffix def suffix$1(served$2: Long): TailRec[Int] = {
         val remaining$1 = customers - served$2
-        def while$1(barber$2: Int, remaining$2: Long, time$2: Long): TailRec[Int] = {
+        @whileLoop def while$1(barber$2: Int, remaining$2: Long, time$2: Long): TailRec[Int] = {
           val greater$1 = remaining$2 > 0
-          def body$1(): TailRec[Int] = {
+          @loopBody def body$1(): TailRec[Int] = {
             val time$4 = time$2 + barbers.map(b => b - time$2 % b).min
             val iter$1 = barbers.zipWithIndex.toIterator
             val bi$1 = null.asInstanceOf[(Int, Int)]
-            def while$2(barber$4: Int, bi$2: (Int, Int), remaining$4: Long): TailRec[Int] = {
+            @whileLoop def while$2(barber$4: Int, bi$2: (Int, Int), remaining$4: Long): TailRec[Int] = {
               val hasNext$1 = iter$1.hasNext
-              def body$2(): TailRec[Int] = {
+              @loopBody def body$2(): TailRec[Int] = {
                 val bi$4 = iter$1.next()
                 val b = bi$4._1
                 val i = bi$4._2
                 val eq$1 = time$4 % b == 0
-                def then$1(): TailRec[Int] = {
+                @suffix def suffix$3(barber$11: Int, remaining$8: Long): TailRec[Int] = {
+                  tailcall(while$2(barber$11, bi$4, remaining$8))
+                }
+                @thenBranch def then$1(): TailRec[Int] = {
                   val remaining$7 = remaining$4 - 1
                   val eq$2 = remaining$7 == 0
-                  def then$2(): TailRec[Int] = {
+                  @suffix def suffix$2(barber$10: Int): TailRec[Int] = {
+                    tailcall(suffix$3(barber$10, remaining$7))
+                  }
+                  @thenBranch def then$2(): TailRec[Int] = {
                     val barber$9 = i + 1
                     tailcall(suffix$2(barber$9))
-                  }
-                  def suffix$2(barber$10: Int): TailRec[Int] = {
-                    tailcall(suffix$3(barber$10, remaining$7))
                   }
                   if (eq$2) tailcall(then$2())
                   else tailcall(suffix$2(barber$4))
                 }
-                def suffix$3(barber$11: Int, remaining$8: Long): TailRec[Int] = {
-                  tailcall(while$2(barber$11, bi$4, remaining$8))
-                }
                 if (eq$1) tailcall(then$1())
                 else tailcall(suffix$3(barber$4, remaining$4))
               }
-              def suffix$4(): TailRec[Int] = {
+              @suffix def suffix$4(): TailRec[Int] = {
                 tailcall(while$1(barber$4, remaining$4, time$4))
               }
               if (hasNext$1) tailcall(body$2())
@@ -190,22 +173,27 @@ class TrampolineSpec extends BaseCompilerSpec {
             }
             tailcall(while$2(barber$2, bi$1, remaining$2))
           }
-          def suffix$5(): TailRec[Int] = {
+          @suffix def suffix$5(): TailRec[Int] = {
             done(barber$2)
           }
           if (greater$1) tailcall(body$1())
           else tailcall(suffix$5())
         }
-        tailcall(while$1(barber$1, remaining$1, time$1))
+        tailcall(while$1(0, remaining$1, time$1))
       }
-      if (less$1) suffix$1(0L).result else else$1().result
+      @elseBranch def else$1(): TailRec[Int] = {
+        val served$1 = barbers.map(time$1 / _ + 1).sum
+        tailcall(suffix$1(served$1))
+      }
+      if (less$1) suffix$1(0L).result
+      else else$1().result
     })
 
     act shouldBe alphaEqTo (exp)
   }
 
   "Google Code Jam 2016 Qual - Counting sheep (verified)" in {
-    val act = trampolinePipeline(u.reify {
+    val act = trampolinePipeline(reify {
       val t1 = 1
       val step = 88
       if (step == 0) {
@@ -228,38 +216,38 @@ class TrampolineSpec extends BaseCompilerSpec {
       }
     })
 
-    val exp = anfPipeline(u.reify {
+    val exp = anfPipeline(reify {
       val t1 = 1
       val step = 88
       val eq$1 = step == 0
-      def then$1(): TailRec[Unit] = {
+      @suffix def suffix$3(println$3: Unit): TailRec[Unit] = {
+        done(println$3)
+      }
+      @thenBranch def then$1(): TailRec[Unit] = {
         val println$1 = println(s"Case #$t1: INSOMNIA")
         tailcall(suffix$3(println$1))
       }
-      def else$1(): TailRec[Unit] = {
-        val sheep$1 = step
-        val digits$1 = 0
-        def while$1(digits$2: Int, sheep$2: Int): TailRec[Unit] = {
+      @elseBranch def else$1(): TailRec[Unit] = {
+        @whileLoop def while$1(digits$2: Int, sheep$2: Int): TailRec[Unit] = {
           val neq$1 = digits$2 != 1023
-          def body$1(): TailRec[Unit] = {
-            val current$1 = sheep$2
-            def while$2(current$2: Int, digits$4: Int): TailRec[Unit] = {
+          @loopBody def body$1(): TailRec[Unit] = {
+            @whileLoop def while$2(current$2: Int, digits$4: Int): TailRec[Unit] = {
               val neq$2 = current$2 != 0
-              def body$2(): TailRec[Unit] = {
+              @loopBody def body$2(): TailRec[Unit] = {
                 val digits$6 = digits$4 | (1 << (current$2 % 10))
                 val current$4 = current$2 / 10
                 tailcall(while$2(current$4, digits$6))
               }
-              def suffix$1(): TailRec[Unit] = {
+              @suffix def suffix$1(): TailRec[Unit] = {
                 val sheep$4 = sheep$2 + step
                 tailcall(while$1(digits$4, sheep$4))
               }
               if (neq$2) tailcall(body$2())
               else tailcall(suffix$1())
             }
-            tailcall(while$2(current$1, digits$2))
+            tailcall(while$2(sheep$2, digits$2))
           }
-          def suffix$2(): TailRec[Unit] = {
+          @suffix def suffix$2(): TailRec[Unit] = {
             val sheep$6 = sheep$2 - step
             val println$2 = println(s"Case #$t1: ${sheep$6}")
             tailcall(suffix$3(println$2))
@@ -267,17 +255,17 @@ class TrampolineSpec extends BaseCompilerSpec {
           if (neq$1) tailcall(body$1())
           else tailcall(suffix$2())
         }
-        tailcall(while$1(digits$1, sheep$1))
+        tailcall(while$1(0, step))
       }
-      def suffix$3(println$3: Unit): TailRec[Unit] = done(println$3)
-      if (eq$1) then$1().result else else$1().result
+      if (eq$1) then$1().result
+      else else$1().result
     })
 
     act shouldBe alphaEqTo (exp)
   }
 
   "Google Code Jam 2016 Qual - Fractiles (verified)" in {
-    val act = trampolinePipeline(u.reify {
+    val act = trampolinePipeline(reify {
       val (tiles, complexity) = (2, 3)
       val one = BigInt(1)
       val necessary = tiles min complexity
@@ -288,8 +276,7 @@ class TrampolineSpec extends BaseCompilerSpec {
         var level = 1
         while (level < necessary) {
           level += 1
-          tile = (tile - one) * tiles +
-            tile % tiles + one
+          tile = (tile - one) * tiles + tile % tiles + one
         }
 
         infoGain += level
@@ -300,43 +287,40 @@ class TrampolineSpec extends BaseCompilerSpec {
       check.reverse.mkString(" ")
     })
 
-    val exp = anfPipeline(u.reify {
+    val exp = anfPipeline(reify {
       val (tiles, complexity) = (2, 3)
       val one = BigInt(1)
       val necessary = tiles min complexity
-      val infoGain$1 = 0
       val check$1 = List.empty[BigInt]
-      val tile$1 = one
-      def while$1(check$2: List[BigInt], infoGain$2: Int, tile$2: BigInt): TailRec[String] = {
+      @whileLoop def while$1(check$2: List[BigInt], infoGain$2: Int, tile$2: BigInt): TailRec[String] = {
         val less$1 = infoGain$2 < tiles
-        def body$1(): TailRec[String] = {
-          val level$1 = 1
-          def while$2(level$2: Int, tile$4: BigInt): TailRec[String] = {
+        @loopBody def body$1(): TailRec[String] = {
+          @whileLoop def while$2(level$2: Int, tile$4: BigInt): TailRec[String] = {
             val less$2 = level$2 < necessary
-            def body$2(): TailRec[String] = {
+            @loopBody def body$2(): TailRec[String] = {
               val level$4 = level$2 + 1
-              val tile$6 = (tile$4 - one) * tiles +
-                tile$4 % tiles + one
+              val tile$6 = (tile$4 - one) * tiles + tile$4 % tiles + one
               tailcall(while$2(level$4, tile$6))
             }
-            def suffix$1(): TailRec[String] = {
+            @suffix def suffix$1(): TailRec[String] = {
               val infoGain$4 = infoGain$2 + level$2
               val check$4 = check$2.::(tile$4)
               val tile$9 = infoGain$4 + 1
-              tailcall(while$1(check$4, infoGain$4, tile$9))
+              val tile$10: BigInt = tile$9
+              tailcall(while$1(check$4, infoGain$4, tile$10))
             }
             if (less$2) tailcall(body$2())
             else tailcall(suffix$1())
           }
-          tailcall(while$2(level$1, tile$2))
+          tailcall(while$2(1, tile$2))
         }
-        def suffix$2(): TailRec[String] = {
+        @suffix def suffix$2(): TailRec[String] = {
           done(check$2.reverse.mkString(" "))
         }
         if (less$1) tailcall(body$1())
         else tailcall(suffix$2())
       }
-      while$1(check$1, infoGain$1, tile$1).result
+      while$1(check$1, 0, one).result
     })
 
     act shouldBe alphaEqTo (exp)


### PR DESCRIPTION
* `ANF`:
  - `var` definitions and assignments have only atoms on the RHS
  - added `AsBlock` extractor for blocks replacing `decompose`
  - added comments to clarify each case
  - removed redundant helper methods
* `DSCF`:
  - improved to one pass over AST (prev. two)
  - `latest` environment contains one value per owner per `var` (prev. two)
  - moved suffix definition before branches
  - added comments to clarify each case
  - adjusted `DSCFSpec` and `TrampolineSpec`
* `Core`: added `Comprehension` and `Continuation` matchers
* `Transversers`: empty trees in statement position are implicitly removed
* `TermName`, `TypeName`: improved fresh name generators