### PR TITLE
[IR] Ensure type-safe transformations (most cases)

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/ast/Symbols.scala
@@ -273,7 +273,8 @@ trait Symbols { this: AST =>
             } else tpe
             // Can't be fused with the traversal above,
             // because method calls might appear before their definition.
-            if (dict.isEmpty) tree else TopDown.transform { case t
+            // Unsafe: The type of substituted symbols might change.
+            if (dict.isEmpty) tree else TopDown.unsafe.transform { case t
               if has.tpe(t) || (has.sym(t) && dict.contains(t.symbol))
               => Tree.With(t)(sym = dict(t.symbol), tpe = subst(t.tpe))
             }._tree(tree)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
@@ -248,7 +248,8 @@ private[core] trait DSCF extends Common {
               method -> api.Sym.With.tpe(method, tpe)
             } (breakOut)
 
-          api.BottomUp.withOwner.transformWith {
+          // Unsafe: The result type changes to Some(result).
+          api.BottomUp.unsafe.withOwner.transformWith {
             case Attr.inh(core.Let(vals, defs, expr), owner :: _) =>
               if (defs.isEmpty && api.Sym.findAnn[suffix](owner).isDefined) f(vals, expr)
               else core.Let(vals, defs, expr)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Trampoline.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Trampoline.scala
@@ -51,8 +51,9 @@ private[core] trait Trampoline extends Common {
      * - All return values and tail calls are wrapped in a trampoline.
      * - The ANF shape of the input is NOT preserved.
      */
-    lazy val transform: u.Tree => u.Tree = api.BottomUp.withAncestors
-      .inherit { // Local method definitions.
+    // Unsafe: Return type of methods changes to TailRec[OriginalType].
+    lazy val transform: u.Tree => u.Tree = api.BottomUp.unsafe
+      .withAncestors.inherit { // Local method definitions.
         case core.Let(_, defs, _) =>
           (for (core.DefDef(method, tparams, paramss, _) <- defs) yield {
             val (own, nme, pos) = (method.owner, method.name, method.pos)


### PR DESCRIPTION
Hook to bypass type-safety assertions: `Strategy.unsafe`.
Unsafe transformations are:
* `api.Tree.rename` - might change symbol infos
* `Core.trampoline` - wraps method return types in `TailRec`
* `DSCF.mapSuffix`  - when a different result type is specified