### PR TITLE
[IR] Refactored Normalize, PrettyPrintSpec, CombinationSpec

### DIFF
--- a/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
@@ -34,7 +34,6 @@ class FlinkMacro(val c: blackbox.Context) extends MacroCompiler with FlinkCompil
       Backend.addCacheCalls,
       Comprehension.combine,
       Backend.specialize(FlinkAPI),
-      Core.inlineLetExprs,
       Core.trampoline
     ).compose(_.tree)
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
@@ -306,9 +306,8 @@ trait Core extends Common
     lazy val lift: u.Tree => u.Tree = Function.chain(Seq(
       lnf,
       Comprehension.resugar(DataBag.sym),
-      inlineLetExprs,
-      Comprehension.normalize(DataBag.sym),
-      uninlineLetExprs))
+      Comprehension.normalize(DataBag.sym)
+    ))
 
     /** Chains [[ANF.transform]], and [[DSCF.transform]]. */
     lazy val lnf: u.Tree => u.Tree = anf andThen dscf
@@ -321,12 +320,6 @@ trait Core extends Common
 
     /** Delegates to [[ANF.flatten]]. */
     lazy val flatten = ANF.flatten
-
-    /** Delegates to [[ANF.inlineLetExprs]]. */
-    lazy val inlineLetExprs = ANF.inlineLetExprs
-
-    /** Delegates to [[ANF.uninlineLetExprs]]. */
-    lazy val uninlineLetExprs = ANF.uninlineLetExprs
 
     /** Delegates to [[DSCF.stripAnnotations]]. */
     lazy val stripAnnotations = DSCF.stripAnnotations

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
@@ -34,7 +34,6 @@ class SparkMacro(val c: blackbox.Context) extends MacroCompiler with SparkCompil
       Backend.addCacheCalls,
       Comprehension.combine,
       Backend.specialize(SparkAPI),
-      Core.inlineLetExprs,
       Core.trampoline
     ).compose(_.tree)
 }


### PR DESCRIPTION
The refactoring allows to remove `[un]inlineLetExprs` altogether and `Core.dce` from some pipelines.