### PR TITLE
[TEST] Benchmarking infrastructure with ScalaMeter

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -49,7 +49,7 @@ This project includes:
   Apache XBean :: ASM 5 shaded (repackaged) under null or null
   ApacheDS I18n under The Apache Software License, Version 2.0
   ApacheDS Protocol Kerberos Codec under The Apache Software License, Version 2.0
-  ASM Core under Apache License, Version 2.0
+  ASM Core under BSD
   Bean Validation API under The Apache Software License, Version 2.0
   breeze under Apache 2
   breeze-macros under Apache 2
@@ -90,6 +90,7 @@ This project includes:
   discipline under MIT
   EL under The Apache Software License, Version 2.0
   emma under The Apache License, Version 2.0
+  emma-benchmarks under The Apache License, Version 2.0
   emma-examples under The Apache License, Version 2.0
   emma-examples-flink under The Apache License, Version 2.0
   emma-examples-library under The Apache License, Version 2.0
@@ -220,6 +221,8 @@ This project includes:
   scala-xml under BSD 3-clause
   scalacheck under BSD-style
   scalactic under the Apache License, ASL Version 2.0
+  scalameter under BSD-style
+  scalameter-core under BSD-style
   Scalap under BSD 3-Clause
   scalatest under the Apache License, ASL Version 2.0
   scalaz-core under BSD-style
@@ -244,7 +247,7 @@ This project includes:
   spray-json under Apache 2
   stream-lib under Apache License, Version 2.0
   Streaming API for XML under Sun Binary Code License
-  test-interface under BSD
+  test-interface under MIT
   The Netty Project under Apache License, Version 2.0
   Uncommons Maths under Apache License, Version 2.0
   univocity-parsers under Apache 2

--- a/emma-benchmarks/.gitignore
+++ b/emma-benchmarks/.gitignore
@@ -1,0 +1,41 @@
+# use glob syntax.
+syntax: glob
+*.ser
+*.class
+*~
+*.bak
+#*.off
+*.old
+
+# eclipse conf file
+.settings
+.classpath
+.project
+.manager
+.scala_dependencies
+
+# idea
+.idea
+*.iml
+
+# building
+target
+build
+null
+tmp*
+temp*
+dist
+test-output
+build.log
+
+# other scm
+.svn
+.CVS
+.hg*
+
+# switch to regexp syntax.
+#  syntax: regexp
+#  ^\.pc/
+
+#SHITTY output not in target directory
+build.log

