### PR TITLE
TreeTransform case class for tree transformations

### DIFF
--- a/emma-flink/src/main/scala/org/emmalanguage/FlinkCompilerAware.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/FlinkCompilerAware.scala
@@ -31,6 +31,6 @@ trait FlinkCompilerAware extends RuntimeCompilerAware {
 
   def Env: u.Type = FlinkAPI.ExecutionEnvironment
 
-  def transformations(cfg: Config): Seq[u.Tree => u.Tree] =
+  def transformations(cfg: Config): Seq[TreeTransform] =
     compiler.transformations(cfg)
 }

--- a/emma-flink/src/main/scala/org/emmalanguage/compiler/backend/FlinkBackend.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/compiler/backend/FlinkBackend.scala
@@ -57,7 +57,7 @@ private[compiler] trait FlinkBackend extends Common {
     } yield srcOp -> tgtOp) (breakOut): Map[u.MethodSymbol, u.MethodSymbol]
 
     /** Specialize backend for Flink. */
-    val transform: u.Tree => u.Tree = tree => {
+    val transform: TreeTransform = TreeTransform("FlinkBackend.transform", tree => {
       val G = ControlFlow.cfg(tree)
       val C = Context.bCtxGraph(G)
       val V = G.data.labNodes.map(_.label)
@@ -192,7 +192,7 @@ private[compiler] trait FlinkBackend extends Common {
             broadcastOps.getOrElse(lhs, Seq(value))
           }, defs, expr)
       })._tree(tree)
-    }
+    })
 
     private lazy val cs = Comprehension.Syntax(API.DataBag.sym)
 

