### PR TITLE
Added inverse DSCF transform

### DIFF
--- a/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/compiler/FlinkMacro.scala
@@ -59,12 +59,18 @@ class FlinkMacro(val c: blackbox.Context) extends MacroCompiler with FlinkCompil
     if (cfg.getBoolean("emma.compiler.opt.auto-cache")) {
       xfms += Backend.addCacheCalls
     }
-    // standard suffix
-    xfms ++= Seq(
-      Comprehension.combine,
-      Backend.specialize(FlinkAPI),
-      Core.trampoline
-    )
+
+    xfms += Comprehension.combine
+
+    xfms += Backend.specialize(FlinkAPI)
+
+    cfg.getString("emma.compiler.lower") match {
+      case "trampoline" =>
+        xfms += Core.trampoline
+      case "dscfInv" =>
+        xfms += Core.dscfInv
+    }
+
     // construct the compilation pipeline
     pipeline()(xfms.result(): _*).compose(_.tree)
   }

--- a/emma-language/src/main/resources/reference.emma.conf
+++ b/emma-language/src/main/resources/reference.emma.conf
@@ -5,6 +5,7 @@ emma {
       fold-fusion = true
       auto-cache = true
     }
+    lower = "dscfInv" // 'dscfInv' or 'trampoline'
     print-result = false
   }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
@@ -187,7 +187,7 @@ private[comprehension] trait Combination extends Common {
      *   }
      * }}}
      */
-    val MatchFlatMap: Rule = {
+    val MatchFlatMap1: Rule = {
       case (_, cs.Comprehension(qs, hd)) => (for {
         xGen @ cs.Generator(x, xRhs) <- qs.view
         (qs1, qs23) = splitAt[u.Tree](xGen)(qs)
@@ -507,7 +507,7 @@ private[comprehension] trait Combination extends Common {
      *   $mapped
      * }}}
      */
-    val MatchResidual: Rule = {
+    val MatchMap: Rule = {
       case (owner, cs.Comprehension(Seq(cs.Generator(x, rhs)), cs.Head(hd))) =>
         val tpe = if (x.info =:= hd.tpe) None else Some(api.Type(DataBag.tpe, Seq(hd.tpe)))
         Some(Core.mapSuffix(rhs, tpe) { (vals, expr) =>
@@ -519,8 +519,8 @@ private[comprehension] trait Combination extends Common {
     }
 
     private val rules = Seq(
-      MatchFilter, MatchFlatMap, MatchFlatMap2,
-      MatchEquiJoin, MatchCross, MatchResidual)
+      MatchFilter, MatchFlatMap1, MatchFlatMap2,
+      MatchEquiJoin, MatchCross, MatchMap)
 
     /** Creates a ValDef, and returns its Ident on the left hand side. */
     private def valRefAndDef(own: u.Symbol, name: String, rhs: u.Tree): (u.Ident, u.ValDef) = {

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
@@ -20,6 +20,7 @@ import compiler.Common
 import compiler.ir.DSCFAnnotations._
 import compiler.lang.AlphaEq
 import compiler.lang.comprehension.Comprehension
+import compiler.lang.cf.ControlFlow
 import compiler.lang.source.Source
 
 /** Core language. */
@@ -33,7 +34,7 @@ private[compiler] trait Core extends Common
   with Pickling
   with Reduce
   with Trampoline {
-  self: AlphaEq with Source =>
+  self: AlphaEq with Source with ControlFlow =>
 
   import API._
   import UniverseImplicits._
@@ -311,6 +312,9 @@ private[compiler] trait Core extends Common
 
     /** Delegates to [[DSCF.transform]]. */
     lazy val dscf = DSCF.transform
+
+    /** Delegates to [[DSCF.inverse]] */
+    lazy val dscfInv = DSCF.inverse
 
     /** Delegates to [[ANF.transform]]. */
     lazy val anf = ANF.transform

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
@@ -84,7 +84,7 @@ class CombinationSpec extends BaseCompilerSpec {
       applyOnce(MatchFilter)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "flatMap" in {
+    "flatMap1" in {
       val inp = reify(comprehension[Long, DataBag] {
         val x = generator[User, DataBag] { users }
         val y = generator[Long, DataBag] {
@@ -100,7 +100,7 @@ class CombinationSpec extends BaseCompilerSpec {
         head { y }
       })
 
-      applyOnce(MatchFlatMap)(inp) shouldBe alphaEqTo(liftPipeline(exp))
+      applyOnce(MatchFlatMap1)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
     "flatMap2" in {
@@ -322,7 +322,7 @@ class CombinationSpec extends BaseCompilerSpec {
 
       val exp = reify(users map { x => x })
       val lifted = liftPipeline(exp)
-      applyOnce(MatchResidual)(inp) shouldBe alphaEqTo(lifted)
+      applyOnce(MatchMap)(inp) shouldBe alphaEqTo(lifted)
       combine(inp) shouldBe alphaEqTo(lifted)
     }
   }
@@ -489,7 +489,7 @@ class CombinationSpec extends BaseCompilerSpec {
       applyOnce(MatchFilter)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "flatMap" in {
+    "flatMap1" in {
       val inp = reify(comprehension[Long, DataBag] {
         val x = generator[User, DataBag] {
           var us = users
@@ -511,7 +511,7 @@ class CombinationSpec extends BaseCompilerSpec {
         head { y }
       })
 
-      applyOnce(MatchFlatMap)(inp) shouldBe alphaEqTo(liftPipeline(exp))
+      applyOnce(MatchFlatMap1)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
     "flatMap2" in {
@@ -627,7 +627,7 @@ class CombinationSpec extends BaseCompilerSpec {
       applyOnce(MatchEquiJoin)(inp) shouldBe alphaEqTo(liftPipeline(exp))
     }
 
-    "residual" in {
+    "map" in {
       val inp = reify(comprehension[User, DataBag] {
         val x = generator[User, DataBag] {
           var us = users
@@ -644,7 +644,7 @@ class CombinationSpec extends BaseCompilerSpec {
       }
 
       val lifted = liftPipeline(exp)
-      applyOnce(MatchResidual)(inp) shouldBe alphaEqTo(lifted)
+      applyOnce(MatchMap)(inp) shouldBe alphaEqTo(lifted)
       combine(inp) shouldBe alphaEqTo(lifted)
     }
   }

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkMacro.scala
@@ -72,7 +72,12 @@ class SparkMacro(val c: blackbox.Context) extends MacroCompiler with SparkCompil
         }
     }
 
-    xfms += Core.trampoline
+    cfg.getString("emma.compiler.lower") match {
+      case "trampoline" =>
+        xfms += Core.trampoline
+      case "dscfInv" =>
+        xfms += Core.dscfInv
+    }
 
     // construct the compilation pipeline
     pipeline()(xfms.result(): _*).compose(_.tree)


### PR DESCRIPTION
One can now choose between `dscfInv` and `trampoline` with the `emma.compiler.lower` parameter.

Resolves #280.