--- a/emma-benchmarks/pom.xml
+++ b/emma-benchmarks/pom.xml
@@ -1,0 +1,121 @@
+<!--
+
+    Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>emma</artifactId>
+        <groupId>org.emmalanguage</groupId>
+        <version>0.2-SNAPSHOT</version>
+    </parent>
+
+
+    <artifactId>emma-benchmarks</artifactId>
+    <name>${project.artifactId}</name>
+
+    <properties>
+        <!-- Predicates -->
+        <scala-maven-plugin.skip>false</scala-maven-plugin.skip>
+        <scalastyle-maven-plugin.skip>false</scalastyle-maven-plugin.skip>
+        <scalatest-maven-plugin.skip>${skipTests}</scalatest-maven-plugin.skip>
+
+        <!-- Versions -->
+        <scalameter.version>0.8.2</scalameter.version>
+    </properties>
+
+    <dependencies>
+        <!-- Scala -->
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-library</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-compiler</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Emma -->
+        <dependency>
+            <groupId>org.emmalanguage</groupId>
+            <artifactId>emma-language</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.emmalanguage</groupId>
+            <artifactId>emma-examples-library</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <!-- Emma (test jars) -->
+        <dependency>
+            <groupId>org.emmalanguage</groupId>
+            <artifactId>emma-language</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>com.storm-enroute</groupId>
+            <artifactId>scalameter_${scala.tools.version}</artifactId>
+            <version>${scalameter.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.mongodb</groupId>
+                    <artifactId>casbah_${scala.tools.version}</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Build a test-jar -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>${maven-jar-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <properties>
+                <!-- Deployment configuration -->
+                <nexus.skipStaging>true</nexus.skipStaging>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/emma-benchmarks/src/test/scala/org/emmalanguage/compiler/benchmark/BaseCompilerBench.scala
+++ b/emma-benchmarks/src/test/scala/org/emmalanguage/compiler/benchmark/BaseCompilerBench.scala
@@ -1,0 +1,122 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler.benchmark
+
+import api._
+import api.Meta.Projections._
+import compiler.RuntimeCompiler
+import examples.graphs._
+import examples.graphs.model._
+import examples.imdb._
+import examples.ml.classification._
+import examples.ml.clustering._
+import examples.ml.model._
+import examples.text._
+import io.csv._
+import util.Iso
+
+import breeze.linalg._
+
+import org.scalameter._
+
+import shapeless.cachedImplicit
+
+import scala.reflect.ClassTag
+
+/** Common methods and mixins for all compier benchmarks. */
+trait BaseCompilerBench extends Bench.OnlineRegressionReport {
+
+  val compiler = RuntimeCompiler.default.instance
+  import compiler._
+  import universe.reify
+
+  val csv   = CSV()
+  val input = "/tmp/dummy.csv"
+
+  // ToolBox.typecheck can't handle type class derivation.
+  implicit val edgeCSVConverter:  CSVConverter[Edge[Long]]      = cachedImplicit
+  implicit val lvecCSVConverter:  CSVConverter[LVector[String]] = cachedImplicit
+  implicit val pointCSVConverter: CSVConverter[Point[Long]]     = cachedImplicit
+  implicit def breezeVecCSVConverter[A: ClassTag: CSVColumn]: CSVConverter[Vector[A]] =
+    CSVConverter.iso[Array[A], Vector[A]](Iso.make(DenseVector.apply, _.toArray), implicitly)
+
+  // ---------------------------------------------------------------------------
+  // Transformation pipelines
+  // ---------------------------------------------------------------------------
+
+  val expandPipeline: u.Expr[Any] => u.Tree =
+    compiler.pipeline(typeCheck = true)(
+      LibSupport.expand
+    ).compose(_.tree)
+
+  // ---------------------------------------------------------------------------
+  // Benchmarking examples
+  // ---------------------------------------------------------------------------
+
+  val connectedComponents = reify {
+    val edges = DataBag.readCSV[Edge[Long]](input, csv)
+    ConnectedComponents(edges)
+  }
+
+  val enumerateTriangles = reify {
+    val edges = DataBag.readCSV[Edge[Long]](input, csv)
+    EnumerateTriangles(edges)
+  }
+
+  val transitiveClosure = reify {
+    val edges = DataBag.readCSV[Edge[Long]](input, csv)
+    TransitiveClosure(edges)
+  }
+
+  val directorsMuses = reify {
+    DirectorsMuses(input, csv)("John Doe")
+  }
+
+  // FIXME: Doesn't work
+  //  val graphPreprocessing = reify {
+  //    GraphPreprocessing(input, csv) {
+  //      _.count(c => c.director == c.actor)
+  //    }
+  //  }
+
+  val naiveBayes = reify {
+    val modelType = NaiveBayes.ModelType.Bernoulli
+    val data = DataBag.readCSV[LVector[String]](input, csv)
+    NaiveBayes(1.0, modelType)(data)
+  }
+
+  val kMeans = reify {
+    val points = DataBag.readCSV[Point[Long]](input, csv)
+    KMeans[Long](8, 1e-3, 10)(points)
+  }
+
+  val wordCount = reify {
+    val documents = DataBag.readText(input)
+    WordCount(documents)
+  }
+
+  val examples = Seq(
+    connectedComponents,
+    enumerateTriangles,
+    transitiveClosure,
+    directorsMuses,
+    //graphPreprocessing,
+    naiveBayes,
+    kMeans,
+    wordCount
+  ).map(expandPipeline)
+}

--- a/emma-benchmarks/src/test/scala/org/emmalanguage/compiler/benchmark/core/ANFBench.scala
+++ b/emma-benchmarks/src/test/scala/org/emmalanguage/compiler/benchmark/core/ANFBench.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package compiler.benchmark.core
+
+import compiler.benchmark.BaseCompilerBench
+
+import org.scalacheck.Gen._
+import org.scalameter.Gen
+
+/** Benchmark for the ANF transformation. */
+object ANFBench extends BaseCompilerBench {
+
+  import compiler._
+
+  val data = for (n <- Gen.range("# Examples")(10, 50, 10))
+    yield listOfN(n, oneOf(examples)).sample.get
+
+  performance of "ANF" in {
+    using(data) curve "Transversers API" in { _ foreach Core.anf }
+  }
+}

--- a/emma-examples/emma-examples-library/src/main/scala/org/emmalanguage/examples/ml/classification/NaiveBayes.scala
+++ b/emma-examples/emma-examples-library/src/main/scala/org/emmalanguage/examples/ml/classification/NaiveBayes.scala
@@ -33,6 +33,10 @@ object NaiveBayes {
   )(
     data: DataBag[LVector[L]] // data-parameters
   ): DataBag[Model[L]] = {
+    // Required for expanding at runtime.
+    // FIXME: Come up with a better Meta scheme.
+    implicit val lCTag = ctagFor[L]
+    implicit val lTTag = ttagFor[L]
     val dimensions = data.map(_.vector.length).distinct.fetch()
     assert(dimensions.size == 1, "Multiple dimensions in input data. All vectors should have the same length.")
     val N = dimensions.head

--- a/emma-examples/emma-examples-library/src/main/scala/org/emmalanguage/examples/ml/clustering/KMeans.scala
+++ b/emma-examples/emma-examples-library/src/main/scala/org/emmalanguage/examples/ml/clustering/KMeans.scala
@@ -31,7 +31,10 @@ object KMeans {
   )(
     points: DataBag[Point[PID]] // data-parameters
   ): DataBag[Solution[PID]] = {
-
+    // Required for expanding at runtime.
+    // FIXME: Come up with a better Meta scheme.
+    implicit val pidCTag = ctagFor[PID]
+    implicit val pidTTag = ttagFor[PID]
     val dimensions = points.map(_.vector.length).distinct.fetch()
     assert(dimensions.size == 1,
       "Multiple dimensions in input data. All vectors should have the same length.")

--- a/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/FlinkDataSet.scala
@@ -29,7 +29,6 @@ import org.apache.flink.configuration.Configuration
 import org.apache.flink.core.fs.FileSystem
 import org.apache.flink.util.Collector
 
-import scala.language.higherKinds
 import scala.language.implicitConversions
 import scala.util.hashing.MurmurHash3
 

--- a/emma-flink/src/main/scala/org/emmalanguage/api/flink/FlinkOps.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/api/flink/FlinkOps.scala
@@ -21,7 +21,6 @@ import api.alg._
 import api.backend.ComprehensionCombinators
 import api.backend.Runtime
 
-import scala.language.higherKinds
 import org.apache.flink.api.java.io.TypeSerializerInputFormat
 import org.apache.flink.api.java.io.TypeSerializerOutputFormat
 import org.apache.flink.api.scala.DataSet

--- a/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
@@ -18,7 +18,6 @@ package compiler
 
 import com.typesafe.config.Config
 
-import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
 class FlinkMacro(val c: blackbox.Context) extends MacroCompiler with FlinkCompiler {

--- a/emma-flink/src/test/scala/org/emmalanguage/compiler/flink/dataset/FlinkCodegenIntegrationSpec.scala
+++ b/emma-flink/src/test/scala/org/emmalanguage/compiler/flink/dataset/FlinkCodegenIntegrationSpec.scala
@@ -26,10 +26,10 @@ import org.apache.flink.api.scala.DataSet
 import org.apache.flink.api.scala.ExecutionEnvironment
 
 class FlinkCodegenIntegrationSpec extends BaseCodegenIntegrationSpec with FlinkAware {
-
-  override lazy val compiler = new RuntimeCompiler with FlinkCompiler
+  override val compiler = new RuntimeCompiler with FlinkCompiler
 
   import compiler._
+  import universe.reify
 
   type Env = ExecutionEnvironment
 
@@ -43,7 +43,7 @@ class FlinkCodegenIntegrationSpec extends BaseCodegenIntegrationSpec with FlinkA
   // Distributed collection conversion
   // --------------------------------------------------------------------------
 
-  "Convert from/to a Flink DataSet" in verify(u.reify {
+  "Convert from/to a Flink DataSet" in verify(reify {
     val xs = DataBag(1 to 1000).withFilter(_ > 800)
     val ys = xs.as[DataSet].filter(_ < 200)
     val zs = DataBag.from(ys)

--- a/emma-language/src/main/scala/org/emmalanguage/api/ScalaSeq.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/ScalaSeq.scala
@@ -21,7 +21,6 @@ import io.csv._
 import io.parquet._
 import io.text._
 
-import scala.language.higherKinds
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.reflect.runtime.universe._

--- a/emma-language/src/main/scala/org/emmalanguage/api/alg/Alg.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/alg/Alg.scala
@@ -21,7 +21,6 @@ import api.Meta
 
 import scala.Function.const
 import scala.annotation.tailrec
-import scala.util.Random
 
 /**
  * A (non-initial) union-representation algebra.

--- a/emma-language/src/main/scala/org/emmalanguage/api/emma/QuoteMacro.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/emma/QuoteMacro.scala
@@ -18,7 +18,6 @@ package api.emma
 
 import compiler.MacroCompiler
 
-import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
 class QuoteMacro(val c: blackbox.Context) extends MacroCompiler {

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
@@ -27,7 +27,7 @@ trait Terms { this: AST =>
     /** Term names. */
     object TermName extends Node {
 
-      private val regex = s"(.*)\\$$$freshNameSuffix.*".r
+      private val regex = s"(.*)\\$$$freshNameSuffix(\\d+)".r
 
       // Predefined term names
       lazy val anon      = apply("anon")
@@ -77,9 +77,9 @@ trait Terms { this: AST =>
         if (is.defined(prefix)) fresh(prefix.name) else fresh()
 
       /** Tries to return the original name used to create this `fresh` name. */
-      def original(fresh: u.Name): u.TermName = fresh match {
-        case u.TermName(regex(original)) => u.TermName(original)
-        case _ => fresh.toTermName
+      def original(fresh: u.Name): (u.TermName, Int) = fresh match {
+        case u.TermName(regex(original, i)) => u.TermName(original) -> i.toInt
+        case _ => fresh.toTermName -> 0
       }
 
       def unapply(name: u.TermName): Option[String] =

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Transversers.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Transversers.scala
@@ -216,7 +216,7 @@ trait Transversers { this: AST =>
 
     /** Prepends an accumulated attribute based on trees only. */
     def accumulate[X: Monoid](acc: Tree =?> X) =
-      accumulateWith[X](forgetful(acc))
+      accumulateWith[X](compose(acc)(_.tree))
 
     /** Prepends an inherited attribute based on inherited and synthesized attributes. */
     def inheritInit[X: Monoid](init: X)(inh: Attr[HNil, X :: I, S] =?> X) =
@@ -228,7 +228,7 @@ trait Transversers { this: AST =>
 
     /** Prepends an inherited attribute based on trees only. */
     def inherit[X: Monoid](inh: Tree =?> X) =
-      inheritWith[X](forgetful(inh))
+      inheritWith[X](compose(inh)(_.tree))
 
     /** Prepends a synthesized attribute based on all synthesized attributes. */
     def synthesizeInit[X: Monoid](init: X)(syn: Attr[HNil, HNil, X :: S] =?> X) =
@@ -240,7 +240,7 @@ trait Transversers { this: AST =>
 
     /** Prepends a synthesized attribute based on trees only. */
     def synthesize[X: Monoid](syn: Tree =?> X) =
-      synthesizeWith[X](forgetful(syn))
+      synthesizeWith[X](compose(syn)(_.tree))
 
     /** Traverses a tree with access to all attributes (and a memoized synthesis function). */
     def traverseSyn(callback: Attr[A, I, Tree => S] =?> Unit): Traversal[A, I, S] = {
@@ -258,7 +258,7 @@ trait Transversers { this: AST =>
 
     /** Traverses a tree without access to attributes. */
     def traverse(callback: Tree =?> Unit): Traversal[A, I, S] =
-      traverseWith(forgetful(callback))
+      traverseWith(compose(callback)(_.tree))
 
     /** Shortcut for visiting every node in a tree. */
     def traverseAny: Traversal[A, I, S] =
@@ -280,7 +280,7 @@ trait Transversers { this: AST =>
 
     /** Transforms a tree without access to attributes. */
     def transform(template: Tree =?> Tree): Transform[A, I, S] =
-      transformWith(forgetful(template))
+      transformWith(compose(template)(_.tree))
 
     /** Inherits the root of the tree ([[None]] if the current node is the root). */
     def withRoot = inherit(partial(Option.apply))(first(None))
@@ -368,11 +368,6 @@ trait Transversers { this: AST =>
     def withDefCalls = synthesize(Attr.group {
       case api.DefCall(_, method, _, _) => method -> 1
     })(merge)
-
-    /** Converts a partial function over trees to a partial function over attributed trees. */
-    private def forgetful[X, Acc, Inh, Syn](pf: Tree =?> X): Attr[Acc, Inh, Syn] =?> X = {
-      case Attr.none(t) if pf.isDefinedAt(t) => pf(t)
-    }
   }
 
   /** An abstract transformation (default is top-down break). */

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Types.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Types.scala
@@ -30,7 +30,7 @@ trait Types { this: AST =>
     /** Type names. */
     object TypeName extends Node {
 
-      private val regex = s"(.*)\\$$$freshNameSuffix.*".r
+      private val regex = s"(.*)\\$$$freshNameSuffix(\\d+)".r
 
       // Predefined type names
       lazy val empty    = u.typeNames.EMPTY
@@ -71,9 +71,9 @@ trait Types { this: AST =>
         if (is.defined(prefix)) fresh(prefix.name) else fresh()
 
       /** Tries to return the original name used to create this `fresh` name. */
-      def original(fresh: u.Name): u.TypeName = fresh match {
-        case u.TypeName(regex(original)) => u.TypeName(original)
-        case _ => fresh.toTypeName
+      def original(fresh: u.Name): (u.TypeName, Int) = fresh match {
+        case u.TypeName(regex(original, i)) => u.TypeName(original) -> i.toInt
+        case _ => fresh.toTypeName -> 0
       }
 
       def unapply(name: u.TypeName): Option[String] =

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/API.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/API.scala
@@ -23,8 +23,8 @@ protected[emmalanguage] trait API extends AST {
 
   import UniverseImplicits._
 
-  trait ReflectedSymbol[Symbol <: u.Symbol] {
-    def sym: Symbol
+  trait ReflectedSymbol[S <: u.Symbol] {
+    def sym: S
 
     def ops: Set[u.MethodSymbol]
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Backend.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/backend/Backend.scala
@@ -26,8 +26,6 @@ trait Backend extends Common
   with Specialization {
   this: Core =>
 
-  import UniverseImplicits._
-
   object Backend {
 
     /** Delegates to [[Specialization.specialize]]. */

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
@@ -116,7 +116,7 @@ private[core] trait DSCF extends Common {
           }))
         case Attr.none(core.DefDef(method, _, paramss, _)) =>
           paramss.flatten.map { case core.ParDef(p, _) =>
-            (method, api.TermName.original(p.name)) -> core.Ref(p)
+            (method, api.TermName.original(p.name)._1) -> core.Ref(p)
           } (breakOut)
       } (overwrite).transformSyn {
         // Eliminate variables

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Pickling.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Pickling.scala
@@ -25,8 +25,6 @@ import scala.Function.const
 private[core] trait Pickling extends Common {
   this: Source with Core =>
 
-  import UniverseImplicits._
-
   private[core] object Pickle {
 
     type D = Int => String // semantic domain (offset => string representation)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/opt/FoldForestFusion.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/opt/FoldForestFusion.scala
@@ -106,7 +106,10 @@ private[compiler] trait FoldForestFusion extends Common {
 
     private lazy val cs = new Comprehension.Syntax(API.DataBag.sym)
 
-    private val ordTermSymbol = Ordering.by((s: u.TermSymbol) => s.name.toString)
+    private val ordTermSymbol = Ordering.by { (s: u.TermSymbol) =>
+      val (name, i) = api.TermName.original(s.name)
+      name.toString -> i
+    }
 
     /** Constructs an index from a sequence of key-value pairs. */
     private def mkIndex(elems: (u.TermSymbol, u.Tree)*): Index =

--- a/emma-language/src/main/scala/org/emmalanguage/io/csv/CSVScalaSupport.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/csv/CSVScalaSupport.scala
@@ -16,7 +16,6 @@
 package org.emmalanguage
 package io.csv
 
-import io.Format
 import io.ScalaSupport
 
 import com.univocity.parsers.csv.CsvParser
@@ -25,12 +24,10 @@ import com.univocity.parsers.csv.CsvWriter
 import com.univocity.parsers.csv.CsvWriterSettings
 import resource._
 
-import scala.language.experimental.macros
-
 import java.io._
 import java.net.URI
 
-/** A [[ScalaSupport]] implementation for the [[CSV]] [[Format]]. */
+/** A [[ScalaSupport]] implementation for the [[CSV]] [[io.Format]]. */
 class CSVScalaSupport[A](val format: CSV)(implicit conv: CSVConverter[A])
   extends ScalaSupport[A, CSV] {
 

--- a/emma-language/src/main/scala/org/emmalanguage/io/parquet/MkParquetConverter.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/parquet/MkParquetConverter.scala
@@ -24,8 +24,6 @@ import shapeless._
 import shapeless.ops.hlist._
 import shapeless.ops.record._
 
-import scala.language.higherKinds
-
 /** Implicit [[ParquetConverter]] privder. */
 trait MkParquetConverter[A] extends (() => ParquetConverter[A])
 

--- a/emma-language/src/main/scala/org/emmalanguage/io/text/TextSupport.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/io/text/TextSupport.scala
@@ -21,8 +21,6 @@ import io.ScalaSupport
 
 import resource._
 
-import scala.language.experimental.macros
-
 import java.io._
 import java.net.URI
 import java.nio.charset.StandardCharsets

--- a/emma-language/src/main/scala/org/emmalanguage/macros/utility/UtilMacros.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/macros/utility/UtilMacros.scala
@@ -18,7 +18,6 @@ package macros.utility
 
 import compiler.MacroCompiler
 
-import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
 class UtilMacros(val c: blackbox.Context) extends MacroCompiler {

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/ASTSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/ASTSpec.scala
@@ -19,13 +19,15 @@ package compiler
 class ASTSpec extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
+
   object Bal
 
   "method calls should" - {
     "resolve overloaded symbols" in {
-      val seq = compiler.typeCheck(u.reify(Seq).tree)
+      val seq = compiler.typeCheck(reify(Seq).tree)
       val fill = api.Type[Seq.type].member(api.TermName("fill")).asTerm
-      val examples = compiler.typeCheck(u.reify {(
+      val examples = compiler.typeCheck(reify {(
         Seq.fill(1)('!'),
         Seq.fill(1, 2)('!'),
         Seq.fill(1, 2, 3)('!')
@@ -61,7 +63,7 @@ class ASTSpec extends BaseCompilerSpec {
 
   "dynamic objects should" - {
     "remain qualified" in {
-      val bal = compiler.typeCheck(u.reify(Bal).tree)
+      val bal = compiler.typeCheck(reify(Bal).tree)
       val ref = api.TermRef(bal.symbol.asTerm)
       val act = unQualifyStatics(bal)
       act should not be alphaEqTo (ref)

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCompilerSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCompilerSpec.scala
@@ -31,8 +31,7 @@ import java.util.UUID
  */
 trait BaseCompilerSpec extends FreeSpec with Matchers with PropertyChecks with TreeMatchers {
 
-  lazy val compiler = RuntimeCompiler.default.instance
-
+  val compiler = RuntimeCompiler.default.instance
   import compiler._
 
   // ---------------------------------------------------------------------------

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/AlphaEqSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/AlphaEqSpec.scala
@@ -22,15 +22,16 @@ import compiler.BaseCompilerSpec
 class AlphaEqSpec extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
 
   "simple valdefs and expressions" in {
-    val lhs = idPipeline(u.reify {
+    val lhs = idPipeline(reify {
       val a$01 = 42 * x
       val a$02 = a$01 * t._1
       15 * a$01 * a$02
     })
 
-    val rhs = idPipeline(u.reify {
+    val rhs = idPipeline(reify {
       val b$01 = 42 * x
       val b$02 = b$01 * t._1
       15 * b$01 * b$02
@@ -40,12 +41,12 @@ class AlphaEqSpec extends BaseCompilerSpec {
   }
 
   "conditionals" in {
-    val lhs = idPipeline(u.reify {
+    val lhs = idPipeline(reify {
       val a$01 = 42 * x
       if (x < 42) x * t._1 else x / a$01
     })
 
-    val rhs = idPipeline(u.reify {
+    val rhs = idPipeline(reify {
       val b$01 = 42 * x
       if (x < 42) x * t._1 else x / b$01
     })
@@ -54,7 +55,7 @@ class AlphaEqSpec extends BaseCompilerSpec {
   }
 
   "variable assignment and loops" in {
-    val lhs = idPipeline(u.reify {
+    val lhs = idPipeline(reify {
       var u = x
       while (u < 20) {
         println(y)
@@ -66,7 +67,7 @@ class AlphaEqSpec extends BaseCompilerSpec {
       } while (u < 20)
     })
 
-    val rhs = idPipeline(u.reify {
+    val rhs = idPipeline(reify {
       var v = x
       while (v < 20) {
         println(y)
@@ -82,7 +83,7 @@ class AlphaEqSpec extends BaseCompilerSpec {
   }
 
   "loops" in {
-    val lhs = idPipeline(u.reify {
+    val lhs = idPipeline(reify {
       def b$00(): Unit = {
         val i$1 = 0
         val r$1 = 0
@@ -103,7 +104,7 @@ class AlphaEqSpec extends BaseCompilerSpec {
       b$00()
     })
 
-    val rhs = idPipeline(u.reify {
+    val rhs = idPipeline(reify {
       def x$00(): Unit = {
         val j$1 = 0
         val k$1 = 0
@@ -128,17 +129,17 @@ class AlphaEqSpec extends BaseCompilerSpec {
   }
 
   "pattern matching" in {
-    val lhs = idPipeline(u.reify {
+    val lhs = idPipeline(reify {
       val u = (t, x)
       u match {
-        case ((i, j: String), _) => i * 42
+        case ((i, _: String), _) => i * 42
       }
     })
 
-    val rhs = idPipeline(u.reify {
+    val rhs = idPipeline(reify {
       val v = (t, x)
       v match {
-        case ((l, m: String), _) => l * 42
+        case ((l, _: String), _) => l * 42
       }
     })
 

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/backend/CachingSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/backend/CachingSpec.scala
@@ -24,6 +24,7 @@ import compiler.BaseCompilerSpec
 class CachingSpec extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
 
   val liftPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
@@ -40,7 +41,7 @@ class CachingSpec extends BaseCompilerSpec {
 
     "used multiple times" in {
 
-      val inp = u.reify {
+      val inp = reify {
         val i = 2
         val xs = DataBag(1 to 5).withFilter(_ % 2 == 0)
         val ys = xs.map(_ + i)
@@ -48,7 +49,7 @@ class CachingSpec extends BaseCompilerSpec {
         ys union zs
       }
 
-      val exp = u.reify {
+      val exp = reify {
         val i = 2
         val xs = cache {
           DataBag(1 to 5).withFilter(_ % 2 == 0)
@@ -64,7 +65,7 @@ class CachingSpec extends BaseCompilerSpec {
 
     "passed as arguments to a loop method" in {
 
-      val inp = u.reify {
+      val inp = reify {
         val i = 2
         val N = 5
         var xs = DataBag(1 to 5)
@@ -72,7 +73,7 @@ class CachingSpec extends BaseCompilerSpec {
         xs
       }
 
-      val exp = u.reify {
+      val exp = reify {
         val i = 2
         val N = 5
         var xs = DataBag(1 to 5)
@@ -88,8 +89,7 @@ class CachingSpec extends BaseCompilerSpec {
 
     "referenced in the closure of a loop method" in {
 
-      val inp = u.reify {
-        val i = 2
+      val inp = reify {
         val N = 5
         var xs = DataBag(1 to 5)
         val ys = DataBag(1 to 5).withFilter(_ % 2 == 0)
@@ -97,8 +97,7 @@ class CachingSpec extends BaseCompilerSpec {
         xs
       }
 
-      val exp = u.reify {
-        val i = 2
+      val exp = reify {
         val N = 5
         var xs = DataBag(1 to 5)
         val ys = cache {

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/backend/OrderSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/backend/OrderSpec.scala
@@ -20,9 +20,11 @@ import api.DataBag
 import compiler.BaseCompilerSpec
 
 /** A spec for order disambiguation. */
+//noinspection ScalaUnusedSymbol
 class OrderSpec extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
 
   val liftPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
@@ -41,7 +43,7 @@ class OrderSpec extends BaseCompilerSpec {
 
     "only driver" in {
 
-      val inp = u.reify {
+      val inp = reify {
         val f = (x: Int) => x + 1
         f(41)
       }
@@ -53,14 +55,14 @@ class OrderSpec extends BaseCompilerSpec {
 
     "ambiguous" in {
 
-      val inp = u.reify {
+      val inp = reify {
         val f = (x: Int) => x + 1
         val x = f(6)
         val b = DataBag(Seq(1))
         b.map(f)
       }
 
-      val exp = u.reify {
+      val exp = reify {
         val f = (x: Int) => x + 1
         val f$high = (x: Int) => x + 1
         val x = f(6)
@@ -73,7 +75,7 @@ class OrderSpec extends BaseCompilerSpec {
 
     "chain of lambda refs" in {
 
-      val inp = u.reify {
+      val inp = reify {
         val g = (x: Int) => x + 2
         val f = (x: Int) => x + g(4)
         val x = g(6)
@@ -81,7 +83,7 @@ class OrderSpec extends BaseCompilerSpec {
         b.map(f)
       }
 
-      val exp = u.reify {
+      val exp = reify {
         val g = (x: Int) => x + 2
         val g$high = (x: Int) => x + 2
         val f = (x: Int) => x + g$high(4)
@@ -95,7 +97,7 @@ class OrderSpec extends BaseCompilerSpec {
 
     "long chain of lambda refs" in {
 
-      val inp = u.reify {
+      val inp = reify {
         val h = (x: Int) => x + 3
         val g = (x: Int) => h(x)
         val f = (x: Int) => x + g(4)
@@ -105,7 +107,7 @@ class OrderSpec extends BaseCompilerSpec {
         b.map(f)
       }
 
-      val exp = u.reify {
+      val exp = reify {
         val h = (x: Int) => x + 3
         val h$high = (x: Int) => x + 3
         val g = (x: Int) => h(x)
@@ -122,7 +124,7 @@ class OrderSpec extends BaseCompilerSpec {
 
     "higher-order function executed in driver" in {
 
-      val inp = u.reify {
+      val inp = reify {
         val h = (l: Int => Int) => {
           val ir = (x: Int) => l(x)
           ir
@@ -134,7 +136,7 @@ class OrderSpec extends BaseCompilerSpec {
         b.map(f)
       }
 
-      val exp = u.reify {
+      val exp = reify {
         val h = (l: Int => Int) => {
           val ir = (x: Int) => l(x)
           val ir$high = (x: Int) => l(x)
@@ -157,7 +159,7 @@ class OrderSpec extends BaseCompilerSpec {
 
     "higher-order function called from high" in {
 
-      val inp = u.reify {
+      val inp = reify {
         val h = (l: Int => Int) => {
           val ir = (x: Int) => l(x)
           ir
@@ -170,7 +172,7 @@ class OrderSpec extends BaseCompilerSpec {
         b.map(f)
       }
 
-      val exp = u.reify {
+      val exp = reify {
         val h = (l: Int => Int) => {
           val ir = (x: Int) => l(x)
           val ir$high = (x: Int) => l(x)

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/cf/CFGSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/cf/CFGSpec.scala
@@ -25,7 +25,9 @@ import test.schema.Graphs._
 
 /** A spec for comprehension normalization. */
 class CFGSpec extends BaseCompilerSpec {
+
   import compiler._
+  import universe.reify
 
   val anfPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
@@ -39,7 +41,7 @@ class CFGSpec extends BaseCompilerSpec {
       val output = "file://path/to/output"
       implicit val edgeCSVConverter = CSVConverter[Edge[Long]]
 
-      val tree = idPipeline(u.reify {
+      val tree = idPipeline(reify {
         // read in a directed graph
         val csv$1 = CSV()
         val read$1 = DataBag.readCSV[Edge[Long]](input, csv$1)
@@ -97,7 +99,7 @@ class CFGSpec extends BaseCompilerSpec {
     }
 
     "with nested methods" in {
-      val tree = anfPipeline(u.reify {
+      val tree = anfPipeline(reify {
         implicit val zipSeqWithIdx = Seq.canBuildFrom[(Int, Int)]
         val customers = 4
         val barbers = Seq(10, 5)

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/PrettyPrintSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/PrettyPrintSpec.scala
@@ -255,8 +255,9 @@ class PrettyPrintSpec extends BaseCompilerSpec {
       //noinspection RedundantNewCaseClass
       val acts = idPipeline(reify {
         //@formatter:off
+        //noinspection RedundantNewCaseClass
         new Ad(1L, "Uber AD", services)                 // args
-        new Tuple2(3.14, "pi")                          // type-args and args
+        new String("pi")                                // type-args and args
         new scala.collection.mutable.ListBuffer[String] // type-args only
         new Object                                      // no-args
         ()
@@ -267,7 +268,7 @@ class PrettyPrintSpec extends BaseCompilerSpec {
 
       val exps = """
         |new Ad(1L, "Uber AD", services)
-        |new Tuple2(3.14, "pi")
+        |new String("pi")
         |new ListBuffer[String]()
         |new Object()
       """.stripMargin.trim.split("\n")

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/libsupport/LibSupportExamples.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/libsupport/LibSupportExamples.scala
@@ -18,8 +18,6 @@ package compiler.lang.libsupport
 
 import compiler.BaseCompilerSpec
 
-import test.schema.Literature.Book
-
 /** A spec for the `Beta.reduce` transformation. */
 trait LibSupportExamples extends BaseCompilerSpec {
 

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/libsupport/LibSupportExamples.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/libsupport/LibSupportExamples.scala
@@ -22,6 +22,7 @@ import compiler.BaseCompilerSpec
 trait LibSupportExamples extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
 
   val liftPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
@@ -44,7 +45,7 @@ trait LibSupportExamples extends BaseCompilerSpec {
 
   lazy val `Example A (Original Expr)` = {
     import lib.example._
-    u.reify {
+    reify {
       val check = (e: Double) => e < ν
       val x = 51L
       val y = 17
@@ -56,7 +57,7 @@ trait LibSupportExamples extends BaseCompilerSpec {
 
   lazy val `Example A (Emma Source)` = {
     import lib.example._
-    u.reify {
+    reify {
       val check = (e: Double) => e < ν
       val x = 51L
       val y = 17
@@ -70,7 +71,7 @@ trait LibSupportExamples extends BaseCompilerSpec {
   }
 
   lazy val `Example A (normalized)` = {
-    u.reify {
+    reify {
       val check = (e: Double) => e < ν
       val x = 51L
       val y = 17
@@ -103,14 +104,14 @@ trait LibSupportExamples extends BaseCompilerSpec {
 
   lazy val `Example B (Original Expr)` = {
     import lib.example._
-    u.reify {
+    reify {
       f1(μ, ν)
     }
   }
 
   lazy val `Example B (Emma Source)` = {
     import lib.example._
-    u.reify {
+    reify {
       f1[Double](μ, ν.toDouble)(Numeric.DoubleIsFractional)
     }
   }
@@ -124,14 +125,14 @@ trait LibSupportExamples extends BaseCompilerSpec {
 
   lazy val `Example C (Original Expr)` = {
     import lib.example._
-    u.reify {
+    reify {
       g1(μ + ν)
     }
   }
 
   lazy val `Example C (Emma Source)` = {
     import lib.example._
-    u.reify {
+    reify {
       g1[Double](μ + ν)(Numeric.DoubleIsFractional)
     }
   }
@@ -145,14 +146,14 @@ trait LibSupportExamples extends BaseCompilerSpec {
 
   lazy val `Example D (Original Expr)` = {
     import lib.example._
-    u.reify {
+    reify {
       baz(μ, ν).x + h1(μ, μ)
     }
   }
 
   lazy val `Example D (Emma Source)` = {
     import lib.example._
-    u.reify {
+    reify {
       baz[Double](μ, ν.toDouble)(Numeric.DoubleIsFractional).x +
         h1[Double](μ, μ)(Numeric.DoubleIsFractional)
     }
@@ -167,7 +168,7 @@ trait LibSupportExamples extends BaseCompilerSpec {
 
   lazy val `Example E (Original Expr)` = {
     import lib.example._
-    u.reify {
+    reify {
       val x = μ * ν
       val y = 100
       val r = pow(x, y)
@@ -177,7 +178,7 @@ trait LibSupportExamples extends BaseCompilerSpec {
 
   lazy val `Example E (Emma Source)` = {
     import lib.example._
-    u.reify {
+    reify {
       val x = μ * ν
       val y = 100
       val r = pow[Double](x, y)(Numeric.DoubleIsFractional)
@@ -186,7 +187,7 @@ trait LibSupportExamples extends BaseCompilerSpec {
   }
 
   lazy val `Example E (normalized)` = {
-    u.reify {
+    reify {
       val x = μ * ν
       val y = 100
       val r = {
@@ -214,7 +215,7 @@ trait LibSupportExamples extends BaseCompilerSpec {
 
   lazy val `Example F (Original Expr)` = {
     import lib.example._
-    u.reify {
+    reify {
       val r = sameAs(μ, ν)
       r
     }
@@ -222,14 +223,14 @@ trait LibSupportExamples extends BaseCompilerSpec {
 
   lazy val `Example F (Emma Source)` = {
     import lib.example._
-    u.reify {
+    reify {
       val r = sameAs[Double](μ, ν.toDouble)
       r
     }
   }
 
   lazy val `Example F (normalized)` = {
-    u.reify {
+    reify {
       val r = {
         μ == ν.toDouble
       }

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/libsupport/LibSupportSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/libsupport/LibSupportSpec.scala
@@ -21,10 +21,10 @@ import org.scalactic.Equality
 /** A spec for the `FunSupport.callGraph` function. */
 class LibSupportSpec extends LibSupportExamples {
 
-  import compiler.LibSupport.CG
-  import compiler.LibSupport.LibDefRegistry
   import compiler._
   import compiler.api._
+  import LibSupport.CG
+  import LibSupport.LibDefRegistry
 
   val prePipeline: u.Expr[Any] => u.Tree = compiler
     .pipeline(typeCheck = true, withPost = false)(

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/opt/FoldForestFusionSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/opt/FoldForestFusionSpec.scala
@@ -27,7 +27,6 @@ class FoldForestFusionSpec extends BaseCompilerSpec {
 
   import compiler._
   import universe.reify
-  import UniverseImplicits._
 
   def testPipeline(prefix: u.Tree => u.Tree): u.Tree => u.Tree =
     pipeline(typeCheck = true)(

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/opt/FoldForestFusionSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/opt/FoldForestFusionSpec.scala
@@ -155,6 +155,14 @@ class FoldForestFusionSpec extends BaseCompilerSpec {
           plus$r1
         }
         val alg$fold$r1 = alg.Fold(1, id, sum)
+        val alg$fold$r2 = alg.Fold(2, id, sum)
+        val alg$fold$r3 = alg.Fold(3, id, sum)
+        val alg$fold$r4 = alg.Fold(4, id, sum)
+        val alg$fold$r5 = alg.Fold(5, id, sum)
+        val alg$fold$r6 = alg.Fold(6, id, sum)
+        val alg$fold$r7 = alg.Fold(7, id, sum)
+        val alg$fold$r8 = alg.Fold(8, id, sum)
+        val alg$fold$r9 = alg.Fold(9, id, sum)
         val alg$fold$r10 = alg.Fold(10, id, sum)
         val alg$fold$r11 = alg.Fold(11, id, sum)
         val alg$fold$r12 = alg.Fold(12, id, sum)
@@ -165,20 +173,12 @@ class FoldForestFusionSpec extends BaseCompilerSpec {
         val alg$fold$r17 = alg.Fold(17, id, sum)
         val alg$fold$r18 = alg.Fold(18, id, sum)
         val alg$fold$r19 = alg.Fold(19, id, sum)
-        val alg$fold$r2 = alg.Fold(2, id, sum)
         val alg$fold$r20 = alg.Fold(20, id, sum)
         val alg$fold$r21 = alg.Fold(21, id, sum)
         val alg$fold$r22 = alg.Fold(22, id, sum)
         val alg$fold$r23 = alg.Fold(23, id, sum)
         val alg$fold$r24 = alg.Fold(24, id, sum)
         val alg$fold$r25 = alg.Fold(25, id, sum)
-        val alg$fold$r3 = alg.Fold(3, id, sum)
-        val alg$fold$r4 = alg.Fold(4, id, sum)
-        val alg$fold$r5 = alg.Fold(5, id, sum)
-        val alg$fold$r6 = alg.Fold(6, id, sum)
-        val alg$fold$r7 = alg.Fold(7, id, sum)
-        val alg$fold$r8 = alg.Fold(8, id, sum)
-        val alg$fold$r9 = alg.Fold(9, id, sum)
         val to$r1 = intWrapper$r1 to 100
         val alg$Alg22$r1 = alg.Alg22(
           alg$fold$r1, alg$fold$r2, alg$fold$r3, alg$fold$r4, alg$fold$r5, alg$fold$r6, alg$fold$r7, alg$fold$r8,

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/opt/FoldGroupFusionSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/opt/FoldGroupFusionSpec.scala
@@ -23,7 +23,6 @@ import compiler.BaseCompilerSpec
 class FoldGroupFusionSpec extends BaseCompilerSpec {
 
   import compiler._
-  import UniverseImplicits._
 
   val testPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/Foreach2LoopSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/Foreach2LoopSpec.scala
@@ -22,6 +22,7 @@ import compiler.BaseCompilerSpec
 class Foreach2LoopSpec extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
 
   val foreach2loopPipeline: u.Expr[Any] => u.Tree =
     compiler.pipeline(typeCheck = true, withPre = false)(
@@ -33,11 +34,11 @@ class Foreach2LoopSpec extends BaseCompilerSpec {
 
   "foreach" - {
     "without closure modification" in {
-      val act = foreach2loopPipeline(u.reify {
+      val act = foreach2loopPipeline(reify {
         for (i <- 1 to 5) println(i)
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         for (i <- 1 to 5) println(i)
       })
 
@@ -45,12 +46,12 @@ class Foreach2LoopSpec extends BaseCompilerSpec {
     }
 
     "without argument access" in {
-      val act = foreach2loopPipeline(u.reify {
+      val act = foreach2loopPipeline(reify {
         var x = 42
         for (_ <- 1 to 5) x += 1
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         var x = 42; {
           val iter$1 = 1.to(5).toIterator
           var _$1 = null.asInstanceOf[Int]
@@ -65,12 +66,12 @@ class Foreach2LoopSpec extends BaseCompilerSpec {
     }
 
     "with argument access" in {
-      val act = foreach2loopPipeline(u.reify {
+      val act = foreach2loopPipeline(reify {
         var x = 42
         for (i <- 1 to 5) x += i
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         var x = 42; {
           val iter$1 = 1.to(5).toIterator
           var i$1 = null.asInstanceOf[Int]
@@ -85,12 +86,12 @@ class Foreach2LoopSpec extends BaseCompilerSpec {
     }
 
     "with monadic filter" in {
-      val act = foreach2loopPipeline(u.reify {
+      val act = foreach2loopPipeline(reify {
         var x = 42
         for (i <- 1 to 10 if i % 2 == 0) x += i
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         var x = 42; {
           val iter$1 = 1.to(10)
             .withFilter(_ % 2 == 0)

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/PatternMatchingSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/PatternMatchingSpec.scala
@@ -19,11 +19,12 @@ package compiler.lang.source
 import compiler.BaseCompilerSpec
 
 /** A spec for the `Core.foreach2loop` transformation. */
+//noinspection ScalaUnusedSymbol
 class PatternMatchingSpec extends BaseCompilerSpec {
 
   import PatternMatchingSpec._
-
   import compiler._
+  import universe.reify
 
   val destructPatternMatchesPipeline: u.Expr[Any] => u.Tree =
     compiler.pipeline(typeCheck = true, withPre = false)(
@@ -45,7 +46,7 @@ class PatternMatchingSpec extends BaseCompilerSpec {
 
       val dogs = (Dog("Max"), Dog("Gidget"))
 
-      val act = destructPatternMatchesPipeline(u.reify {
+      val act = destructPatternMatchesPipeline(reify {
         val nameFst = dogs match {
           case pair@(Dog(name), _) => name
         }
@@ -57,7 +58,7 @@ class PatternMatchingSpec extends BaseCompilerSpec {
         nameFst == nameSnd
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         val nameFst = {
           val pair = dogs
           val name = pair._1.name
@@ -80,7 +81,7 @@ class PatternMatchingSpec extends BaseCompilerSpec {
 
       val dogs = (Dog("Max"), Dog("Gidget"))
 
-      val act = destructPatternMatchesPipeline(u.reify {
+      val act = destructPatternMatchesPipeline(reify {
         val nameFst = (dogs: (Dog, Dog)@unchecked) match {
           case pair@(Dog(name), _) => name
         }
@@ -92,7 +93,7 @@ class PatternMatchingSpec extends BaseCompilerSpec {
         nameFst == nameSnd
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         val nameFst = {
           val pair = dogs
           val name = pair._1.name
@@ -113,7 +114,7 @@ class PatternMatchingSpec extends BaseCompilerSpec {
 
     "with complex lhs" in {
 
-      val act = destructPatternMatchesPipeline(u.reify {
+      val act = destructPatternMatchesPipeline(reify {
         val nameFst = (Dog("Max"), Dog("Gidget")) match {
           case pair@(Dog(name), _) => name
         }
@@ -125,7 +126,7 @@ class PatternMatchingSpec extends BaseCompilerSpec {
         nameFst == nameSnd
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         val nameFst = {
           val x$1 = (Dog("Max"), Dog("Gidget"))
           val pair = x$1

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/SourceLangSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/SourceLangSpec.scala
@@ -28,9 +28,10 @@ import org.example.foo.Baz
 class SourceLangSpec extends BaseCompilerSpec {
 
   import compiler._
+  import Validation._
   import Source.valid
   import Source.{Lang => src}
-  import Validation._
+  import universe.reify
 
   // ---------------------------------------------------------------------------
   // Helper methods
@@ -67,7 +68,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `Lit` objects in `Source.Lang`
     // - `Literal(Constant(value))` nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify(42, 4.2, "42", '!'))
+    val examples = extractFrom(reify(42, 4.2, "42", '!'))
     examples should not be empty
 
     "are valid language constructs" in {
@@ -86,7 +87,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `Ref` objects in `Source.Lang`
     // - `Ident(sym)` nodes where `sym` is a (free) `TermSymbol` in Scala ASTs
 
-    val examples = extractFrom(u.reify {
+    val examples = extractFrom(reify {
       val u = 42
       val v = 4.2
       var w = "42"
@@ -114,7 +115,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `This` objects in `Source.Lang`
     // - `This(qual)` nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify {
+    val examples = extractFrom(reify {
       class Unqualified { println(this.toString) }
       class Qualified { println(SourceLangSpec.this.x) }
       object Module { println(this.hashCode) }
@@ -145,7 +146,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `BindingDef` objects in `Source.Lang`
     // - `ValDef(lhs, rhs)` nodes nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify {
+    val examples = extractFrom(reify {
       val u = s"$x is $y"
       val v = 42
       var w = "42"
@@ -177,7 +178,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `DefCall` objects in `Source.Lang`
     // - `Apply(fun, args)` nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify(
+    val examples = extractFrom(reify(
       t._2,
       DEFAULT_CLASS,
       x == 42,
@@ -185,7 +186,7 @@ class SourceLangSpec extends BaseCompilerSpec {
       y.substring(1),
       ((x: Int, y: Int) => x + y) (x, x),
       Seq(x, x),
-      DataBag(xs.fetch().toSeq),
+      DataBag(xs.fetch()),
       List.canBuildFrom[Int],
       DataBag(Seq(1, 2, 3)).sum
     )).map(api.Tree.unAscribe)
@@ -212,7 +213,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `While` objects in `Source.Lang`
     // - `LabelDef(...)` nodes nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify {
+    val examples = extractFrom(reify {
       var r = 0
       var i = 0
       while (i < x) {
@@ -242,7 +243,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `DoWhile` objects in `Source.Lang`
     // - `LabelDef(...)` nodes nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify {
+    val examples = extractFrom(reify {
       var i = 0
       var r = 0
       do {
@@ -276,11 +277,11 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `PatMat` objects in `Source.Lang`
     // - `Match(selector, cases)` nodes nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify(
+    val examples = extractFrom(reify(
       ((1, 2): Any) match {
         case (x: Int, _) => x
-        case Ad(id, name, _) => id
-        case Click(adID, userID, time) => adID
+        case Ad(id, _, _) => id
+        case Click(adID, _, _) => adID
         case _ => 42
       },
       "binding" match {
@@ -312,7 +313,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `Block` objects in `Source.Lang`
     // - `Block(stats, expr)` nodes nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify(
+    val examples = extractFrom(reify(
       { val z = 5; x + z },
       t._2 + "implicit unit": Unit
     )).map(api.Tree.unAscribe)
@@ -335,7 +336,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `Branch` objects in `Source.Lang`
     // - `If(cond, thn, els)` nodes nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify(
+    val examples = extractFrom(reify(
       if (x == 42) x else x / 42,
       if (x < 42) "only one branch"
     ))
@@ -358,7 +359,8 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `Inst` objects in `Source.Lang`
     // - `Apply(tpt: New, _)` nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify(
+    //noinspection RedundantNewCaseClass
+    val examples = extractFrom(reify(
       new Ad(1, "Uber AD", AdClass.SERVICES),
       new Baz(x),
       new Bar[Int](x)
@@ -382,7 +384,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `Lambda` objects in `Source.Lang`
     // - `Function(args, body)` nodes nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify(
+    val examples = extractFrom(reify(
       (x: Int, y: Int) => x + y,
       "ellipsis".charAt _
     )).flatMap {
@@ -408,7 +410,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `inst` objects in `Source.Language`
     // - `Typed(expr, tpt)` nodes nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify(
+    val examples = extractFrom(reify(
       x: Number,
       t: (Any, String)
     ))
@@ -435,7 +437,7 @@ class SourceLangSpec extends BaseCompilerSpec {
     // - `val_` objects in `Source.Language`
     // - `Assign(lhs, rhs)` nodes nodes in Scala ASTs
 
-    val examples = extractFrom(u.reify {
+    val examples = extractFrom(reify {
       var u = "still a ValDef but mutable"
       var w = 42
       u = "an updated ValDef"

--- a/emma-language/src/test/scala/org/emmalanguage/test/util.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/test/util.scala
@@ -89,7 +89,7 @@ object util {
   /** Deletes a file recursively. */
   def deleteRecursive(path: java.io.File): Boolean = {
     val ret = if (path.isDirectory) {
-      path.listFiles().toSeq.foldLeft(true)((r, f) => deleteRecursive(f))
+      path.listFiles().toSeq.foldLeft(true)((_, f) => deleteRecursive(f))
     } else /* regular file */ {
       true
     }

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkDataset.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
-import scala.language.higherKinds
 import scala.language.implicitConversions
 import scala.util.hashing.MurmurHash3
 

--- a/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/SparkRDD.scala
@@ -25,7 +25,6 @@ import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
-import scala.language.higherKinds
 import scala.language.implicitConversions
 import scala.util.hashing.MurmurHash3
 

--- a/emma-spark/src/main/scala/org/emmalanguage/api/spark/SparkOps.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/spark/SparkOps.scala
@@ -26,8 +26,6 @@ import org.apache.spark.sql.Encoder
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
 
-import scala.language.higherKinds
-
 /** Spark backend operators. */
 object SparkOps extends ComprehensionCombinators[SparkSession] with Runtime[SparkSession] {
 

--- a/emma-spark/src/main/scala/org/emmalanguage/api/spark/package.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/api/spark/package.scala
@@ -20,8 +20,6 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.SparkSession
 
-import scala.language.higherKinds
-
 package object spark {
 
   import Meta.Projections.ctagFor

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
@@ -18,7 +18,6 @@ package compiler
 
 import com.typesafe.config.Config
 
-import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
 class SparkMacro(val c: blackbox.Context) extends MacroCompiler with SparkCompiler {

--- a/emma-spark/src/test/scala/org/emmalanguage/compiler/spark/rdd/SparkCodegenIntegrationSpec.scala
+++ b/emma-spark/src/test/scala/org/emmalanguage/compiler/spark/rdd/SparkCodegenIntegrationSpec.scala
@@ -26,10 +26,10 @@ import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.SparkSession
 
 class SparkCodegenIntegrationSpec extends BaseCodegenIntegrationSpec with SparkAware {
-
-  override lazy val compiler = new RuntimeCompiler with SparkCompiler
+  override val compiler = new RuntimeCompiler with SparkCompiler
 
   import compiler._
+  import universe.reify
 
   type Env = SparkSession
 
@@ -43,7 +43,7 @@ class SparkCodegenIntegrationSpec extends BaseCodegenIntegrationSpec with SparkA
   // Distributed collection conversion
   // --------------------------------------------------------------------------
 
-  "Convert from/to a Spark RDD" in verify(u.reify {
+  "Convert from/to a Spark RDD" in verify(reify {
     val xs = DataBag(1 to 1000).withFilter(_ > 800)
     val ys = xs.as[RDD].filter(_ < 200)
     val zs = DataBag.from(ys)

--- a/pom.xml
+++ b/pom.xml
@@ -480,6 +480,7 @@
                         <arg>-deprecation</arg>
                         <arg>-feature</arg>
                         <arg>-Yrangepos</arg>
+                        <arg>-Ywarn-unused-import</arg>
                         <arg>-Xmax-classfile-name</arg>
                         <arg>140</arg>
                         <arg>-Xlint:package-object-classes</arg>

--- a/pom.xml
+++ b/pom.xml
@@ -888,6 +888,7 @@
         <module>emma-examples</module>
         <module>emma-gui</module>
         <module>emma-quickstart</module>
+        <module>emma-benchmarks</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -483,7 +483,7 @@
                         <arg>-Ywarn-unused-import</arg>
                         <arg>-Xmax-classfile-name</arg>
                         <arg>140</arg>
-                        <arg>-Xlint:package-object-classes</arg>
+                        <arg>-Xlint:-adapted-args,_</arg>
                         <arg>-Xfatal-warnings</arg>
                         <!--<arg>-Xdisable-assertions</arg>-->
                     </args>

--- a/tools/license-mappings.xml
+++ b/tools/license-mappings.xml
@@ -39,4 +39,9 @@
         <version>0.1</version>
         <license>Apache License, Version 2.0</license>
     </artifact>
+    <artifact>
+        <groupId>org.scala-tools.testing</groupId>
+        <artifactId>test-interface</artifactId>
+        <license>MIT</license>
+    </artifact>
 </license-lookup>


### PR DESCRIPTION
#### Minor infrastructure and test improvements
* Enabled `Xlint:-adapted-args` and `Ywarn-unused-imports`
* Fixed Intellij highlighting errors in compiler tests
* Warmup inline benchmarks
#### Benchmarking infrastructure
* To create a benchmark, extend `compiler.benchmark.BaseCompilerBench`
* Made `RuntimeCompiler` serializable (required to run benchmark in separate JVM)
* Initial benchmark for the `ANF` transformation (~22ms per example)
* To change report location run with e.g. `-CresultDir docs/benchmarks`