--- a/emma-flink/src/main/scala/org/emmalanguage/compiler/opt/FlinkSpecializeLoops.scala
+++ b/emma-flink/src/main/scala/org/emmalanguage/compiler/opt/FlinkSpecializeLoops.scala
@@ -43,7 +43,7 @@ private[opt] trait FlinkSpecializeLoops {
      * (i.e., it  should correspond to a dataflow consisting only of sources
      * and transformations) and should not depend on the iterator variable.
      */
-    lazy val specializeLoops: u.Tree => u.Tree = tree => {
+    lazy val specializeLoops: TreeTransform = TreeTransform("FlinkSpecializeLoops.specializeLoops", tree => {
       val G = ControlFlow.cfg(tree)
       api.BottomUp.withValUses.transformWith({
         case Attr.syn(t@core.Let(
@@ -137,7 +137,7 @@ private[opt] trait FlinkSpecializeLoops {
 
           api.Owner.at(loop.owner)(rslt)
       })._tree(tree)
-    }
+    })
 
     private type VMap = Map[u.Symbol, u.Tree]
 

--- a/emma-flink/src/test/scala/org/emmalanguage/compiler/opt/FlinkSpecializeLoopsSpec.scala
+++ b/emma-flink/src/test/scala/org/emmalanguage/compiler/opt/FlinkSpecializeLoopsSpec.scala
@@ -37,7 +37,7 @@ class FlinkSpecializeLoopsSpec extends BaseCompilerSpec with FlinkAware {
   lazy val testPipeline: u.Expr[Any] => u.Tree =
     pipeline(true)(
       Core.lift,
-      tree => time(FlinkSpecializeLoops.specializeLoops(tree), "specializeLoops")
+      (tree: u.Tree) => time(FlinkSpecializeLoops.specializeLoops(tree), FlinkSpecializeLoops.specializeLoops.name)
     ).compose(_.tree)
 
   lazy val dscfPipeline: u.Expr[Any] => u.Tree =

--- a/emma-language/src/main/scala/org/emmalanguage/api/emma/QuoteMacro.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/api/emma/QuoteMacro.scala
@@ -33,8 +33,8 @@ class QuoteMacro(val c: blackbox.Context) extends MacroCompiler {
   lazy val quotePipeline: c.Expr[Any] => u.Tree =
     pipeline()(qualifyThis).compose(_.tree)
 
-  lazy val qualifyThis = api.BottomUp.transform {
+  lazy val qualifyThis = TreeTransform("qualifyThis", api.BottomUp.transform {
     case api.This(sym) if sym.isClass && sym.isStatic =>
       api.Ref(sym.asClass.module)
-  }._tree
+  }._tree)
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/Common.scala
@@ -31,16 +31,16 @@ trait Common extends AST with API {
   // --------------------------------------------------------------------------
 
   /** Standard pipeline prefix. Brings a tree into a form convenient for transformation. */
-  def preProcess: Seq[u.Tree => u.Tree]
+  def preProcess: Seq[TreeTransform]
 
   /** Standard pipeline suffix. Brings a tree into a form acceptable for `scalac` after being transformed. */
-  def postProcess: Seq[u.Tree => u.Tree]
+  def postProcess: Seq[TreeTransform]
 
   /** Combines a sequence of `transformations` into a pipeline with pre- and post-processing. */
   def pipeline(
     typeCheck: Boolean = false, withPre: Boolean = true, withPost: Boolean = true
   )(
-    transformations: (u.Tree => u.Tree)*
+    transformations: TreeTransform*
   ): u.Tree => u.Tree
 
   /** The identity transformation with pre- and post-processing. */

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Combination.scala
@@ -57,11 +57,11 @@ private[comprehension] trait Combination extends Common {
      *
      * - An ANF tree with no mock-comprehensions.
      */
-    val transform: u.Tree => u.Tree =
+    val transform: TreeTransform = TreeTransform("Combination.transform",
       api.TopDown.withOwner.transformWith {
         case Attr.inh(comp @ cs.Comprehension(_, _), owner :: _) =>
           combine(owner, comp)
-      }.andThen(_.tree)
+      }.andThen(_.tree))
 
     /**
      * Performs the combination for one comprehension. That is, the root of the given tree

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Comprehension.scala
@@ -44,19 +44,19 @@ private[compiler] trait Comprehension extends Common
     // -------------------------------------------------------------------------
 
     /** Delegates to [[ReDeSugar.resugar()]]. */
-    def resugar(monad: u.Symbol): u.Tree => u.Tree =
+    def resugar(monad: u.Symbol): TreeTransform =
       ReDeSugar.resugar(monad)
 
     /** Delegates to [[ReDeSugar.desugar()]]. */
-    def desugar(monad: u.Symbol): u.Tree => u.Tree =
+    def desugar(monad: u.Symbol): TreeTransform =
       ReDeSugar.desugar(monad)
 
     /** `resugar` the default [[DataBag]] monad. */
-    lazy val resugarDataBag: u.Tree => u.Tree =
+    lazy val resugarDataBag: TreeTransform =
       ReDeSugar.resugar(API.DataBag.sym)
 
     /** `desugar` the default [[DataBag]] monad. */
-    lazy val desugarDataBag: u.Tree => u.Tree =
+    lazy val desugarDataBag: TreeTransform =
       ReDeSugar.desugar(API.DataBag.sym)
 
     // -------------------------------------------------------------------------
@@ -68,7 +68,7 @@ private[compiler] trait Comprehension extends Common
       Normalize.normalize(monad)(tree)
 
     /** `normalize` the default [[DataBag]] monad. */
-    lazy val normalizeDataBag: u.Tree => u.Tree =
+    lazy val normalizeDataBag: TreeTransform =
       Normalize.normalize(API.DataBag.sym)
 
     // -------------------------------------------------------------------------

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Normalize.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/Normalize.scala
@@ -41,7 +41,7 @@ private[comprehension] trait Normalize extends Common {
      * @param monad The symbol of the monad syntax to be normalized.
      * @return The normalized input tree.
      */
-    def normalize(monad: u.Symbol): u.Tree => u.Tree = {
+    def normalize(monad: u.Symbol): TreeTransform = TreeTransform("Normalize.normalize", {
       // construct comprehension syntax helper for the given monad
       val cs = Syntax(monad)
       val nr = NormalizationRules(cs)
@@ -49,7 +49,7 @@ private[comprehension] trait Normalize extends Common {
       strategy.transformWith({ case attr@Attr.inh(_: u.Block, parent :: _)
         if nr.isValid(parent) => nr.UnnestGenerator(attr).getOrElse(attr.tree)
       })._tree
-    }
+    })
   }
 
   private case class NormalizationRules(cs: ComprehensionSyntax) {

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugar.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugar.scala
@@ -48,7 +48,7 @@ private[comprehension] trait ReDeSugar extends Common {
      * @param monad The symbol of the monad to be resugared.
      * @return A resugaring transformation for that particular monad.
      */
-    def resugar(monad: u.Symbol): u.Tree => u.Tree = {
+    def resugar(monad: u.Symbol): TreeTransform = TreeTransform("ReDeSugar.resugar", {
       // Construct comprehension syntax helper for the given monad
       val cs = Comprehension.Syntax(monad)
       // Handle the case when a lambda is defined externally
@@ -100,7 +100,7 @@ private[comprehension] trait ReDeSugar extends Common {
               cs.Guard(asLet(body))),
               cs.Head(core.Let(expr = core.Ref(sym)))))
       }._tree andThen Core.dce
-    }
+    })
 
     /**
      * Desugars mock-comprehension syntax into monad ops.
@@ -116,7 +116,7 @@ private[comprehension] trait ReDeSugar extends Common {
      * @param monad The symbol of the monad syntax to be desugared.
      * @return A desugaring transformation for that particular monad.
      */
-    def desugar(monad: u.Symbol): u.Tree => u.Tree = {
+    def desugar(monad: u.Symbol): TreeTransform = TreeTransform("ReDeSugar.desugar", {
       // construct comprehension syntax helper for the given monad
       val cs = Comprehension.Syntax(monad)
       api.TopDown.withOwner.transformWith {
@@ -176,6 +176,6 @@ private[comprehension] trait ReDeSugar extends Common {
               core.Let(allVals, Seq.empty, core.Ref(opSym))
           }
       }._tree.andThen(Core.unnest)
-    }
+    })
   }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/ANF.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/ANF.scala
@@ -35,7 +35,7 @@ private[core] trait ANF extends Common {
   private[core] object ANF {
 
     /** The ANF transformation. */
-    private lazy val anf: u.Tree => u.Tree =
+    private lazy val anf: TreeTransform = TreeTransform("ANF.anf",
       api.BottomUp.withParent.withOwner.transformWith {
         // lit | this | x
         case Attr.inh(src.Atomic(atom), _ :: parent :: _) => parent.collect {
@@ -155,7 +155,7 @@ private[core] trait ANF extends Common {
           }
 
           src.Block(stats ++ inner, expr)
-      }._tree.andThen(api.Owner.atEncl)
+      }._tree.andThen(api.Owner.atEncl))
 
     /**
      * Converts a tree into administrative normal form (ANF).
@@ -168,7 +168,7 @@ private[core] trait ANF extends Common {
      *
      * @return An ANF version of the input tree.
      */
-    lazy val transform: u.Tree => u.Tree =
+    lazy val transform: TreeTransform =
       resolveNameClashes andThen anf
 
     /**
@@ -180,7 +180,7 @@ private[core] trait ANF extends Common {
      * == Postconditions ==
      * - An ANF tree where all nested blocks have been flattened.
      */
-    lazy val unnest: u.Tree => u.Tree =
+    lazy val unnest: TreeTransform = TreeTransform("ANF.unnest",
       api.BottomUp.transform {
         case parent @ core.Let(vals, defs, expr) if hasNestedLets(parent) =>
           // Flatten nested let expressions in value position without control flow.
@@ -208,7 +208,7 @@ private[core] trait ANF extends Common {
 
           val (trimmedVals, trimmedExpr) = trimVals(flatVals ++ exprVals, flatExpr)
           core.Let(trimmedVals, flatDefs, trimmedExpr)
-      }._tree.andThen(api.Owner.atEncl)
+      }._tree.andThen(api.Owner.atEncl))
 
     // ---------------
     // Helper methods

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/CSE.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/CSE.scala
@@ -50,7 +50,7 @@ private[core] trait CSE extends Common {
     def transform(
       revTab: Map[HKey, u.TermSymbol],
       aliases: Map[u.Symbol, u.Tree]
-    ): u.Tree => u.Tree = api.TopDown.break.transform {
+    ): TreeTransform = TreeTransform("CSE.transform", api.TopDown.break.transform {
       // Substitute aliases.
       case core.Ref(target) if aliases contains target =>
         aliases(target)
@@ -89,7 +89,7 @@ private[core] trait CSE extends Common {
         }
     } andThen (_.tree) andThen {
       api.Tree.rename(for ((k, core.Ref(v)) <- aliases.toSeq) yield k -> v)
-    }
+    })
 
     // ---------------
     // Helper methods

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Core.scala
@@ -300,15 +300,15 @@ private[compiler] trait Core extends Common
     // -------------------------------------------------------------------------
 
     /** Lifting. The canonical compiler frontend. */
-    lazy val lift: u.Tree => u.Tree = Function.chain(Seq(
-      lnf,
-      Comprehension.resugarDataBag,
-      Comprehension.normalizeDataBag,
+    lazy val lift: TreeTransform = {
+      lnf andThen
+      Comprehension.resugarDataBag andThen
+      Comprehension.normalizeDataBag andThen
       Reduce.transform
-    ))
+    }
 
     /** Chains [[ANF.transform]], and [[DSCF.transform]]. */
-    lazy val lnf: u.Tree => u.Tree = anf andThen dscf
+    lazy val lnf: TreeTransform = anf andThen dscf
 
     /** Delegates to [[DSCF.transform]]. */
     lazy val dscf = DSCF.transform
@@ -323,7 +323,7 @@ private[compiler] trait Core extends Common
     lazy val unnest = ANF.unnest
 
     /** Reduce an Emma Core term. */
-    lazy val reduce: u.Tree => u.Tree =
+    lazy val reduce: TreeTransform =
       Reduce.transform
 
     /** Delegates to [[DSCF.stripAnnotations]]. */
@@ -345,7 +345,7 @@ private[compiler] trait Core extends Common
     // -------------------------------------------------------------------------
 
     /** Delegates to [[CSE.transform()]]. */
-    lazy val cse: u.Tree => u.Tree =
+    lazy val cse: TreeTransform =
       CSE.transform(Map.empty, Map.empty)
 
     // -------------------------------------------------------------------------

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DCE.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DCE.scala
@@ -38,7 +38,7 @@ private[core] trait DCE extends Common {
      * == Postconditions ==
      * - All unused value definitions are pruned.
      */
-    lazy val transform: u.Tree => u.Tree =
+    lazy val transform: TreeTransform = TreeTransform("DCE.transform",
       api.BottomUp.withDefCalls.withValUses.transformSyn {
         case Attr(let @ core.Let(vals, defs, expr), _, _, syn) =>
           def refs(tree: u.Tree) = syn(tree).head.keySet
@@ -71,7 +71,7 @@ private[core] trait DCE extends Common {
           val liveVals = vals.filter(liveRefs.compose(_.symbol.asTerm))
           if (liveVals.size == vals.size && liveDefs.size == defs.size) let
           else core.Let(liveVals, liveDefs, expr)
-      }.andThen(_.tree)
+      }.andThen(_.tree))
 
     private def maybeMutable(method: u.MethodSymbol): Boolean = {
       method.returnType =:= api.Type[Unit]

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/DSCF.scala
@@ -104,7 +104,7 @@ private[core] trait DSCF extends Common {
       Ordering.by(_.name.toString)
 
     /** The Direct-Style Control-Flow (DSCF) transformation. */
-    lazy val transform: u.Tree => u.Tree = api.TopDown
+    lazy val transform: TreeTransform = TreeTransform("DSCF.transform", api.TopDown
       .withBindUses.withVarDefs.withOwnerChain
       .synthesize(Attr.collect[SortedSet, u.TermSymbol] {
         // Collect all variable assignments in a set sorted by name.
@@ -230,10 +230,10 @@ private[core] trait DSCF extends Common {
                       els = core.DefCall(None, suffMeth, argss = noArgs)))),
                 loopCall)
           }
-      }._tree
+    }._tree)
 
     /** The Direct-Style Control-Flow (DSCF) inverse transformation. */
-    lazy val inverse: u.Tree => u.Tree = (tree: u.Tree) => {
+    lazy val inverse: TreeTransform = TreeTransform("DSCF.inverse", tree => {
       // construct dataflow graph
       val cfg = ControlFlow.cfg(tree)
       // construct transitive closure of nesting graph
@@ -584,7 +584,7 @@ private[core] trait DSCF extends Common {
             suff.expr)
 
       }._tree.andThen(api.Tree.rename(varOf.toSeq))(tree)
-    }
+    })
 
     /** Applies `f` to the deepest suffix (i.e. without control flow) in a let block. */
     def mapSuffix(let: u.Block, res: Option[u.Type] = None)

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Trampoline.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/core/Trampoline.scala
@@ -52,7 +52,7 @@ private[core] trait Trampoline extends Common {
      * - The ANF shape of the input is NOT preserved.
      */
     // Unsafe: Return type of methods changes to TailRec[OriginalType].
-    lazy val transform: u.Tree => u.Tree = api.BottomUp.unsafe
+    lazy val transform: TreeTransform = TreeTransform("Trampoline.transform", api.BottomUp.unsafe
       .withAncestors.inherit { // Local method definitions.
         case core.Let(_, defs, _) =>
           (for (core.DefDef(method, tparams, paramss, _) <- defs) yield {
@@ -80,7 +80,7 @@ private[core] trait Trampoline extends Common {
             case _: u.DefDef => false
             case _ => true
           } => core.DefCall(Some(core.DefCall(None, local(cont), targs, argss)), result)
-      }.andThen(_.tree)
+      }.andThen(_.tree))
 
     /** Wraps the return value / tail call of a method in a trampoline. */
     private def wrap(expr: u.Tree, local: Map[u.MethodSymbol, u.MethodSymbol]): u.Tree =

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/Foreach2Loop.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/Foreach2Loop.scala
@@ -52,7 +52,7 @@ private[source] trait Foreach2Loop extends Common {
   private[source] object Foreach2Loop {
 
     /** The Foreach2Loop transformation. */
-    lazy val transform: u.Tree => u.Tree = {
+    lazy val transform: TreeTransform = TreeTransform("Foreach2Loop.transform", {
       val asInst = api.Type.any.member(api.TermName("asInstanceOf")).asTerm
       api.BottomUp.withOwner.withVarDefs.withAssignments
         .transformWith {
@@ -100,7 +100,7 @@ private[source] trait Foreach2Loop extends Common {
                 }))),
             api.Term.unit)
       }.andThen(_.tree)
-    }
+    })
 
     /** [[FilterMonadic]]. */
     private object FM {

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/PatternMatching.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/PatternMatching.scala
@@ -53,7 +53,7 @@ private[source] trait PatternMatching extends Common {
      *   }
      * }}}
      */
-    lazy val destruct: u.Tree => u.Tree =
+    lazy val destruct: TreeTransform = TreeTransform("PatternMatching.destruct",
       api.BottomUp.withOwner.transformWith {
         case Attr.inh(
           mat @ src.PatMat(target, Seq(src.PatCase(pat, src.Empty(_), body), _*)),
@@ -79,7 +79,7 @@ private[source] trait PatternMatching extends Common {
               assert(vals.isDefined, s"Unsupported refutable pattern matching:\n${api.Tree.show(mat)}")
               src.Block(src.ValDef(lhs, unascr) +: vals.get, body)
           }
-      }.andThen(_.tree)
+      }.andThen(_.tree))
 
     /**
      * Tests if `pattern` is irrefutable for the given selector, i.e. if it always matches. If it

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/Source.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/lang/source/Source.scala
@@ -284,7 +284,7 @@ private[compiler] trait Source extends Common
     }
 
     /** Removes implicit lists consisting of the following symbols. */
-    def removeImplicits(types: Set[u.Type]): u.Tree => u.Tree = {
+    def removeImplicits(types: Set[u.Type]): TreeTransform = TreeTransform("Source.removeImplicits", {
 
       object Matching {
 
@@ -310,6 +310,6 @@ private[compiler] trait Source extends Common
         case Matching(api.DefCall(target, method, targs, argss)) =>
           api.DefCall(target, method, targs, argss.init)
       }.andThen(_.tree)
-    }
+    })
   }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/opt/Caching.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/opt/Caching.scala
@@ -71,7 +71,7 @@ private[opt] trait Caching extends Common {
      *
      * - A tree where DataBag have been wrapped in `cache(...)` calls if needed.
      */
-    lazy val addCacheCalls: u.Tree => u.Tree = tree => {
+    lazy val addCacheCalls: TreeTransform = TreeTransform("Caching.addCacheCalls", tree => {
       // Per DataBag reference, collect flag for access in a loop and ref count.
       val refs = api.TopDown.withOwnerChain.accumulateWith[CacheFlags] {
         // Increment counter and set flag if referenced in a loop.
@@ -136,6 +136,6 @@ private[opt] trait Caching extends Common {
         case Attr.acc(core.Ref(x), cached :: _) if cached.contains(x) =>
           core.Ref(cached(x).symbol.asTerm)
       }._tree(tree)
-    }
+    })
   }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/opt/FoldForestFusion.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/opt/FoldForestFusion.scala
@@ -326,7 +326,7 @@ private[compiler] trait FoldForestFusion extends Common {
      *   val x = xs.fold(alg.FlatMap(f, alg))
      * }}}
      */
-    lazy val foldForestFusion: u.Tree => u.Tree = tree => {
+    lazy val foldForestFusion: TreeTransform = TreeTransform("FoldForestFusion.foldForestFusion", tree => {
       api.BottomUp.withOwner.transformWith {
         // Fuse only folds within a single block.
         case Attr.inh(let@core.Let(vals, defs, expr), owner :: _) =>
@@ -834,6 +834,6 @@ private[compiler] trait FoldForestFusion extends Common {
             core.Let(sortedVals, defs, expr)
           }
       }._tree(tree)
-    }
+    })
   }
 }

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/opt/FoldGroupFusion.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/opt/FoldGroupFusion.scala
@@ -81,7 +81,7 @@ private[compiler] trait FoldGroupFusion extends Common {
      *   }
      * }}}
      */
