### PR TITLE
[API] Added `DataBag.zipWithIndex` and reworked `DataBag.sample`.

### DIFF
--- a/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/DataBag.scala
@@ -106,7 +106,7 @@ trait DataBag[A] extends Serializable {
   def groupBy[K: Meta](k: (A) => K): DataBag[Group[K, DataBag[A]]]
 
   // -----------------------------------------------------
-  // Set operations
+  // Set Ops
   // -----------------------------------------------------
 
   /**
@@ -131,6 +131,33 @@ trait DataBag[A] extends Serializable {
    * @return A version of this DataBag without duplicate entries.
    */
   def distinct: DataBag[A]
+
+  // -----------------------------------------------------
+  // Partition-based Ops
+  // -----------------------------------------------------
+
+  /**
+   * Creates a sample of up to `k` elements using reservoir sampling initialized with the given `seed`.
+   *
+   * If the collection represented by the [[DataBag]] instance contains less then `n` elements,
+   * the resulting collection is trimmed to a smaller size.
+   *
+   * The method should be deterministic for a fixed [[DataBag]] instance with a materialized result.
+   * In other words, calling `xs.sample(n)(seed)` two times in succession will return the same result.
+   *
+   * The result, however, might vary between program runs and [[DataBag]] implementations.
+   */
+  def sample(k: Int, seed: Long = 5394826801L): Vector[A]
+
+  /**
+   * Zips the elements of this collection with a unique dense index.
+   *
+   * The method should be deterministic for a fixed [[DataBag]] instance with a materialized result.
+   * In other words, calling `xs.zipWithIndex()` two times in succession will return the same result.
+   *
+   * The result, however, might vary between program runs and [[DataBag]] implementations.
+   */
+  def zipWithIndex(): DataBag[(A, Long)]
 
   // -----------------------------------------------------
   // Sinks
@@ -317,17 +344,6 @@ trait DataBag[A] extends Serializable {
    */
   def top(n: Int)(implicit o: Ordering[A]): List[A] =
     fold(Top(n, o))
-
-  /**
-   * Take a random sample of specified size.
-   *
-   * @param n number of elements to return
-   * @return a [[List]] of `n` random elements
-   */
-  def sample(n: Int): List[A] = {
-    if (n <= 0) List.empty[A]
-    else fold(Sample[A](n))._2
-  }
 
   // -----------------------------------------------------
   // equals and hashCode

--- a/emma-language/src/main/scala/org/emmalanguage/api/ScalaSeq.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/ScalaSeq.scala
@@ -78,6 +78,25 @@ class ScalaSeq[A] private[api](private[api] val rep: Seq[A]) extends DataBag[A] 
     rep.distinct
 
   // -----------------------------------------------------
+  // Partition-based Ops
+  // -----------------------------------------------------
+
+  def sample(k: Int, seed: Long = 5394826801L): Vector[A] = {
+    val sample = new collection.mutable.ArrayBuffer[A](k)
+    val random = util.RanHash(seed)
+    for ((e, i) <- rep.zipWithIndex) {
+      if (i >= k) {
+        val j = random.nextInt(i + 1)
+        if (j < k) sample(j) = e
+      } else sample += e
+    }
+    sample.toVector
+  }
+
+  def zipWithIndex(): DataBag[(A, Long)] =
+    rep zip Stream.iterate(0L)(_ + 1)
+
+  // -----------------------------------------------------
   // Sinks
   // -----------------------------------------------------
 

--- a/emma-language/src/main/scala/org/emmalanguage/api/alg/Alg.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/alg/Alg.scala
@@ -176,22 +176,6 @@ case class Top[A](n: Int, ord: Ordering[A]) extends Alg[A, List[A]] {
   val plus: (List[A], List[A]) => List[A] = bottom.plus
 }
 
-/** Constructed by `xs.sample(n)`. */
-case class Sample[A](n: Int) extends Alg[A, (Long, List[A])] {
-  private def now = System.nanoTime()
-
-  val zero: (Long, List[A]) = (now, Nil)
-  val init: A => (Long, List[A]) = x => (now ^ x.hashCode, x :: Nil)
-  val plus: ((Long, List[A]), (Long, List[A])) => (Long, List[A]) = {
-    case ((hx, xs), (hy, ys)) =>
-      val pair@(seed, xys) = (hx ^ hy, xs ++ ys)
-      if (xys.size <= n) pair else {
-        val rand = new Random(seed)
-        (rand.nextLong(), rand.shuffle(xys).take(n))
-      }
-  }
-}
-
 // -------------------------------------------------------
 // Algebras encoding fused MonadOps
 // -------------------------------------------------------

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/API.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/API.scala
@@ -78,9 +78,12 @@ protected[emmalanguage] trait API extends AST {
     val withFilter            = op("withFilter")
     // Grouping
     val groupBy               = op("groupBy")
-    // Set operations
+    // Set ops
     val union                 = op("union")
     val distinct              = op("distinct")
+    // Partition-based ops
+    val sample                = op("sample")
+    val zipWithIndex          = op("zipWithIndex")
     // Structural recursion & Folds
     val fold1                 = op("fold", List(1 /*alg*/ , 1 /*meta*/))
     val fold2                 = op("fold", List(1 /*zero*/ , 2 /*init, plus*/ , 1 /*meta*/))
@@ -99,12 +102,12 @@ protected[emmalanguage] trait API extends AST {
     val find                  = op("find")
     val bottom                = op("bottom")
     val top                   = op("top")
-    val sample                = op("sample")
 
     val sinkOps               = Set(fetch, as, writeCSV, writeParquet, writeText)
     val monadOps              = Set(map, flatMap, withFilter)
     val nestOps               = Set(groupBy)
     val boolAlgOps            = Set(union, distinct)
+    val partOps               = Set(sample, zipWithIndex)
     val foldOps               = Set(
       fold1, fold2,
       isEmpty, nonEmpty,
@@ -112,11 +115,10 @@ protected[emmalanguage] trait API extends AST {
       min, max, sum, product,
       size, count,
       exists, forall,
-      find, top, bottom,
-      sample
+      find, top, bottom
     )
 
-    val ops = sinkOps | monadOps | nestOps | boolAlgOps | foldOps
+    val ops = sinkOps | monadOps | nestOps | boolAlgOps | partOps | foldOps
     //@formatter:on
   }
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Compiler.scala
@@ -106,9 +106,11 @@ trait Compiler extends AlphaEq
     val sEnv = ConfigFactory.systemEnvironment()
 
     val cfgs = for {
-      n <- paths.map(_.stripPrefix("/"))
-      _ <- Option(getClass.getResource(s"/$n"))
-    } yield ConfigFactory.parseResources(n, opts)
+      p <- paths.map(_.stripPrefix("/"))
+    } yield Option(getClass.getResource(s"/$p")) match {
+      case Some(_) => ConfigFactory.parseResources(p, opts)
+      case None => abort(s"Cannot find Emma config resource `/$p`")
+    }
 
     cfgs
       .foldLeft(sEnv withFallback sPrp)((acc, cfg) => acc withFallback cfg)

--- a/emma-language/src/main/scala/org/emmalanguage/util/RanHash.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/util/RanHash.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright © 2014 TU Berlin (emma@dima.tu-berlin.de)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.emmalanguage
+package util
+
+import java.io.Serializable
+
+/**
+ * c.f. "Press, William H. Numerical recipes 3rd edition: The art of scientific computing. Cambridge
+ * university press, 2007.", pp. 352
+ */
+class RanHash private(val seed: Long, var currPos: Long = 0) extends Serializable {
+
+  def at(pos: Long): RanHash = {
+    currPos = pos
+    this
+  }
+
+  def skip(pos: Long): RanHash = {
+    currPos += pos
+    this
+  }
+
+  def fork: RanHash =
+    new RanHash(seed)
+
+  def toStream: Stream[Double] = {
+    val rand = this.fork
+    Stream.continually(rand.next())
+  }
+
+  def next(): Double = {
+    var x = seed + currPos
+    x = 3935559000370003845L * x + 2691343689449507681L
+    x = x ^ (x >> 21)
+    x = x ^ (x << 37)
+    x = x ^ (x >> 4)
+    x = 4768777513237032717L * x
+    x = x ^ (x << 20)
+    x = x ^ (x >> 41)
+    x = x ^ (x << 5)
+    currPos += 1
+    x * RanHash.D_2_POW_NEG_64 + 0.5
+  }
+
+  def nextInt(k: Int): Int =
+    Math.floor(next * k).toInt
+
+  def nextLong(k: Long): Long =
+    Math.floor(next * k).toLong
+}
+
+object RanHash {
+  private val D_2_POW_NEG_64 = 5.4210108624275221700e-20
+
+  def apply(seed: Long, substream: Int = 0): RanHash =
+    new RanHash(seed + substream * (2L << 54))
+}

--- a/emma-language/src/test/scala/org/emmalanguage/api/DataBagSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/api/DataBagSpec.scala
@@ -65,191 +65,211 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
   // spec tests
   // ---------------------------------------------------------------------------
 
-  "structural recursion" in {
-    withBackendContext { implicit ctx =>
-      val act = {
-        val vs = TestBag(Seq((0, 0.0)))
-        val ws = TestBag(Seq(0))
-        val xs = TestBag(hhCrts)
-        val ys = TestBag(hhCrts.map(DataBagSpec.f))
-        val zs = TestBag(Seq.empty[Double])
+  "structural recursion" in withBackendContext { implicit ctx =>
+    val act = {
+      val vs = TestBag(Seq((0, 0.0)))
+      val ws = TestBag(Seq(0))
+      val xs = TestBag(hhCrts)
+      val ys = TestBag(hhCrts.map(DataBagSpec.f))
+      val zs = TestBag(Seq.empty[Double])
 
-        Seq(
-          //@formatter:off
-          "isEmpty"     -> xs.isEmpty,
-          "nonEmpty"    -> xs.nonEmpty,
-          "min (1)"     -> vs.min,
-          "min (2)"     -> ws.min,
-          "min (3)"     -> vs.min,
-          "max (1)"     -> vs.max,
-          "max (2)"     -> ws.max,
-          "max (3)"     -> ys.max,
-          "sum (1)"     -> ys.sum,
-          "sum (2)"     -> zs.sum,
-          "product (1)" -> ys.product,
-          "product (2)" -> zs.product,
-          "size (1)"    -> xs.size,
-          "size (2)"    -> zs.size,
-          "count (1)"   -> xs.count(_.name startsWith "Zaphod"),
-          "count (2)"   -> zs.count(_ < 42.0),
-          "existsP"     -> xs.exists(_.name startsWith "Arthur"),
-          "existsN"     -> xs.exists(_.name startsWith "Marvin"),
-          "forallP"     -> xs.forall(_.name startsWith "Arthur"),
-          "forallN"     -> xs.forall(_.name startsWith "Trillian"),
-          "findP"       -> xs.find(_.name startsWith "Ford"),
-          "findN"       -> xs.find(_.name startsWith "Marvin"),
-          "bottom"      -> ys.bottom(1),
-          "top"         -> ys.top(2)
-          //@formatter:on
-        )
-      }
-
-      val exp = {
-        val vs = TestBag(Seq((0, 0.0)))
-        val ws = Seq(0)
-        val xs = hhCrts
-        val ys = hhCrts.map(_.book.title.length)
-        val zs = Seq.empty[Double]
-
-        Seq(
-          //@formatter:off
-          "isEmpty"     -> xs.isEmpty,
-          "nonEmpty"    -> xs.nonEmpty,
-          "min (1)"     -> vs.min,
-          "min (2)"     -> ws.min,
-          "min (3)"     -> vs.min,
-          "max (1)"     -> vs.max,
-          "max (2)"     -> ws.max,
-          "max (3)"     -> ys.max,
-          "sum (1)"     -> ys.sum,
-          "sum (2)"     -> zs.sum,
-          "product (1)" -> ys.product,
-          "product (2)" -> zs.product,
-          "size (1)"    -> xs.size,
-          "size (2)"    -> zs.size,
-          "count (1)"   -> xs.count(_.name startsWith "Zaphod"),
-          "count (2)"   -> zs.count(_ < 42.0),
-          "existsP"     -> xs.exists(_.name startsWith "Arthur"),
-          "existsN"     -> xs.exists(_.name startsWith "Marvin"),
-          "forallP"     -> xs.forall(_.name startsWith "Arthur"),
-          "forallN"     -> xs.forall(_.name startsWith "Trillian"),
-          "findP"       -> xs.find(_.name startsWith "Ford"),
-          "findN"       -> xs.find(_.name startsWith "Marvin"),
-          "bottom"      -> ys.sorted.slice(ys.length - 1, ys.length),
-          "top"         -> ys.sorted.slice(0, 2)
-          //@formatter:on
-        )
-      }
-
-
-      withClue("Bag.empty[(Int, Double)].min throws `NoSuchElementException`") {
-        intercept[NoSuchElementException](TestBag.empty[(Int, Double)].min)
-      }
-      withClue("Bag.empty[Int].max throws `NoSuchElementException`") {
-        intercept[NoSuchElementException](TestBag.empty[Int].max)
-      }
-
-      act should have size exp.size
-
-      for ((k, v) <- exp)
-        act should contain(k, v)
+      Seq(
+        //@formatter:off
+        "isEmpty"     -> xs.isEmpty,
+        "nonEmpty"    -> xs.nonEmpty,
+        "min (1)"     -> vs.min,
+        "min (2)"     -> ws.min,
+        "min (3)"     -> vs.min,
+        "max (1)"     -> vs.max,
+        "max (2)"     -> ws.max,
+        "max (3)"     -> ys.max,
+        "sum (1)"     -> ys.sum,
+        "sum (2)"     -> zs.sum,
+        "product (1)" -> ys.product,
+        "product (2)" -> zs.product,
+        "size (1)"    -> xs.size,
+        "size (2)"    -> zs.size,
+        "count (1)"   -> xs.count(_.name startsWith "Zaphod"),
+        "count (2)"   -> zs.count(_ < 42.0),
+        "existsP"     -> xs.exists(_.name startsWith "Arthur"),
+        "existsN"     -> xs.exists(_.name startsWith "Marvin"),
+        "forallP"     -> xs.forall(_.name startsWith "Arthur"),
+        "forallN"     -> xs.forall(_.name startsWith "Trillian"),
+        "findP"       -> xs.find(_.name startsWith "Ford"),
+        "findN"       -> xs.find(_.name startsWith "Marvin"),
+        "bottom"      -> ys.bottom(1),
+        "top"         -> ys.top(2)
+        //@formatter:on
+      )
     }
+
+    val exp = {
+      val vs = TestBag(Seq((0, 0.0)))
+      val ws = Seq(0)
+      val xs = hhCrts
+      val ys = hhCrts.map(_.book.title.length)
+      val zs = Seq.empty[Double]
+
+      Seq(
+        //@formatter:off
+        "isEmpty"     -> xs.isEmpty,
+        "nonEmpty"    -> xs.nonEmpty,
+        "min (1)"     -> vs.min,
+        "min (2)"     -> ws.min,
+        "min (3)"     -> vs.min,
+        "max (1)"     -> vs.max,
+        "max (2)"     -> ws.max,
+        "max (3)"     -> ys.max,
+        "sum (1)"     -> ys.sum,
+        "sum (2)"     -> zs.sum,
+        "product (1)" -> ys.product,
+        "product (2)" -> zs.product,
+        "size (1)"    -> xs.size,
+        "size (2)"    -> zs.size,
+        "count (1)"   -> xs.count(_.name startsWith "Zaphod"),
+        "count (2)"   -> zs.count(_ < 42.0),
+        "existsP"     -> xs.exists(_.name startsWith "Arthur"),
+        "existsN"     -> xs.exists(_.name startsWith "Marvin"),
+        "forallP"     -> xs.forall(_.name startsWith "Arthur"),
+        "forallN"     -> xs.forall(_.name startsWith "Trillian"),
+        "findP"       -> xs.find(_.name startsWith "Ford"),
+        "findN"       -> xs.find(_.name startsWith "Marvin"),
+        "bottom"      -> ys.sorted.slice(ys.length - 1, ys.length),
+        "top"         -> ys.sorted.slice(0, 2)
+        //@formatter:on
+      )
+    }
+
+
+    withClue("Bag.empty[(Int, Double)].min throws `NoSuchElementException`") {
+      intercept[NoSuchElementException](TestBag.empty[(Int, Double)].min)
+    }
+    withClue("Bag.empty[Int].max throws `NoSuchElementException`") {
+      intercept[NoSuchElementException](TestBag.empty[Int].max)
+    }
+
+    act should have size exp.size
+
+    for ((k, v) <- exp)
+      act should contain(k, v)
   }
 
   "monad ops" - {
+    "map" in withBackendContext { implicit ctx =>
+      val act = TestBag(hhCrts)
+        .map(c => c.name)
 
-    "map" in {
-      withBackendContext { implicit ctx =>
-        val act = TestBag(hhCrts)
-          .map(c => c.name)
+      val exp = hhCrts
+        .map(c => c.name)
 
-        val exp = hhCrts
-          .map(c => c.name)
-
-        act shouldEqual DataBag(exp)
-      }
+      act shouldEqual DataBag(exp)
     }
 
-    "flatMap" in {
-      withBackendContext { implicit ctx =>
-        val act = TestBag(Seq((hhBook, hhCrts)))
-          .flatMap { case (b, cs) => DataBag(cs) }
+    "flatMap" in withBackendContext { implicit ctx =>
+      val act = TestBag(Seq((hhBook, hhCrts)))
+        .flatMap { case (b, cs) => DataBag(cs) }
 
-        val exp = Seq((hhBook, hhCrts))
-          .flatMap { case (b, cs) => cs }
+      val exp = Seq((hhBook, hhCrts))
+        .flatMap { case (b, cs) => cs }
 
-        act shouldEqual DataBag(exp)
-      }
+      act shouldEqual DataBag(exp)
     }
 
-    "withFilter" in {
-      withBackendContext { implicit spark =>
-        val act = TestBag(Seq(hhBook))
-          .withFilter(_.title == "The Hitchhiker's Guide to the Galaxy")
+    "withFilter" in withBackendContext { implicit spark =>
+      val act = TestBag(Seq(hhBook))
+        .withFilter(_.title == "The Hitchhiker's Guide to the Galaxy")
 
-        val exp = Seq(hhBook)
-          .filter(_.title == "The Hitchhiker's Guide to the Galaxy")
+      val exp = Seq(hhBook)
+        .filter(_.title == "The Hitchhiker's Guide to the Galaxy")
 
-        act shouldEqual DataBag(exp)
-      }
+      act shouldEqual DataBag(exp)
     }
 
-    "for-comprehensions" in {
-      withBackendContext { implicit ctx =>
-        val act = for {
-          b <- TestBag(Seq(hhBook))
-          c <- ScalaSeq(hhCrts) // nested DataBag cannot be RDDDataBag, as those are not serializable
-          if b.title == c.book.title
-          if b.title == "The Hitchhiker's Guide to the Galaxy"
-        } yield (b.title, c.name)
+    "for-comprehensions" in withBackendContext { implicit ctx =>
+      val act = for {
+        b <- TestBag(Seq(hhBook))
+        c <- ScalaSeq(hhCrts) // nested DataBag cannot be RDDDataBag, as those are not serializable
+        if b.title == c.book.title
+        if b.title == "The Hitchhiker's Guide to the Galaxy"
+      } yield (b.title, c.name)
 
-        val exp = for {
-          b <- Seq(hhBook)
-          c <- hhCrts
-          if b.title == c.book.title
-          if b.title == "The Hitchhiker's Guide to the Galaxy"
-        } yield (b.title, c.name)
-
-        act shouldEqual DataBag(exp)
-      }
-    }
-  }
-
-  "grouping" in {
-    withBackendContext { implicit ctx =>
-      val act = TestBag(hhCrts).groupBy(_.book)
-
-      val exp = hhCrts.groupBy(_.book).toSeq.map {
-        case (k, vs) => Group(k, DataBag(vs))
-      }
+      val exp = for {
+        b <- Seq(hhBook)
+        c <- hhCrts
+        if b.title == c.book.title
+        if b.title == "The Hitchhiker's Guide to the Galaxy"
+      } yield (b.title, c.name)
 
       act shouldEqual DataBag(exp)
     }
   }
 
-  "set operations" - {
+  "grouping" in withBackendContext { implicit ctx =>
+    val act = TestBag(hhCrts).groupBy(_.book)
 
+    val exp = hhCrts.groupBy(_.book).toSeq.map {
+      case (k, vs) => Group(k, DataBag(vs))
+    }
+
+    act shouldEqual DataBag(exp)
+  }
+
+  "set operations" - {
     val xs = Seq("foo", "bar", "baz", "boo", "buz", "baz", "bag")
     val ys = Seq("fuu", "bin", "bar", "bur", "lez", "liz", "lag")
 
-    "union" in {
-      withBackendContext { implicit ctx =>
-        val act = TestBag(xs) union TestBag(ys)
-        val exp = xs union ys
+    "union" in withBackendContext { implicit ctx =>
+      val act = TestBag(xs) union TestBag(ys)
+      val exp = xs union ys
 
-        act shouldEqual DataBag(exp)
-      }
+      act shouldEqual DataBag(exp)
     }
 
-    "distinct" in {
-      withBackendContext { implicit ctx =>
-        val acts = Seq(TestBag(xs).distinct, TestBag(ys).distinct)
-        val exps = Seq(xs.distinct, ys.distinct)
+    "distinct" in withBackendContext { implicit ctx =>
+      val acts = Seq(TestBag(xs).distinct, TestBag(ys).distinct)
+      val exps = Seq(xs.distinct, ys.distinct)
 
-        for ((act, exp) <- acts zip exps)
-          act shouldEqual TestBag(exp)
-      }
+      for ((act, exp) <- acts zip exps)
+        act shouldEqual TestBag(exp)
     }
+  }
+
+  "sample" - {
+    val s1 = 54326427L
+    val s2 = 23546473L
+
+    "with k >= bag.size" in withBackendContext { implicit ctx =>
+      val xs = TestBag(0 to 7)
+      xs.sample(8) should contain theSameElementsAs (0 to 7)
+      xs.sample(9) should contain theSameElementsAs (0 to 7)
+    }
+
+    "with k < bag.size" in withBackendContext { implicit ctx =>
+      val xs = TestBag(0 to 7)
+      xs.sample(1) shouldEqual xs.sample(1)
+      xs.sample(7) shouldEqual xs.sample(7)
+    }
+
+    "with matching explicit seeds" in withBackendContext { implicit ctx =>
+      val xs = TestBag(0 to 7)
+      xs.sample(1, s1) shouldEqual xs.sample(1, s1)
+      xs.sample(7, s1) shouldEqual xs.sample(7, s1)
+    }
+
+    "with non-matching explicit seeds" in withBackendContext { implicit ctx =>
+      val xs = TestBag(0 to 7)
+      xs.sample(1, s1) shouldNot equal(xs.sample(1, s2))
+      xs.sample(4, s1) shouldNot equal(xs.sample(4, s2))
+    }
+  }
+
+  "zipWithIndex" in withBackendContext { implicit ctx =>
+    val xs = (('a' to 'z') ++ ('A' to 'Z')).map(_.toString)
+
+    val act = TestBag(xs).zipWithIndex().map(_._2)
+    val exp = 0L to 51L
+
+    act shouldEqual DataBag(exp)
   }
 
   "empty" in withBackendContext(implicit ctx =>
@@ -268,12 +288,12 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
 
     "Book" - {
       val exp = Seq(hhBook)
-      s"can read native output" ifSupportsCSV withBackendContext { implicit ctx =>
+      "can read native output" ifSupportsCSV withBackendContext { implicit ctx =>
         val pat = path(s"books.native.csv")
         DataBag(exp).writeCSV(pat, format)
         TestBag.readCSV[Book](pat, format) shouldEqual DataBag(exp)
       }
-      s"can read backend output" ifSupportsCSV withBackendContext { implicit ctx =>
+      "can read backend output" ifSupportsCSV withBackendContext { implicit ctx =>
         val pat = path(s"books.$suffix.csv")
         TestBag(exp).writeCSV(pat, format)
         TestBag.readCSV[Book](pat, format) shouldEqual DataBag(exp)
@@ -282,12 +302,12 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
 
     "Record" - {
       val exp = csvRecords()
-      s"can read native output" ifSupportsCSV withBackendContext { implicit ctx =>
+      "can read native output" ifSupportsCSV withBackendContext { implicit ctx =>
         val pat = path(s"records.native.csv")
         DataBag(exp).writeCSV(pat, format)
         TestBag.readCSV[CSVRecord](pat, format) shouldEqual DataBag(exp)
       }
-      s"can read backend output" ifSupportsCSV withBackendContext { implicit ctx =>
+      "can read backend output" ifSupportsCSV withBackendContext { implicit ctx =>
         val pat = path(s"records.$suffix.csv")
         TestBag(exp).writeCSV(pat, format)
         TestBag.readCSV[CSVRecord](pat, format) shouldEqual DataBag(exp)
@@ -304,12 +324,12 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
 
     "Book" - {
       val exp = Seq(hhBook)
-      s"can read native output" ifSupportsParquet withBackendContext { implicit ctx =>
+      "can read native output" ifSupportsParquet withBackendContext { implicit ctx =>
         val pat = path(s"books.native.parquet")
         DataBag(exp).writeParquet(pat, format)
         TestBag.readParquet[Book](pat, format) shouldEqual DataBag(exp)
       }
-      s"can read backend output" ifSupportsParquet withBackendContext { implicit ctx =>
+      "can read backend output" ifSupportsParquet withBackendContext { implicit ctx =>
         val pat = path(s"books.$suffix.parquet")
         TestBag(exp).writeParquet(pat, format)
         TestBag.readParquet[Book](pat, format) shouldEqual DataBag(exp)
@@ -318,12 +338,12 @@ trait DataBagSpec extends FreeSpec with Matchers with PropertyChecks with DataBa
 
     "Record" - {
       val exp = parquetRecords()
-      s"can read native output" ifSupportsParquet withBackendContext { implicit ctx =>
+      "can read native output" ifSupportsParquet withBackendContext { implicit ctx =>
         val pat = path(s"records.native.parquet")
         DataBag(exp).writeParquet(pat, format)
         TestBag.readParquet[ParquetRecord](pat, format).fetch() should contain theSameElementsAs exp
       }
-      s"can read backend output" ifSupportsParquet withBackendContext { implicit ctx =>
+      "can read backend output" ifSupportsParquet withBackendContext { implicit ctx =>
         val pat = path(s"records.$suffix.parquet")
         TestBag(exp).writeParquet(pat, format)
         TestBag.readParquet[ParquetRecord](pat, format).fetch() should contain theSameElementsAs exp

--- a/emma-language/src/test/scala/org/emmalanguage/api/ScalaSeqSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/api/ScalaSeqSpec.scala
@@ -16,8 +16,6 @@
 package org.emmalanguage
 package api
 
-import io.csv.{CSV, CSVConverter}
-
 class ScalaSeqSpec extends DataBagSpec {
 
   override type TestBag[A] = ScalaSeq[A]

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/opt/FoldForestFusionSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/opt/FoldForestFusionSpec.scala
@@ -79,7 +79,6 @@ class FoldForestFusionSpec extends BaseCompilerSpec {
           rands.find(`_ > 0`),
           rands.bottom(10),
           rands.top(10),
-          rands.sample(10),
           rands.reduce(0)(`_ * _ % 5`),
           rands.reduceOption(`_.abs min _.abs`)
         )
@@ -96,7 +95,6 @@ class FoldForestFusionSpec extends BaseCompilerSpec {
         val alg$Max$r1 = alg.Max(Ordering.Int)
         val alg$Min$r1 = alg.Min(Ordering.Int)
         val alg$Product$r1 = alg.Product(Numeric.IntIsIntegral)
-        val alg$Sample$r1 = alg.Sample[Int](10)
         val alg$Sum$r1 = alg.Sum(Numeric.IntIsIntegral)
         val alg$Top$r1 = alg.Top(10, Ordering.Int)
         val rands = this.rands
@@ -106,33 +104,31 @@ class FoldForestFusionSpec extends BaseCompilerSpec {
         val alg$Forall$r1 = alg.Forall(`_ != 0$r1`)
         val alg$Reduce$r1 = alg.Reduce(0, `_ * _ % 5$r1`)
         val alg$ReduceOpt$r1 = alg.ReduceOpt(`_.abs min _.abs$r1`)
-        val alg$Alg16$r1 = alg.Alg16(
-          alg$Max$r1, alg$Min$r1, alg$Sample$r1, alg$Bottom$r1, alg$Count$r1, alg$Exists$r1, alg$Find$r1,
+        val alg$Alg15$r1 = alg.Alg15(
+          alg$Max$r1, alg$Min$r1, alg$Bottom$r1, alg$Count$r1, alg$Exists$r1, alg$Find$r1,
           alg$Forall$r1, alg.IsEmpty, alg.NonEmpty, alg$Product$r1, alg$Reduce$r1, alg$ReduceOpt$r1, alg.Size,
           alg$Sum$r1, alg$Top$r1)
-        val app$Alg16$r1 = rands fold alg$Alg16$r1
-        val app$Max$r1 = app$Alg16$r1._1
-        val app$Min$r1 = app$Alg16$r1._2
-        val app$Sample$r1 = app$Alg16$r1._3
-        val bottom$r1 = app$Alg16$r1._4
-        val count$r1 = app$Alg16$r1._5
-        val exists$r1 = app$Alg16$r1._6
-        val find$r1 = app$Alg16$r1._7
-        val forall$r1 = app$Alg16$r1._8
-        val isEmpty$r1 = app$Alg16$r1._9
-        val nonEmpty$r1 = app$Alg16$r1._10
-        val product$r1 = app$Alg16$r1._11
-        val reduce$r1 = app$Alg16$r1._12
-        val reduceOption$r1 = app$Alg16$r1._13
-        val size$r1 = app$Alg16$r1._14
-        val sum$r1 = app$Alg16$r1._15
-        val top$r1 = app$Alg16$r1._16
+        val app$Alg15$r1 = rands fold alg$Alg15$r1
+        val app$Max$r1 = app$Alg15$r1._1
+        val app$Min$r1 = app$Alg15$r1._2
+        val bottom$r1 = app$Alg15$r1._3
+        val count$r1 = app$Alg15$r1._4
+        val exists$r1 = app$Alg15$r1._5
+        val find$r1 = app$Alg15$r1._6
+        val forall$r1 = app$Alg15$r1._7
+        val isEmpty$r1 = app$Alg15$r1._8
+        val nonEmpty$r1 = app$Alg15$r1._9
+        val product$r1 = app$Alg15$r1._10
+        val reduce$r1 = app$Alg15$r1._11
+        val reduceOption$r1 = app$Alg15$r1._12
+        val size$r1 = app$Alg15$r1._13
+        val sum$r1 = app$Alg15$r1._14
+        val top$r1 = app$Alg15$r1._15
         val max$r1 = app$Max$r1.get
         val min$r1 = app$Min$r1.get
-        val sample$r1 = app$Sample$r1._2
         val apply$r1 = (
           isEmpty$r1, nonEmpty$r1, size$r1, min$r1, max$r1, sum$r1, product$r1, count$r1, exists$r1,
-          forall$r1, find$r1, bottom$r1, top$r1, sample$r1, reduce$r1, reduceOption$r1)
+          forall$r1, find$r1, bottom$r1, top$r1, reduce$r1, reduceOption$r1)
         apply$r1
       })
 


### PR DESCRIPTION
Resolves #61 by adding a `DataBag.zipWithIndex` method.

In addition, reworked `DataBag.sample` as a reservoir sampling algorithm, which if not fully deterministic, at least makes it a bit more predictable. Subsequent calls of `xs.sample(k)` on the same object `xs` should return the same value in most situations.

As @fschueler proposed the addition in #61, I suggest he takes care of the review.