### PR TITLE
[IR] Precise types for symbols (no widen)

### DIFF
--- a/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/compiler/integration/graphs/EnumerateTrianglesIntegrationSpec.scala
+++ b/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/compiler/integration/graphs/EnumerateTrianglesIntegrationSpec.scala
@@ -30,6 +30,7 @@ import scala.Ordering.Implicits._
 class EnumerateTrianglesIntegrationSpec extends BaseCompilerIntegrationSpec {
 
   import compiler._
+  import universe.reify
 
   // ---------------------------------------------------------------------------
   // Program closure
@@ -44,7 +45,7 @@ class EnumerateTrianglesIntegrationSpec extends BaseCompilerIntegrationSpec {
   // Program representations
   // ---------------------------------------------------------------------------
 
-  val sourceExpr = liftPipeline(u.reify {
+  val sourceExpr = liftPipeline(reify {
     // convert a list of directed edges
     val incoming = DataBag.readCSV[Edge[Long]](input, csv)
     val outgoing = incoming.map(e => Edge(e.dst, e.src))
@@ -57,10 +58,10 @@ class EnumerateTrianglesIntegrationSpec extends BaseCompilerIntegrationSpec {
     println(s"The number of triangles in the graph is $triangleCount")
   })
 
-  val coreExpr = anfPipeline(u.reify {
+  val coreExpr = anfPipeline(reify {
     // convert a list of directed edges
-    val input = this.input
-    val csv = this.csv
+    val input: this.input.type = this.input
+    val csv:   this.csv.type   = this.csv
     val incoming = DataBag.readCSV[Edge[Long]](input, csv)
     val outgoing = comprehension[Edge[Long], DataBag] {
       val e = generator[Edge[Long], DataBag](incoming)

--- a/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/compiler/integration/graphs/TransitiveClosureIntegrationSpec.scala
+++ b/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/compiler/integration/graphs/TransitiveClosureIntegrationSpec.scala
@@ -55,8 +55,8 @@ class TransitiveClosureIntegrationSpec extends BaseCompilerIntegrationSpec {
 
   val coreExpr = anfPipeline(reify {
     // read in a directed graph
-    val input = this.input
-    val csv$1 = this.csv
+    val input: this.input.type = this.input
+    val csv$1: this.csv.type   = this.csv
     val readCSV = DataBag.readCSV[Edge[Int]](input, csv$1)
     val paths$1 = readCSV.distinct
     val count$1 = paths$1.size
@@ -76,8 +76,8 @@ class TransitiveClosureIntegrationSpec extends BaseCompilerIntegrationSpec {
       val isReady = added$2 > 0
       @suffix def suffix$1(): Unit = {
         val closure = paths$2
-        val output = this.output
-        val csv$2 = this.csv
+        val output: this.output.type = this.output
+        val csv$2:  this.csv.type    = this.csv
         closure.writeCSV(output, csv$2)
       }
 

--- a/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/compiler/integration/text/WordCountIntegrationSpec.scala
+++ b/emma-examples/emma-examples-library/src/test/scala/org/emmalanguage/compiler/integration/text/WordCountIntegrationSpec.scala
@@ -26,6 +26,7 @@ import io.csv._
 class WordCountIntegrationSpec extends BaseCompilerIntegrationSpec {
 
   import compiler._
+  import universe.reify
 
   // ---------------------------------------------------------------------------
   // Program closure
@@ -41,7 +42,7 @@ class WordCountIntegrationSpec extends BaseCompilerIntegrationSpec {
   // Program representations
   // ---------------------------------------------------------------------------
 
-  val sourceExpr = liftPipeline(u.reify {
+  val sourceExpr = liftPipeline(reify {
     // read the input files and split them into lowercased words
     val docs = DataBag.readCSV[String](input, csv)
     // parse and count the words
@@ -50,9 +51,9 @@ class WordCountIntegrationSpec extends BaseCompilerIntegrationSpec {
     counts.writeCSV(output, csv)
   })
 
-  val coreExpr = anfPipeline(u.reify {
-    val input = this.input
-    val csv$r1 = this.csv
+  val coreExpr = anfPipeline(reify {
+    val input:  this.input.type = this.input
+    val csv$r1: this.csv.type   = this.csv
     val docs = DataBag.readCSV[String](input, csv$r1)
 
     // read the input files and split them into lowercased words
@@ -90,8 +91,8 @@ class WordCountIntegrationSpec extends BaseCompilerIntegrationSpec {
     }
 
     // write the results into a CSV file
-    val output$r1 = this.output
-    val csv$r2 = this.csv
+    val output$r1: this.output.type = this.output
+    val csv$r2:    this.csv.type    = this.csv
     val x$r1 = counts.writeCSV(output$r1, csv$r2)
     x$r1
   })

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
@@ -120,7 +120,7 @@ trait Symbols { this: AST =>
               else newTermSymbol(own, termNme, pos, flg)
             }
 
-            setInfo(dup, tpe.dealias.widen)
+            setInfo(dup, tpe.dealias)
             setAnnotations(dup, ans.toList)
             dup.asInstanceOf[S]
           }

--- a/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Terms.scala
@@ -107,7 +107,7 @@ trait Terms { this: AST =>
         assert(is.defined(nme), s"$this name is not defined")
         assert(is.defined(tpe),  s"$this type is not defined")
         val sym = newTermSymbol(own, TermName(nme), pos, flg)
-        setInfo(sym, tpe.dealias.widen)
+        setInfo(sym, tpe.dealias)
         setAnnotations(sym, ans.toList)
       }
 
@@ -119,7 +119,7 @@ trait Terms { this: AST =>
         assert(is.defined(name), s"$this name is not defined")
         assert(is.defined(tpe),  s"$this type is not defined")
         val free = internal.newFreeTerm(TermName(name).toString, null, flg, null)
-        setInfo(free, tpe.dealias.widen)
+        setInfo(free, tpe.dealias)
         setAnnotations(free, ans.toList)
       }
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugar.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugar.scala
@@ -57,7 +57,7 @@ private[comprehension] trait ReDeSugar extends Common {
         val sym = api.Sym.With(arg)(flg = u.NoFlags).asTerm
         sym -> api.Tree.rename(Seq(arg -> sym))(body)
       }.getOrElse {
-        val nme = api.TermName.fresh("x")
+        val nme = api.TermName.fresh()
         val tpe = f.info.dealias.widen.typeArgs.last
         val arg = api.ValSym(owner, nme, tpe)
         val tgt = Some(core.ValRef(f))
@@ -109,16 +109,11 @@ private[comprehension] trait ReDeSugar extends Common {
     def desugar(monad: u.Symbol): u.Tree => u.Tree = {
       // construct comprehension syntax helper for the given monad
       val cs = new Comprehension.Syntax(monad)
-
-      val desugarTransform = api.TopDown.transform {
+      api.TopDown.withOwner.transformWith {
         // Match: `for { x <- { $vals; $rhs}; $qs*; } yield $expr`
-        //@formatter:off
-        case cs.Comprehension(
-          Seq(
-            cs.Generator(x, core.Let(vals, Seq(), core.Ref(rhs))),
-            qs@_*),
-          cs.Head(expr)) =>
-          //@formatter:on
+        case Attr.inh(
+          cs.Comprehension(Seq(cs.Generator(x, core.Let(vals, Seq(), core.Ref(rhs))), qs@_*), cs.Head(expr)),
+          owner :: _) =>
 
           val (guards, rest) = qs.span {
             case cs.Guard(_) => true
@@ -127,17 +122,17 @@ private[comprehension] trait ReDeSugar extends Common {
 
           // Accumulate filters in a prefix of values and keep track of the tail value symbol
           val (tail, prefix) = guards.foldLeft(rhs, Vector.empty[u.ValDef]) {
-            case ((currSym, currPfx), cs.Guard(p)) =>
-              val currRef = core.Ref(currSym)
-              val funcRhs = core.Lambda(Seq(x), p)
-              val funcNme = api.TermName.fresh("guard")
-              val funcSym = api.TermSym.free(funcNme, funcRhs.tpe)
-              val funcRef = core.Ref(funcSym)
-              val funcVal = api.ValDef(funcSym, funcRhs)
-              val nextNme = api.TermName.fresh(cs.WithFilter.symbol)
-              val nextSym = api.TermSym.free(nextNme, currSym.info)
-              val nextVal = api.ValDef(nextSym, cs.WithFilter(currRef)(funcRef))
-              (nextSym, currPfx :+ funcVal :+ nextVal)
+            case ((curSym, curPre), cs.Guard(pred)) =>
+              val curRef = core.Ref(curSym)
+              val lambda = core.Lambda(Seq(x), pred)
+              val funNme = api.TermName.fresh("guard")
+              val funSym = api.ValSym(owner, funNme, lambda.tpe)
+              val funRef = core.Ref(funSym)
+              val funVal = api.ValDef(funSym, lambda)
+              val tmpNme = api.TermName.fresh(cs.WithFilter.symbol)
+              val tmpSym = api.ValSym(owner, tmpNme, curSym.info.widen)
+              val tmpVal = api.ValDef(tmpSym, cs.WithFilter(curRef)(funRef))
+              (tmpSym, curPre ++ Seq(funVal, tmpVal))
           }
 
           val tailRef = core.Ref(tail)
@@ -150,38 +145,36 @@ private[comprehension] trait ReDeSugar extends Common {
             case _ =>
               // Append a map or a flatMap to the result depending on
               // the size of the residual qualifier sequence 'qs'
-              val (op, body) =
-                if (rest.isEmpty) (cs.Map, expr)
+              val (op, body) = if (rest.isEmpty) (cs.Map, expr)
                 else (cs.FlatMap, cs.Comprehension(rest, cs.Head(expr)))
 
-              val fnRhs = core.Lambda(Seq(x), {
-                val bodyNme = api.TermName.fresh("x")
-                val bodySym = api.TermSym.free(bodyNme, body.tpe)
-                core.Let(Seq(core.ValDef(bodySym, body)), Seq.empty, core.Ref(bodySym))
-              })
-              val fnNme = api.TermName.fresh(api.TermName.lambda)
-              val fnSym = api.TermSym.free(fnNme, fnRhs.tpe)
-              val fnVal = core.ValDef(fnSym, fnRhs)
+              val funNme = api.TermName.fresh(api.TermName.lambda)
+              val funTpe = api.Type.fun(Seq(x.info), body.tpe.widen)
+              val funSym = api.ValSym(owner, funNme, funTpe)
+              val tmpNme = api.TermName.fresh()
+              val tmpSym = api.ValSym(funSym, tmpNme, body.tpe.widen)
+              val tmpRef = core.Ref(tmpSym)
+              val tmpVal = core.ValDef(tmpSym, body)
+              val lambda = core.Lambda(Seq(x), core.Let(Seq(tmpVal), Seq.empty, tmpRef))
+              val funVal = core.ValDef(funSym, lambda)
 
-              val opRhs = op(tailRef)(core.Ref(fnSym))
-              val opSym = api.TermSym.free(op.symbol.name, opRhs.tpe)
+              val opRhs = op(tailRef)(core.Ref(funSym))
+              val opSym = api.ValSym(owner, op.symbol.name, opRhs.tpe)
               val opVal = core.ValDef(opSym, opRhs)
 
-              core.Let(vals ++ prefix ++ Seq(fnVal, opVal), Seq.empty, core.Ref(opSym))
+              val allVals = Seq.concat(vals, prefix, Seq(funVal, opVal))
+              core.Let(allVals, Seq.empty, core.Ref(opSym))
           }
 
         // Match: `flatten { $vals; $defs; for { $qs } yield $head }`
-        case cs.Flatten(core.Let(vals, defs, cs.Comprehension(qs, cs.Head(hd)))) =>
-          val genNme = api.TermName.fresh("x")
-          val genSym = api.TermSym.free(genNme, api.Type.arg(1, hd.tpe))
+        case Attr.inh(cs.Flatten(core.Let(vals, defs, cs.Comprehension(qs, cs.Head(hd)))), owner :: _) =>
+          val genNme = api.TermName.fresh()
+          val genSym = api.ValSym(owner, genNme, api.Type.arg(1, hd.tpe))
           // Return: { $vals; $defs; for { $qs; x <- $head } yield x }
-          core.Let(vals, defs, cs.Comprehension(
-            qs :+ cs.Generator(genSym, hd),
-            cs.Head(core.Let(expr = core.Ref(genSym)))
-          ))
-      }
-
-      desugarTransform andThen (_.tree) andThen Core.flatten
+          val gen = cs.Generator(genSym, hd)
+          val hd1 = cs.Head(core.Let(expr = core.Ref(genSym)))
+          core.Let(vals, defs, cs.Comprehension(qs :+ gen, hd1))
+      }._tree.andThen(Core.flatten)
     }
   }
 }

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
@@ -22,7 +22,7 @@ import compiler.BaseCompilerSpec
 import compiler.ir.ComprehensionSyntax._
 import test.schema.Marketing._
 
-import shapeless._
+import shapeless.::
 
 /** A spec for comprehension combination. */
 class CombinationSpec extends BaseCompilerSpec {
@@ -128,7 +128,8 @@ class CombinationSpec extends BaseCompilerSpec {
           x.id != y
         }
         val z = generator[User, DataBag] {
-          DataBag(Seq(xy._1))
+          val x = xy._1
+          DataBag(Seq(x))
         }
         head {
           val x = xy._1
@@ -151,7 +152,11 @@ class CombinationSpec extends BaseCompilerSpec {
         val xy = generator[(User, User), DataBag] {
           cross(users, users)
         }
-        head { (xy._1, xy._2) }
+        head {
+          val x = xy._1
+          val y = xy._2
+          (x, y)
+        }
       })
 
       applyOnce(MatchCross)(inp) shouldBe alphaEqTo(liftPipeline(exp))
@@ -206,13 +211,17 @@ class CombinationSpec extends BaseCompilerSpec {
 
       val exp = reify(comprehension[(User, User), DataBag] {
         val xy = generator[(User, User), DataBag] {
-          val users$1 = users
-          val users$2 = users
+          val users$1: test.schema.Marketing.users.type = users
+          val users$2: test.schema.Marketing.users.type = users
           val kx = (x: User) => x.id
           val ky = (y: User) => y.id
           equiJoin(kx, ky)(users$1, users$2)
         }
-        head { (xy._1, xy._2) }
+        head {
+          val x = xy._1
+          val y = xy._2
+          (x, y)
+        }
       })
 
       applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(exp))
@@ -229,13 +238,17 @@ class CombinationSpec extends BaseCompilerSpec {
 
       val exp = reify(comprehension[(User, User), DataBag] {
         val xy = generator[(User, User), DataBag] {
-          val users$1 = users
-          val users$2 = users
+          val users$1: test.schema.Marketing.users.type = users
+          val users$2: test.schema.Marketing.users.type = users
           val kx = (x: User) => x.id
           val ky = (y: User) => y.id
           equiJoin(kx, ky)(users$1, users$2)
         }
-        head { (xy._1, xy._2) }
+        head {
+          val x = xy._1
+          val y = xy._2
+          (x, y)
+        }
       })
 
       applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(exp))
@@ -356,7 +369,11 @@ class CombinationSpec extends BaseCompilerSpec {
           val x = xy._1
           val y = xy._2
           x.id != y.id
-        } map { xy => (xy._1, xy._2) }
+        } map { xy =>
+          val x = xy._1
+          val y = xy._2
+          (x, y)
+        }
       }
 
       combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
@@ -375,7 +392,11 @@ class CombinationSpec extends BaseCompilerSpec {
         cross(
           users withFilter { _.id != 3 },
           users withFilter { _.id != 5 }
-        ) map { xy => (xy._1, xy._2) }
+        ) map { xy =>
+          val x = xy._1
+          val y = xy._2
+          (x, y)
+        }
       }
 
       combine(inp) shouldBe alphaEqTo(liftPipeline(exp))
@@ -524,7 +545,8 @@ class CombinationSpec extends BaseCompilerSpec {
           x.id != y
         }
         val z = generator[User, DataBag] {
-          DataBag(Seq(xy._1))
+          val x = xy._1
+          DataBag(Seq(x))
         }
         head {
           val x = xy._1
@@ -559,7 +581,11 @@ class CombinationSpec extends BaseCompilerSpec {
           do us2 = us2 union us2 while (us2.size < 100)
           cross(us1, us2)
         }
-        head { (xy._1, xy._2) }
+        head {
+          val x = xy._1
+          val y = xy._2
+          (x, y)
+        }
       })
 
       applyOnce(MatchCross)(inp) shouldBe alphaEqTo(liftPipeline(exp))
@@ -591,7 +617,11 @@ class CombinationSpec extends BaseCompilerSpec {
           val ky = (y: User) => y.id
           equiJoin(kx, ky)(us1, us2)
         }
-        head { (xy._1, xy._2) }
+        head {
+          val x = xy._1
+          val y = xy._2
+          (x, y)
+        }
       })
 
       applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(exp))

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugarSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugarSpec.scala
@@ -25,6 +25,7 @@ import test.schema.Marketing._
 class ReDeSugarSpec extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
 
   // ---------------------------------------------------------------------------
   // Helper methods
@@ -57,15 +58,13 @@ class ReDeSugarSpec extends BaseCompilerSpec {
 
   // map
   val (des1, res1) = {
-
-    val des = u.reify {
-      val names = users
-        .map(u => (u.name.first, u.name.last))
+    val des = reify {
+      val names = users.map(u => (u.name.first, u.name.last))
       names
     }
 
-    val res = u.reify {
-      val users$1 = users
+    val res = reify {
+      val users$1: test.schema.Marketing.users.type = users
       val names$1 = comprehension[(String, String), DataBag] {
         val u = generator(users$1)
         head {
@@ -80,15 +79,13 @@ class ReDeSugarSpec extends BaseCompilerSpec {
 
   // flatMap
   val (des2, res2) = {
-
-    val des = u.reify {
-      val names = users
-        .flatMap(u => DataBag(Seq(u.name.first, u.name.last)))
+    val des = reify {
+      val names = users.flatMap(u => DataBag(Seq(u.name.first, u.name.last)))
       names
     }
 
-    val res = u.reify {
-      val users$1 = users
+    val res = reify {
+      val users$1: test.schema.Marketing.users.type = users
       val names$1 = flatten[String, DataBag] {
         comprehension[DataBag[String], DataBag] {
           val u = generator(users$1)
@@ -105,20 +102,18 @@ class ReDeSugarSpec extends BaseCompilerSpec {
 
   // withFilter
   val (des3, res3) = {
-
-    val des = u.reify {
-      val names = users
-        .withFilter(u => u.name.first != "John")
+    val des = reify {
+      val names = users.withFilter(u => u.name.first != "John")
       names
     }
 
-    val res = u.reify {
-      val users$1 = users
+    val res = reify {
+      val users$1: test.schema.Marketing.users.type = users
       val names$1 = comprehension[User, DataBag] {
         val u = generator(users$1)
         guard {
-          val name$1 = u.name
-          val first$1 = name$1.first
+          val name$1: u.name.type = u.name
+          val first$1: name$1.first.type = name$1.first
           val neq$1 = first$1 != "John"
           neq$1
         }
@@ -135,7 +130,7 @@ class ReDeSugarSpec extends BaseCompilerSpec {
   // nested (flat)maps - 2 generators
   val (des4, res4, nor4) = {
 
-    val des = u.reify {
+    val des = reify {
       val users$1 = users
       val clicks$1 = clicks
       val names = users$1
@@ -144,7 +139,7 @@ class ReDeSugarSpec extends BaseCompilerSpec {
       names
     }
 
-    val res = u.reify {
+    val res = reify {
       val users$1 = users
       val clicks$1 = clicks
       val names$1 = flatten[(User, Click), DataBag] {
@@ -164,7 +159,7 @@ class ReDeSugarSpec extends BaseCompilerSpec {
       names$1
     }
 
-    val nor = u.reify {
+    val nor = reify {
       val users$1 = users
       val clicks$1 = clicks
       val names = comprehension[(User, Click), DataBag] {
@@ -182,8 +177,7 @@ class ReDeSugarSpec extends BaseCompilerSpec {
 
   // nested (flat)maps - 3 generators
   val (des5, res5) = {
-
-    val des = u.reify {
+    val des = reify {
       val names = users
         .flatMap(u => clicks
           .flatMap(c => ads
@@ -191,18 +185,18 @@ class ReDeSugarSpec extends BaseCompilerSpec {
       names
     }
 
-    val res = u.reify {
-      val users$1 = users
+    val res = reify {
+      val users$1: test.schema.Marketing.users.type = users
       val names = flatten[(Ad, User, Click), DataBag] {
         comprehension[DataBag[(Ad, User, Click)], DataBag] {
           val u = generator(users$1)
           head {
-            val clicks$1 = clicks
+            val clicks$1: test.schema.Marketing.clicks.type = clicks
             val flatMap$1 = flatten[(Ad, User, Click), DataBag] {
               comprehension[DataBag[(Ad, User, Click)], DataBag] {
                 val c = generator(clicks$1)
                 head {
-                  val ads$1 = ads
+                  val ads$1: test.schema.Marketing.ads.type = ads
                   val map$1 = comprehension[(Ad, User, Click), DataBag] {
                     val a = generator(ads$1)
                     head {
@@ -225,8 +219,7 @@ class ReDeSugarSpec extends BaseCompilerSpec {
 
   // nested (flat)maps - 3 generators and a filter
   val (des6, res6) = {
-
-    val des = u.reify {
+    val des = reify {
       val names = users
         .flatMap(u => clicks
           .withFilter(_.userID == u.id)
@@ -234,13 +227,13 @@ class ReDeSugarSpec extends BaseCompilerSpec {
       names
     }
 
-    val res = u.reify {
-      val users$1 = users
+    val res = reify {
+      val users$1: test.schema.Marketing.users.type = users
       val names = flatten[(Ad, User, Click), DataBag] {
         comprehension[DataBag[(Ad, User, Click)], DataBag] {
           val u = generator(users$1)
           head {
-            val clicks$1 = clicks
+            val clicks$1: test.schema.Marketing.clicks.type = clicks
             val withFilter$1 = comprehension[Click, DataBag] {
               val c = generator(clicks$1)
               guard {
@@ -255,7 +248,7 @@ class ReDeSugarSpec extends BaseCompilerSpec {
               comprehension[DataBag[(Ad, User, Click)], DataBag] {
                 val c = generator(withFilter$1)
                 head {
-                  val ads$1 = ads
+                  val ads$1: test.schema.Marketing.ads.type = ads
                   val map$1 = comprehension[(Ad, User, Click), DataBag] {
                     val a = generator(ads$1)
                     head {
@@ -278,16 +271,15 @@ class ReDeSugarSpec extends BaseCompilerSpec {
 
   // with two correlated generators
   val (des7, res7, nor7) = {
-
-    val des = u.reify {
+    val des = reify {
       val res = xs
         .flatMap(x =>  DataBag(Seq(x, x))
           .map(y => (x, y)))
       res
     }
 
-    val res = u.reify {
-      val xs$1 = xs
+    val res = reify {
+      val xs$1: this.xs.type = xs
       val res = flatten[(Int, Int), DataBag] {
         comprehension[DataBag[(Int, Int)], DataBag] {
           val x = generator[Int, DataBag] { xs$1 }
@@ -309,8 +301,8 @@ class ReDeSugarSpec extends BaseCompilerSpec {
       res
     }
 
-    val nor = u.reify {
-      val xs$1 = xs
+    val nor = reify {
+      val xs$1: this.xs.type = xs
       val res = comprehension[(Int, Int), DataBag] {
         val x = generator[Int, DataBag] { xs$1 }
         val y = generator[Int, DataBag] {
@@ -328,16 +320,15 @@ class ReDeSugarSpec extends BaseCompilerSpec {
 
   // with two correlated generators and a filter
   val (des8, res8) = {
-
-    val des = u.reify {
+    val des = reify {
       val names = users
         .flatMap(u =>  DataBag(Seq(u.name.first, u.name.last))
           .withFilter(_.contains(u.id.toString)))
       names
     }
 
-    val res = u.reify {
-      val users$1 = users
+    val res = reify {
+      val users$1: test.schema.Marketing.users.type = users
       val names = flatten[String, DataBag] {
         comprehension[DataBag[String], DataBag] {
           val u = generator[User, DataBag] { users$1 }
@@ -362,20 +353,20 @@ class ReDeSugarSpec extends BaseCompilerSpec {
 
   // degenerate flatMap
   val (des9, res9, nor9) = {
-
-    val des = u.reify {
-      val users$1 = users
+    val des = reify {
+      val users$1  = users
       val clicks$1 = clicks
       val clicks$2 = users$1
         .flatMap(_ => clicks$1)
       clicks$2
     }
 
-    val res = u.reify {
-      val users$1 = users
+    val res = reify {
+      val users$1  = users
       val clicks$1 = clicks
       val clicks$2 = flatten[Click, DataBag] {
         comprehension[DataBag[Click], DataBag] {
+          //noinspection ScalaUnusedSymbol
           val u = generator(users$1)
           head(clicks$1)
         }
@@ -383,10 +374,11 @@ class ReDeSugarSpec extends BaseCompilerSpec {
       clicks$2
     }
 
-    val nor = u.reify {
+    val nor = reify {
       val users$1 = users
       val clicks$1 = clicks
       val clicks$2 = comprehension[Click, DataBag] {
+        //noinspection ScalaUnusedSymbol
         val u = generator(users$1)
         val c = generator(clicks$1)
         head(c)
@@ -401,7 +393,6 @@ class ReDeSugarSpec extends BaseCompilerSpec {
   // ---------------------------------------------------------------------------
 
   "resugar" - {
-
     "map" in {
       resugarPipeline(des1) shouldBe alphaEqTo(anfPipeline(res1))
     }

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/ANFSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/ANFSpec.scala
@@ -24,7 +24,9 @@ import test.schema.Math._
 
 /** A spec for the `ANF.transform` transformation. */
 class ANFSpec extends BaseCompilerSpec {
+
   import compiler._
+  import universe.reify
 
   val anfPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
@@ -42,15 +44,17 @@ class ANFSpec extends BaseCompilerSpec {
     }
   }
 
-  "field selections" - {
+  def abcx(x: A.B.C.x.type) =
+    x.trim.toInt
 
+  "field selections" - {
     "as argument" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         15 * t._1
       })
 
-      val exp = idPipeline(u.reify {
-        val x$1 = t
+      val exp = idPipeline(reify {
+        val x$1: this.t.type = t
         val x$2 = x$1._1
         val x$3 = 15 * x$2
         x$3
@@ -60,12 +64,12 @@ class ANFSpec extends BaseCompilerSpec {
     }
 
     "as selection" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         (t._1 * 15).toDouble
       })
 
-      val exp = idPipeline(u.reify {
-        val t$1 = t
+      val exp = idPipeline(reify {
+        val t$1: this.t.type = t
         val t_1$1 = t$1._1
         val prod$1 = t_1$1 * 15
         val d$1 = prod$1.toDouble
@@ -76,12 +80,12 @@ class ANFSpec extends BaseCompilerSpec {
     }
 
     "package selections" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         val bag = DataBag(Seq(1, 2, 3))
         scala.Predef.println(bag.fetch())
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         val x$1 = Seq(1, 2, 3)
         val bag = DataBag(x$1)
         val x$2 = bag.fetch()
@@ -95,13 +99,13 @@ class ANFSpec extends BaseCompilerSpec {
 
   "complex arguments" - {
     "lhs" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         y.substring(y.indexOf('l') + 1)
       })
 
-      val exp = idPipeline(u.reify {
-        val y$1 = y
-        val y$2 = y
+      val exp = idPipeline(reify {
+        val y$1: this.y.type = y
+        val y$2: this.y.type = y
         val x$1 = y$2.indexOf('l')
         val x$2 = x$1 + 1
         val x$3 = y$1.substring(x$2)
@@ -112,11 +116,11 @@ class ANFSpec extends BaseCompilerSpec {
     }
 
     "with multiple parameter lists" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         List(1, 2, 3).foldLeft(0)(_ * _)
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         val list$1 = List(1, 2, 3)
         val mult$1 = (x: Int, y: Int) => {
           val prod$1 = x * y
@@ -131,7 +135,7 @@ class ANFSpec extends BaseCompilerSpec {
   }
 
   "nested blocks" in {
-    val act = anfPipeline(u.reify {
+    val act = anfPipeline(reify {
       val a = {
         val b = y.indexOf('T')
         b + 15
@@ -143,11 +147,11 @@ class ANFSpec extends BaseCompilerSpec {
       a * c
     })
 
-    val exp = idPipeline(u.reify {
-      val y$1 = y
+    val exp = idPipeline(reify {
+      val y$1: this.y.type = y
       val b$1 = y$1.indexOf('T')
       val a = b$1 + 15
-      val y$2 = y
+      val y$2: this.y.type = y
       val b$2 = y$2.indexOf('a')
       val c = b$2 + 15
       val prod$1 = a * c
@@ -158,11 +162,11 @@ class ANFSpec extends BaseCompilerSpec {
   }
 
   "type ascriptions" in {
-    val act = anfPipeline(u.reify {
+    val act = anfPipeline(reify {
       (x: AnyVal).toString
     })
 
-    val exp = idPipeline(u.reify {
+    val exp = idPipeline(reify {
       val a$1 = x
       val a$2 = a$1: AnyVal
       val b$1 = a$2.toString
@@ -173,8 +177,7 @@ class ANFSpec extends BaseCompilerSpec {
   }
 
   "bypass mock comprehensions" in {
-
-    val act = anfPipeline(u.reify {
+    val act = anfPipeline(reify {
       val res = comprehension {
         val u = generator(users)
         val a = generator(ads)
@@ -186,18 +189,18 @@ class ANFSpec extends BaseCompilerSpec {
       res
     })
 
-    val exp = idPipeline(u.reify {
+    val exp = idPipeline(reify {
       val res = comprehension {
         val u = generator[User, DataBag] {
-          val users$1 = users
+          val users$1: test.schema.Marketing.users.type = users
           users$1
         }
         val a = generator[Ad, DataBag] {
-          val ads$1 = ads
+          val ads$1: test.schema.Marketing.ads.type = ads
           ads$1
         }
         val c = generator[Click, DataBag] {
-          val clicks$1 = clicks
+          val clicks$1: test.schema.Marketing.clicks.type = clicks
           clicks$1
         }
         guard {
@@ -213,8 +216,8 @@ class ANFSpec extends BaseCompilerSpec {
           x$6
         }
         head {
-          val x$7 = c.time
-          val x$8 = a.`class`
+          val x$7: c.time.type = c.time
+          val x$8: a.`class`.type = a.`class`
           val x$9 = (x$7, x$8)
           x$9
         }
@@ -227,14 +230,14 @@ class ANFSpec extends BaseCompilerSpec {
 
   "irrefutable pattern matching" - {
     "of tuples" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         ("life", 42) match {
           case (s: String, i: Int) =>
             s + i
         }
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         val x$1 = ("life", 42)
         val s = x$1._1
         val i = x$1._2
@@ -246,14 +249,14 @@ class ANFSpec extends BaseCompilerSpec {
     }
 
     "of case classes" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         Point(1, 2) match {
           case Point(i, j) =>
             i + j
         }
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         val p$1 = Point(1, 2)
         val i = p$1.x
         val j = p$1.y
@@ -265,23 +268,23 @@ class ANFSpec extends BaseCompilerSpec {
     }
 
     "of nested product types" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         (Point(1, 2), (3, 4)) match {
           case (a@Point(i, j), (m, n)) =>
             a.copy(x = i * m, y = j * n)
         }
       })
 
-      val exp = idPipeline(u.reify {
+      val exp = idPipeline(reify {
         val point$1 = Point(1, 2)
         val pair$1 = (3, 4)
         val pair$2 = (point$1, pair$1)
         val a = pair$2._1
         val i = a.x
         val j = a.y
-        val pair$3 = pair$2._2
+        val pair$3: pair$2._2.type = pair$2._2
         val m = pair$3._1
-        val pair$4 = pair$2._2
+        val pair$4: pair$2._2.type = pair$2._2
         val n = pair$4._2
         val prod$1 = i * m
         val prod$2 = j * n
@@ -294,14 +297,14 @@ class ANFSpec extends BaseCompilerSpec {
   }
 
   "method calls" in {
-    val act = anfPipeline(u.reify(
+    val act = anfPipeline(reify(
       x.asInstanceOf[Long],
       List(1, 2, 3).foldLeft(1) { _ + _ },
       42.toChar,
       t._2.indexOf('f')
     ))
 
-    val exp = idPipeline(u.reify {
+    val exp = idPipeline(reify {
       val x$1 = this.x
       val asInstanceOf$1 = x$1.asInstanceOf[Long]
       val List$1 = List(1, 2, 3)
@@ -311,8 +314,8 @@ class ANFSpec extends BaseCompilerSpec {
       }
       val foldLeft$1 = List$1.foldLeft(1)(sum$1)
       val toChar$1 = 42.toChar
-      val t$1 = this.t
-      val _2$1 = t$1._2
+      val t$1: this.t.type = this.t
+      val _2$1: t$1._2.type = t$1._2
       val indexOf$1 = _2$1.indexOf('f')
       val Tuple$1 = (asInstanceOf$1, foldLeft$1, toChar$1, indexOf$1)
       Tuple$1
@@ -323,12 +326,12 @@ class ANFSpec extends BaseCompilerSpec {
 
   "conditionals" - {
     "with simple branches" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         if (t._1 < 42) "less" else "more"
       })
 
-      val exp = idPipeline(u.reify {
-        val t$1 = t
+      val exp = idPipeline(reify {
+        val t$1: this.t.type = t
         val t_1$1 = t$1._1
         val less$1 = t_1$1 < 42
         val if$1 = if (less$1) "less" else "more"
@@ -339,12 +342,12 @@ class ANFSpec extends BaseCompilerSpec {
     }
 
     "with complex branches" in {
-      val act = anfPipeline(u.reify {
+      val act = anfPipeline(reify {
         if (t._1 < 42) x + 10 else x - 10.0
       })
 
-      val exp = idPipeline(u.reify {
-        val t$1 = t
+      val exp = idPipeline(reify {
+        val t$1: this.t.type = t
         val t_1$1 = t$1._1
         val less$1 = t_1$1 < 42
         val if$1 = if (less$1) {
@@ -365,11 +368,11 @@ class ANFSpec extends BaseCompilerSpec {
   }
 
   "variable length arguments" in {
-    val act = anfPipeline(u.reify {
+    val act = anfPipeline(reify {
       Seq(Seq(1, 2, 3 + x): _*)
     })
 
-    val exp = idPipeline(u.reify {
+    val exp = idPipeline(reify {
       val x$1 = this.x
       val sum$1 = 3 + x$1
       val Seq$1 = Seq(1, 2, sum$1)
@@ -381,16 +384,17 @@ class ANFSpec extends BaseCompilerSpec {
   }
 
   "path-dependent types" in {
-    val act = anfPipeline(u.reify {
-      A.B.C.x
+    val act = anfPipeline(reify {
+      abcx(A.B.C.x)
     })
 
-    val exp = idPipeline(u.reify {
-      val A$1 = this.A
-      val B$1 = A$1.B
-      val C$1 = B$1.C
-      val x$1 = C$1.x
-      x$1
+    val exp = idPipeline(reify {
+      val A$1: this.A.type = this.A
+      val B$1: A$1.B.type = A$1.B
+      val C$1: B$1.C.type = B$1.C
+      val x$1: C$1.x.type = C$1.x
+      val abcx$1 = abcx(x$1)
+      abcx$1
     })
 
     act shouldBe alphaEqTo(exp)

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DCESpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DCESpec.scala
@@ -22,6 +22,7 @@ import compiler.BaseCompilerSpec
 class DCESpec extends BaseCompilerSpec {
 
   import compiler._
+  import universe.reify
 
   val dcePipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
@@ -30,15 +31,15 @@ class DCESpec extends BaseCompilerSpec {
     ).compose(_.tree)
 
   "eliminate unused valdefs" - {
-
     "directly" in {
-      val act = dcePipeline(u.reify {
+      //noinspection ScalaUnusedSymbol
+      val act = dcePipeline(reify {
         val x = 15
         15 * t._1
       })
 
-      val exp = idPipeline(u.reify {
-        val x$1 = t
+      val exp = idPipeline(reify {
+        val x$1: this.t.type = t
         val x$2 = x$1._1
         val x$3 = 15 * x$2
         x$3
@@ -48,14 +49,15 @@ class DCESpec extends BaseCompilerSpec {
     }
 
     "transitively" in {
-      val act = dcePipeline(u.reify {
+      //noinspection ScalaUnusedSymbol
+      val act = dcePipeline(reify {
         val x = 15
         val y = 2 * x
         15 * t._1
       })
 
-      val exp = idPipeline(u.reify {
-        val x$1 = t
+      val exp = idPipeline(reify {
+        val x$1: this.t.type = t
         val x$2 = x$1._1
         val x$3 = 15 * x$2
         x$3
@@ -67,13 +69,14 @@ class DCESpec extends BaseCompilerSpec {
 
   "don't eliminate unit valdefs" - {
     "println" in {
-      val act = dcePipeline(u.reify {
+      val act = dcePipeline(reify {
         println("alma")
         val x = 5
         x
       })
 
-      val exp = idPipeline(u.reify {
+      //noinspection ScalaUnusedSymbol
+      val exp = idPipeline(reify {
         val res = println("alma")
         val x = 5
         x


### PR DESCRIPTION
Before:
```scala
val tuple = ("answer", 42)
val x$1: String = tuple._1
```
After:
```scala
val tuple = ("answer", 42)
val x$1: tuple._1.type = tuple._1
```

* Improves path-dependent type support (see `ANFSpec`)
* Sometimes avoids inaccessible type issues
* Fixed a bug in `Type.tree`
* Refactored `ReDeSugar`
* Adjusted specs where necessary