-    lazy val foldGroupFusion: u.Tree => u.Tree = tree => {
+    lazy val foldGroupFusion: TreeTransform = TreeTransform("FoldGroupFusion.foldGroupFusion", tree => {
       val cfg = ControlFlow.cfg(tree)
       val dat = cfg.data
       val nst = cfg.nest.tclose
@@ -165,7 +165,7 @@ private[compiler] trait FoldGroupFusion extends Common {
           val mat = gMap(sym)
           core.Ref(mat.gNew)
       })._tree(tree)
-    }
+    })
 
     private val ordTermSymbol = Ordering.by((s: u.TermSymbol) => s.name.toString)
 

--- a/emma-language/src/main/scala/org/emmalanguage/compiler/opt/Optimizations.scala
+++ b/emma-language/src/main/scala/org/emmalanguage/compiler/opt/Optimizations.scala
@@ -31,7 +31,7 @@ trait Optimizations extends Common
   object Optimizations {
 
     /** Performs [[FoldForestFusion.foldForestFusion()]] followed by [[FoldGroupFusion.foldGroupFusion]]. */
-    lazy val foldFusion: u.Tree => u.Tree =
+    lazy val foldFusion: TreeTransform =
       FoldForestFusion.foldForestFusion andThen FoldGroupFusion.foldGroupFusion
 
     /** Delegates to [[Caching.addCacheCalls]]. */

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCodegenIntegrationSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCodegenIntegrationSpec.scala
@@ -57,7 +57,7 @@ abstract class BaseCodegenIntegrationSpec extends FreeSpec
 
   lazy val actPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
-      transformations(loadConfig(baseConfig)) :+ addContext _: _*
+      transformations(loadConfig(baseConfig)) :+ addContext: _*
     ).compose(_.tree)
 
   lazy val expPipeline: u.Expr[Any] => u.Tree =

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCompilerSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/BaseCompilerSpec.scala
@@ -59,7 +59,7 @@ trait BaseCompilerSpec extends FreeSpec with Matchers with PropertyChecks with T
   protected def pipeline(
     typeCheck: Boolean = false, withPre: Boolean = true, withPost: Boolean = true
   )(
-    transformations: (u.Tree => u.Tree)*
+    transformations: TreeTransform*
   ): u.Tree => u.Tree = {
     compiler.pipeline(typeCheck, withPre, withPost)(transformations: _*)
   } andThen {

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/backend/OrderSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/backend/OrderSpec.scala
@@ -36,7 +36,7 @@ class OrderSpec extends BaseCompilerSpec {
   val disamb: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.lnf,
-      tree => time(dis(tree), "disambiguate")
+      (tree: u.Tree) => time(dis(tree), "disambiguate")
     ).compose(_.tree)
 
   "order disambiguation" - {

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/CombinationSpec.scala
@@ -43,7 +43,7 @@ class CombinationSpec extends BaseCompilerSpec {
   val combine: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.lnf,
-      tree => time(Comprehension.combine(tree), "combine"),
+      (tree: u.Tree) => time(Comprehension.combine(tree), Comprehension.combine.name),
       Core.unnest
     ).compose(_.tree)
 
@@ -54,7 +54,7 @@ class CombinationSpec extends BaseCompilerSpec {
 
     pipeline(typeCheck = true)(
       Core.lnf,
-      tree => time(transform(tree), "match rule"),
+      (tree: u.Tree) => time(transform(tree), "match rule"),
       Core.unnest
     ).compose(_.tree)
   }

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/NormalizeSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/NormalizeSpec.scala
@@ -44,7 +44,7 @@ class NormalizeSpec extends BaseCompilerSpec {
     pipeline(typeCheck = true)(
       Core.lnf,
       Comprehension.resugarDataBag,
-      tree => time(Comprehension.normalizeDataBag(tree), "normalize")
+      (tree: u.Tree) => time(Comprehension.normalizeDataBag(tree), Comprehension.normalizeDataBag.name)
     ).compose(_.tree)
 
   // ---------------------------------------------------------------------------

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugarSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/comprehension/ReDeSugarSpec.scala
@@ -39,13 +39,13 @@ class ReDeSugarSpec extends BaseCompilerSpec {
   val resugarPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.lnf,
-      tree => time(Comprehension.resugarDataBag(tree), "resugar")
+      (tree: u.Tree) => time(Comprehension.resugarDataBag(tree), Comprehension.resugarDataBag.name)
     ).compose(_.tree)
 
   val desugarPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.lnf,
-      tree => time(Comprehension.desugarDataBag(tree), "desugar")
+      (tree: u.Tree) => time(Comprehension.desugarDataBag(tree), Comprehension.desugarDataBag.name)
     ).compose(_.tree)
 
   // ---------------------------------------------------------------------------

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/ANFSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/ANFSpec.scala
@@ -30,7 +30,7 @@ class ANFSpec extends BaseCompilerSpec {
 
   val anfPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
-      tree => time(ANF.transform(tree), "anf")
+      (tree: u.Tree) => time(ANF.transform(tree), ANF.transform.name)
     ).compose(_.tree)
 
   val A = new A

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/CSESpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/CSESpec.scala
@@ -30,7 +30,7 @@ class CSESpec extends BaseCompilerSpec {
   val csePipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.lnf,
-      tree => time(Core.cse(tree), "cse")
+      (tree: u.Tree) => time(Core.cse(tree), Core.cse.name)
     ).compose(_.tree)
 
   val lnfPipeline: u.Expr[Any] => u.Tree =

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/CoreLangSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/CoreLangSpec.scala
@@ -36,7 +36,8 @@ class CoreLangSpec extends BaseCompilerSpec {
   // ---------------------------------------------------------------------------
 
   /** Example pre-processing pipeline. */
-  lazy val pipeline = { compiler.typeCheck(_: u.Tree) }
+  lazy val pipeline =
+    TreeTransform("CoreLangSpec.pipeline/compiler.typecheck", { compiler.typeCheck(_: u.Tree) })
     .andThen(compiler.fixSymbolTypes)
     .andThen(compiler.unQualifyStatics)
     .andThen(compiler.normalizeStatements)

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DCESpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DCESpec.scala
@@ -27,7 +27,7 @@ class DCESpec extends BaseCompilerSpec {
   val dcePipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.lnf,
-      tree => time(DCE.transform(tree), "dce")
+      (tree: u.Tree) => time(DCE.transform(tree), DCE.transform.name)
     ).compose(_.tree)
 
   "eliminate unused valdefs" - {

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DSCFSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/DSCFSpec.scala
@@ -28,14 +28,14 @@ class DSCFSpec extends BaseCompilerSpec {
   val dscfPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.anf,
-      tree => time(DSCF.transform(tree), "dscf"),
+      (tree: u.Tree) => time(DSCF.transform(tree), DSCF.transform.name),
       Core.dce
     ).compose(_.tree)
 
   val dscfInvPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.anf,
-      tree => time(DSCF.inverse(tree), "dscfInv")
+      (tree: u.Tree) => time(DSCF.inverse(tree), DSCF.inverse.name)
     ).compose(_.tree)
 
   val anfPipeline: u.Expr[Any] => u.Tree =

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/ReduceSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/ReduceSpec.scala
@@ -32,7 +32,7 @@ class ReduceSpec extends BaseCompilerSpec {
   val actPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.lift,
-      tree => time(Reduce.transform(tree), "transform")
+      (tree: u.Tree) => time(Reduce.transform(tree), Reduce.transform.name)
     ).compose(_.tree)
 
   "propagates trivial value definitions" in {

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/TrampolineSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/core/TrampolineSpec.scala
@@ -31,7 +31,7 @@ class TrampolineSpec extends BaseCompilerSpec {
     pipeline(typeCheck = true)(
       Core.anf,
       Core.dscf,
-      tree => time(Core.trampoline(tree), "trampoline"),
+      (tree: u.Tree) => time(Core.trampoline(tree), Core.trampoline.name),
       Core.anf
     ).compose(_.tree)
 

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/Foreach2LoopSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/Foreach2LoopSpec.scala
@@ -29,7 +29,7 @@ class Foreach2LoopSpec extends BaseCompilerSpec {
       fixSymbolTypes,
       unQualifyStatics,
       normalizeStatements,
-      tree => time(Foreach2Loop.transform(tree), "foreach -> loop")
+      (tree: u.Tree) => time(Foreach2Loop.transform(tree), Foreach2Loop.transform.name)
     ).compose(_.tree)
 
   "foreach" - {

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/PatternMatchingSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/PatternMatchingSpec.scala
@@ -31,7 +31,7 @@ class PatternMatchingSpec extends BaseCompilerSpec {
       fixSymbolTypes,
       unQualifyStatics,
       normalizeStatements,
-      tree => time(PatternMatching.destruct(tree), "destruct irrefutable pattern matches")
+      (tree: u.Tree) => time(PatternMatching.destruct(tree), PatternMatching.destruct.name)
     ).compose(_.tree)
 
   val noopPipeline: u.Expr[Any] => u.Tree =

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/SourceLangSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lang/source/SourceLangSpec.scala
@@ -38,7 +38,7 @@ class SourceLangSpec extends BaseCompilerSpec {
   // ---------------------------------------------------------------------------
 
   /** Example pre-processing pipeline. */
-  lazy val pipeline = { compiler.typeCheck(_: u.Tree) }
+  lazy val pipeline = TreeTransform("SourceLangSpec.pipeline/compiler.typeCheck", { compiler.typeCheck(_: u.Tree) })
     .andThen(compiler.fixSymbolTypes)
     .andThen(compiler.unQualifyStatics)
     .andThen(compiler.normalizeStatements)

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/lib/ExpandSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/lib/ExpandSpec.scala
@@ -25,11 +25,11 @@ class ExpandSpec extends LibExamples {
 
   val prePipeline: u.Expr[Any] => u.Tree = compiler
     .pipeline(typeCheck = true, withPost = false)(
-      api.Owner.atEncl
+      TreeTransform("ExpandSpec/api.Owner.atEncl", api.Owner.atEncl)
     ).compose(_.tree)
 
   val expand: u.Tree => u.Tree = tree =>
-    time(Lib.expand(tree), "expand")
+    time(Lib.expand(tree), Lib.expand.name)
 
   "Exampe A" in {
     val inp = prePipeline(`Example A (Emma Source)`)

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/opt/CachingSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/opt/CachingSpec.scala
@@ -34,7 +34,7 @@ class CachingSpec extends BaseCompilerSpec {
   val addCacheCalls: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.lift,
-      tree => time(Caching.addCacheCalls(tree), "addCacheCalls")
+      (tree: u.Tree) => time(Caching.addCacheCalls(tree), Caching.addCacheCalls.name)
     ).compose(_.tree)
 
   "cache DataBag terms" - {

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/opt/FoldForestFusionSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/opt/FoldForestFusionSpec.scala
@@ -28,10 +28,10 @@ class FoldForestFusionSpec extends BaseCompilerSpec {
   import compiler._
   import u.reify
 
-  def testPipeline(prefix: u.Tree => u.Tree): u.Tree => u.Tree =
+  def testPipeline(prefix: TreeTransform): u.Tree => u.Tree =
     pipeline(typeCheck = true)(
       prefix,
-      tree =>time(FoldForestFusion.foldForestFusion(tree), "foldForestFusion")
+      (tree: u.Tree) =>time(FoldForestFusion.foldForestFusion(tree), FoldForestFusion.foldForestFusion.name)
     )
 
   val anfPipeline: u.Expr[Any] => u.Tree =

--- a/emma-language/src/test/scala/org/emmalanguage/compiler/opt/FoldGroupFusionSpec.scala
+++ b/emma-language/src/test/scala/org/emmalanguage/compiler/opt/FoldGroupFusionSpec.scala
@@ -27,7 +27,7 @@ class FoldGroupFusionSpec extends BaseCompilerSpec {
   val testPipeline: u.Expr[Any] => u.Tree =
     pipeline(typeCheck = true)(
       Core.lift,
-      tree => time(FoldGroupFusion.foldGroupFusion(tree), "foldGroupFusion")
+      (tree: u.Tree) => time(FoldGroupFusion.foldGroupFusion(tree), FoldGroupFusion.foldGroupFusion.name)
     ) compose (_.tree)
 
   lazy val liftPipeline: u.Expr[Any] => u.Tree = {

--- a/emma-spark/src/main/scala/org/emmalanguage/SparkCompilerAware.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/SparkCompilerAware.scala
@@ -31,6 +31,6 @@ trait SparkCompilerAware extends RuntimeCompilerAware {
 
   def Env: u.Type = SparkAPI.SparkSession
 
-  def transformations(cfg: Config): Seq[u.Tree => u.Tree] =
+  def transformations(cfg: Config): Seq[TreeTransform] =
     compiler.transformations(cfg)
 }

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkCompiler.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/SparkCompiler.scala
@@ -29,7 +29,7 @@ trait SparkCompiler extends Compiler
 
   override lazy val implicitTypes: Set[u.Type] = API.implicitTypes ++ SparkAPI.implicitTypes
 
-  def transformations(implicit cfg: Config): Seq[u.Tree => u.Tree] = Seq(
+  def transformations(implicit cfg: Config): Seq[TreeTransform] = Seq(
     // lifting
     Lib.expand,
     Core.lift,

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/backend/SparkBackend.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/backend/SparkBackend.scala
@@ -57,7 +57,7 @@ private[compiler] trait SparkBackend extends Compiler {
     } yield srcOp -> tgtOp) (breakOut): Map[u.MethodSymbol, u.MethodSymbol]
 
     /** Specialize backend for Spark. */
-    val transform: u.Tree => u.Tree = tree => {
+    val transform: TreeTransform = TreeTransform("SparkBackend.transform", tree => {
       val G = ControlFlow.cfg(tree)
       val C = Context.bCtxGraph(G)
 
@@ -144,7 +144,7 @@ private[compiler] trait SparkBackend extends Compiler {
             else pref :+ api.Tree.rename(bcMap(lhs))(value).asInstanceOf[u.ValDef]
           }, defs, expr)
       })._tree(tree)
-    }
+    })
   }
 
 }

--- a/emma-spark/src/main/scala/org/emmalanguage/compiler/opt/SparkSpecializeOps.scala
+++ b/emma-spark/src/main/scala/org/emmalanguage/compiler/opt/SparkSpecializeOps.scala
@@ -33,7 +33,7 @@ private[opt] trait SparkSpecializeOps {
 
   private[opt] object SparkSpecializeOps {
     /** Introduces [[org.emmalanguage.api.spark.SparkNtv native Spark operators]] whenever possible. */
-    lazy val specializeOps: u.Tree => u.Tree = tree => {
+    lazy val specializeOps: TreeTransform = TreeTransform("SparkSpecializeOps.specializeOps", tree => {
       val cfg = ControlFlow.cfg(tree)
       val ctx = Context.bCtxMap(cfg)
       val vds = cfg.data.labNodes.map(_.label)
@@ -127,10 +127,10 @@ private[opt] trait SparkSpecializeOps {
             }
           } yield y, defs, expr)
       }(tree).tree
-    }
+    })
 
     /** Specializes lambdas as [[org.emmalanguage.api.spark.SparkExp SparkExp]] expressions. */
-    lazy val specializeLambda: u.Tree => u.Tree = {
+    lazy val specializeLambda: TreeTransform = TreeTransform("SparkspecializeLambda.specializeLambda", {
       case lambda@core.Lambda(_, Seq(core.ParDef(p, _)), core.Let(vals, Seq(), core.Ref(r))) =>
 
         val valOf = vals.map(vd => {
@@ -232,7 +232,7 @@ private[opt] trait SparkSpecializeOps {
 
       case root =>
         root
-    }
+    })
 
     private[opt] def supported(tpes: Seq[u.Type]): Boolean =
       tpes.forall(supported)

--- a/emma-spark/src/test/scala/org/emmalanguage/compiler/opt/SparkSpecializeLambdaSpec.scala
+++ b/emma-spark/src/test/scala/org/emmalanguage/compiler/opt/SparkSpecializeLambdaSpec.scala
@@ -32,16 +32,19 @@ class SparkSpecializeLambdaSpec extends BaseCompilerSpec with SparkAware {
   import u.reify
 
   lazy val testPipeline: u.Expr[Any] => u.Tree =
-    pipeline(true)(Core.anf, collectFirstLambda,
-      tree => time(SparkSpecializeOps.specializeLambda(tree), "specializeLambda")
+    pipeline(true)(
+      Core.anf,
+      collectFirstLambda,
+      (tree: u.Tree) => time(SparkSpecializeOps.specializeLambda(tree), SparkSpecializeOps.specializeLambda.name)
     ).compose(_.tree)
 
   lazy val anfPipeline: u.Expr[Any] => u.Tree =
     pipeline(true)(Core.anf, collectFirstLambda).compose(_.tree)
 
-  lazy val collectFirstLambda: u.Tree => u.Tree = tree => (tree collect {
-    case t: u.Function => t
-  }).head
+  lazy val collectFirstLambda: TreeTransform = TreeTransform("SparkSpecializeLambdaSpec.collectFirstLambda", tree =>
+    (tree collect {
+      case t: u.Function => t
+    }).head)
 
   protected override def wrapInClass(tree: u.Tree): u.Tree = {
     import u.Quasiquote

--- a/emma-spark/src/test/scala/org/emmalanguage/compiler/opt/SparkSpecializeOpsSpec.scala
+++ b/emma-spark/src/test/scala/org/emmalanguage/compiler/opt/SparkSpecializeOpsSpec.scala
@@ -37,7 +37,7 @@ class SparkSpecializeOpsSpec extends BaseCompilerSpec with SparkAware {
 
   lazy val testPipeline: u.Expr[Any] => u.Tree =
     pipeline(true)(Core.dscf,
-      tree => time(SparkSpecializeOps.specializeOps(tree), "specializeOps")
+      (tree: u.Tree) => time(SparkSpecializeOps.specializeOps(tree), SparkSpecializeOps.specializeOps.name)
     ).compose(_.tree)
 
   lazy val dscfPipeline: u.Expr[Any] => u.Tree =


### PR DESCRIPTION
solves #358 Named Tree Transformations

- added TreeTransform case class to org.emmalanguage.ast.AST
--> supports andThen, compose and apply
- changed org.emmalanguage.Common.pipeline to accept TreeTransforms instead of u.Tree => u.Tree
- added function to print TreeTransform name if org.emmalanguage.Compiler.printAllTrees is enabled
- adjusted tree transformation functions where possible and reasonable