### PR TITLE
[IR] Enabled Attr lookup by key in Transversers

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/ast/AST.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/AST.scala
@@ -16,8 +16,6 @@
 package org.emmalanguage
 package ast
 
-import shapeless._
-
 /** Common super-trait for macro- and runtime-compilation. */
 trait AST extends CommonAST
   with Bindings
@@ -50,6 +48,7 @@ trait AST extends CommonAST
     with ValueAPI
     with VariableAPI
 
+  import Attr._
   import universe._
   import internal._
   import reificationSupport._
@@ -78,7 +77,7 @@ trait AST extends CommonAST
   lazy val stubTypeTrees = api.TopDown.break
     .withParent.transformWith {
       // Leave `val/var` types to be inferred by the compiler.
-      case Attr.inh(api.TypeQuote(tpe), Some(api.BindingDef(lhs, rhs)) :: _)
+      case api.TypeQuote(tpe) ~@ Parent(Some(api.BindingDef(lhs, rhs)))
         if !lhs.isParameter && rhs.nonEmpty && tpe =:= rhs.tpe.dealias.widen =>
         api.TypeQuote.empty
       case Attr.none(api.TypeQuote(tpe)) =>
@@ -124,7 +123,7 @@ trait AST extends CommonAST
     }
 
     api.BottomUp.withParent.transformWith {
-      case Attr.inh(tree, Some(_: u.Block) :: _)
+      case tree ~@ Parent(Some(u.Block(_, _)))
         if isStat(tree) => tree
       case Attr.none(tree)
         if isStat(tree) => api.Block(Seq(tree))

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
@@ -58,7 +58,7 @@ private[comprehension] trait Combination extends Common {
      * - An ANF tree with no mock-comprehensions.
      */
     val transform: u.Tree => u.Tree =
-      api.TopDown.withOwner.transformWith {
+      api.TopDown.withOwner().transformWith {
         case Attr.inh(comp @ cs.Comprehension(_, _), owner :: _) =>
           combine(owner, comp)
       }.andThen(_.tree)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugar.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugar.scala
@@ -65,7 +65,7 @@ private[comprehension] trait ReDeSugar extends Common {
         arg -> core.DefCall(tgt, app, argss = Seq(Seq(core.ValRef(arg))))
       }
 
-      api.TopDown.withOwner.accumulate(Attr.group {
+      api.TopDown.withOwner().accumulate(Attr.group {
         // Accumulate a LHS -> (arg, body) Map from lambdas
         case core.ValDef(lhs, core.Lambda(_, Seq(core.ParDef(arg, _)), body)) =>
           lhs -> (arg, body)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/libsupport/LibSupport.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/libsupport/LibSupport.scala
@@ -206,7 +206,7 @@ trait LibSupport extends Common {
             .accumulate({
               case api.TermDef(s) => Set[u.Name](s.name)
             })
-            .withOwner
+            .withOwner()
             .transformWith({
               case Attr(DefCall(Some(TermRef(_)), `sym`, targs, argss), _, owner :: _, _) =>
                 // compute type bindings sequence

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/opt/FoldFusion.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/opt/FoldFusion.scala
@@ -201,7 +201,7 @@ private[compiler] trait FoldFusion extends Common {
      * }}}
      */
     def foldForestFusion(cfg: CFG.FlowGraph[u.TermSymbol]): u.Tree => u.Tree =
-      api.BottomUp.withOwner.transformWith {
+      api.BottomUp.withOwner().transformWith {
         // Fuse only folds within a single block.
         case Attr.inh(let @ core.Let(vals, defs, expr), owner :: _) =>
           val valIndex = lhs2rhs(vals)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/Foreach2Loop.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/Foreach2Loop.scala
@@ -54,7 +54,7 @@ private[source] trait Foreach2Loop extends Common {
     /** The Foreach2Loop transformation. */
     lazy val transform: u.Tree => u.Tree = {
       val asInst = api.Type.any.member(api.TermName("asInstanceOf")).asTerm
-      api.BottomUp.withOwner.withVarDefs.withAssignments
+      api.BottomUp.withOwner().withVarDefs.withAssigns
         .transformWith {
           case Attr.all(
             src.DefCall(xsOpt @ Some(xs), method, _,

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/PatternMatching.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/PatternMatching.scala
@@ -54,7 +54,7 @@ private[source] trait PatternMatching extends Common {
      * }}}
      */
     lazy val destruct: u.Tree => u.Tree =
-      api.BottomUp.withOwner.transformWith {
+      api.BottomUp.withOwner().transformWith {
         case Attr.inh(
           mat @ src.PatMat(target, Seq(src.PatCase(pat, src.Empty(_), body), _*)),
           owner :: _) =>

--- a/emma-language/src/main/scala/org/emmalanguage/util/Monoids.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/util/Monoids.scala
@@ -19,8 +19,9 @@ package util
 import cats.Monoid
 import quiver.Graph
 import shapeless._
+import shapeless.labelled._
 
-import scala.collection.SortedSet
+import scala.collection.immutable.SortedSet
 import scala.collection.generic.CanBuildFrom
 import scala.language.higherKinds
 
@@ -51,6 +52,14 @@ object Monoids {
       val empty = H.empty :: T.empty
       def combine(x: H :: T, y: H :: T) =
         H.combine(x.head, y.head) :: T.combine(x.tail, y.tail)
+    }
+
+  /** Generic field monoid. */
+  implicit def kv[K, V](implicit V: Monoid[V])
+    : Monoid[FieldType[K, V]] = new Monoid[FieldType[K, V]] {
+      def empty = field[K](V.empty)
+      def combine(x: FieldType[K, V], y: FieldType[K, V]) =
+        field[K](V.combine(x, y))
     }
 
   /** Trivial monoid with bias to the left. */

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
@@ -48,7 +48,7 @@ class CombinationSpec extends BaseCompilerSpec {
     ).compose(_.tree)
 
   def applyOnce(rule: (u.Symbol, u.Tree) => Option[u.Tree]): u.Expr[Any] => u.Tree = {
-    val transform = api.TopDown.withOwner.transformWith {
+    val transform = api.TopDown.withOwner().transformWith {
       case Attr.inh(tree, owner :: _) => rule(owner, tree).getOrElse(tree)
     }.andThen(_.tree)
 

--- a/emma-language/src/test/scala/org/emmalanguage/util/Equivalences.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/util/Equivalences.scala
@@ -19,7 +19,7 @@ package util
 import cats.Eq
 import shapeless._
 
-import scala.collection.SortedSet
+import scala.collection.immutable.SortedSet
 
 /** Missing instances of [[cats.Eq]]. */
 trait Equivalences {

--- a/emma-language/src/test/scala/org/emmalanguage/util/MonoidSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/util/MonoidSpec.scala
@@ -24,7 +24,7 @@ import org.scalatest._
 import org.scalatest.prop.Checkers
 import shapeless._
 
-import scala.collection.SortedSet
+import scala.collection.immutable.SortedSet
 
 class MonoidSpec extends FreeSpec with Checkers with Equivalences with Arbitraries {
 


### PR DESCRIPTION
Allows for order independent pattern matching of attributes
(instead of reversed order due to `HList` semantics).

Examples: `ANF`, `DSCF`, `Caching`